### PR TITLE
feat: add v1.1 schemas and templates

### DIFF
--- a/bin/approve-mix
+++ b/bin/approve-mix
@@ -104,7 +104,7 @@ trap rollback_on_failure EXIT HUP INT TERM
 
 # Update approval and superseding state in one jq transformation, then validate it.
 jl_revision_approve "$manifest" "$revision_number" "$approved_by" "$approval_date"
-jl_json_validate_schema "$APP_ROOT/schemas/project-manifest.schema.json" "$manifest"
+jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$manifest"
 
 # Human approval notes are appended only after machine state validates.
 if [ -n "$notes" ]; then

--- a/bin/complete-project
+++ b/bin/complete-project
@@ -95,7 +95,7 @@ jl_json_update "$manifest" \
      .state.completed_at = $timestamp |
      .metadata.last_modified_at = $timestamp' \
     --arg timestamp "$completion_date"
-if ! jl_json_validate_schema "$APP_ROOT/schemas/project-manifest.schema.json" "$manifest"; then
+if ! jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$manifest"; then
     cp -p "$backup" "$manifest"
     rm -f "$backup"
     exit "$JL_EXIT_VALIDATION"

--- a/bin/create-delivery
+++ b/bin/create-delivery
@@ -320,7 +320,7 @@ if [ "$mark_only" -eq 0 ]; then
         }' > "$delivery_manifest"
 
     # Validate the package manifest before optional archive creation.
-    jl_json_validate_schema "$APP_ROOT/schemas/delivery-manifest.schema.json" "$delivery_manifest"
+    jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/delivery-manifest.schema.json" "$delivery_manifest"
 
     # Replace only the untouched system placeholder, preserving user edits.
     delivery_notes="$delivery_root/Delivery_Notes.md"
@@ -371,8 +371,8 @@ if [ "$mark_delivered" -eq 1 ]; then
          .state.delivered_at = $timestamp |
          .metadata.last_modified_at = $timestamp' \
         --arg timestamp "$timestamp" ||
-       ! jl_json_validate_schema "$APP_ROOT/schemas/delivery-manifest.schema.json" "$delivery_manifest" ||
-       ! jl_json_validate_schema "$APP_ROOT/schemas/project-manifest.schema.json" "$manifest"; then
+       ! jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/delivery-manifest.schema.json" "$delivery_manifest" ||
+       ! jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$manifest"; then
         cp -p "$project_backup" "$manifest"
         cp -p "$delivery_backup" "$delivery_manifest"
         rm -f "$project_backup" "$delivery_backup"

--- a/bin/new-client
+++ b/bin/new-client
@@ -182,7 +182,7 @@ jl_json_update "$client_root/client.json" \
     --argjson revision_limit "$revision_limit"
 
 # Schema validation is the commit point for client creation.
-jl_json_validate_schema "$APP_ROOT/schemas/client.schema.json" "$client_root/client.json"
+jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/client.schema.json" "$client_root/client.json"
 cleanup=0
 trap - EXIT HUP INT TERM
 

--- a/bin/new-mix
+++ b/bin/new-mix
@@ -307,7 +307,7 @@ if [ -n "$resolved_template" ]; then
 fi
 
 # The schema-valid manifest commits the otherwise provisional project tree.
-jl_json_validate_schema "$APP_ROOT/schemas/project-manifest.schema.json" "$project_root/00_Admin/project-manifest.json"
+jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$project_root/00_Admin/project-manifest.json"
 cleanup=0
 trap - EXIT HUP INT TERM
 

--- a/bin/new-revision
+++ b/bin/new-revision
@@ -109,7 +109,7 @@ jl_template_render "$APP_ROOT/templates/revision/Revision_Notes.md" "$revision_r
 
 # Append the machine-readable record only after the folder and notes exist.
 jl_revision_append "$manifest" "$description" "$number" "$timestamp" "$revision_id" "$prefix" "$padding"
-jl_json_validate_schema "$APP_ROOT/schemas/project-manifest.schema.json" "$manifest"
+jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$manifest"
 
 cleanup=0
 rm -f "$backup"

--- a/bin/new-studio
+++ b/bin/new-studio
@@ -139,7 +139,7 @@ jl_json_update "$root/Studio/studio.json" \
     --arg file_format "$file_format"
 
 # Validate before releasing the rollback trap and reporting success.
-jl_json_validate_schema "$APP_ROOT/schemas/studio.schema.json" "$root/Studio/studio.json"
+jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/studio.schema.json" "$root/Studio/studio.json"
 cleanup=0
 trap - EXIT HUP INT TERM
 

--- a/examples/client-profile-snapshot.json
+++ b/examples/client-profile-snapshot.json
@@ -1,0 +1,29 @@
+{
+  "metadata": {
+    "schema": "mixing-client-profile-snapshot",
+    "schema_version": "1.1.0",
+    "document_id": "33333333-3333-4333-8333-333333333333",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00"
+  },
+  "source_client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme",
+    "client_name": "Acme Records"
+  },
+  "defaults": {
+    "artist": "The Example Band",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  }
+}

--- a/examples/client.json
+++ b/examples/client.json
@@ -1,36 +1,27 @@
 {
   "metadata": {
     "schema": "mixing-client",
+    "schema_version": "1.1.0",
     "document_id": "22222222-2222-4222-8222-222222222222",
-    "created_by": "new-client",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:05:00-04:00",
+    "last_modified_at": "2026-07-14T20:05:00-04:00"
   },
   "client_id": "acme",
-  "client_name": "Acme",
-  "artist_name": "",
-  "contact": {
-    "name": "",
-    "email": "",
-    "phone": ""
-  },
-  "company": "",
-  "audio_defaults": {
-    "sample_rate": 48000,
-    "bit_depth": 24,
-    "file_format": "WAV"
-  },
-  "delivery_defaults": {
-    "method": "Cloud transfer",
-    "deliverables": [
-      "main_mix",
-      "instrumental"
-    ]
-  },
-  "revision_defaults": {
-    "included_revisions": 2
-  },
-  "notes": ""
+  "client_name": "Acme Records",
+  "defaults": {
+    "artist": "The Example Band",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  }
 }

--- a/examples/delivery-manifest.json
+++ b/examples/delivery-manifest.json
@@ -1,15 +1,13 @@
 {
   "metadata": {
     "schema": "mixing-delivery",
-    "document_id": "55555555-5555-4555-8555-555555555555",
-    "created_by": "create-delivery",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "schema_version": "1.1.0",
+    "document_id": "66666666-6666-4666-8666-666666666666",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-20T15:30:00-04:00"
   },
   "project": {
-    "project_document_id": "33333333-3333-4333-8333-333333333333",
+    "project_document_id": "44444444-4444-4444-8444-444444444444",
     "project_id": "blue-sky",
     "project_name": "Blue Sky"
   },
@@ -17,27 +15,36 @@
     "client_document_id": "22222222-2222-4222-8222-222222222222",
     "client_id": "acme"
   },
-  "approved_revision": 1,
+  "revision": {
+    "number": 3,
+    "revision_id": "55555555-5555-4555-8555-555555555553",
+    "description": "Final vocal balance",
+    "approval": {
+      "approved_at": "2026-07-20T14:00:00-04:00",
+      "approved_by": "Client"
+    }
+  },
   "delivery": {
-    "method": "Cloud transfer",
-    "delivered_at": null,
-    "delivered_by": "",
-    "notes": ""
+    "method": "Cloud transfer"
   },
   "files": [
     {
-      "path": "Acme - Blue Sky - Main Mix.wav",
+      "path": "Blue Sky Main Mix.wav",
       "deliverable_type": "main_mix",
-      "sample_rate": 48000,
-      "bit_depth": 24,
-      "file_format": "WAV",
-      "channels": 2,
-      "duration_seconds": 243.52,
-      "file_size_bytes": 70133760
+      "size_bytes": 104857600,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     },
     {
-      "path": "Stems/",
-      "deliverable_type": "stems"
+      "path": "BlueSky_NoVox.wav",
+      "deliverable_type": "unclassified",
+      "size_bytes": 101234567,
+      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    {
+      "path": "Stems/Blue Sky Stem Drums.wav",
+      "deliverable_type": "stems",
+      "size_bytes": 53428800,
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
     }
   ]
 }

--- a/examples/project-manifest.json
+++ b/examples/project-manifest.json
@@ -1,21 +1,19 @@
 {
   "metadata": {
     "schema": "mixing-project",
-    "document_id": "33333333-3333-4333-8333-333333333333",
-    "created_by": "new-mix",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "schema_version": "1.1.0",
+    "document_id": "44444444-4444-4444-8444-444444444444",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00",
+    "last_modified_at": "2026-07-20T14:00:00-04:00"
   },
   "project_id": "blue-sky",
   "project_name": "Blue Sky",
-  "project_type": "mixing",
   "client": {
     "client_document_id": "22222222-2222-4222-8222-222222222222",
     "client_id": "acme"
   },
-  "artist": "Acme",
+  "artist": "The Example Band",
   "album": "",
   "producer": "",
   "mix_engineer": "Jake",
@@ -29,11 +27,6 @@
     "bit_depth": 24,
     "file_format": "WAV"
   },
-  "daw": {
-    "name": "Logic Pro",
-    "template": "",
-    "project_path": "03_DAW_Project/Project"
-  },
   "delivery": {
     "method": "Cloud transfer",
     "requested_deliverables": [
@@ -46,25 +39,40 @@
   },
   "creative_direction": "Keep the verses intimate and let the choruses open up.",
   "state": {
-    "status": "active",
-    "current_revision": 1,
-    "approved": true,
-    "approved_revision": 1,
-    "approved_at": "2026-07-18T14:30:00-04:00",
-    "approved_by": "Client",
-    "delivered": false,
-    "delivered_at": null,
-    "completed_at": null
+    "current_revision": 3,
+    "approved_revision": 3,
+    "delivered_revision": 3
   },
   "revisions": [
     {
       "number": 1,
-      "revision_id": "44444444-4444-4444-8444-444444444444",
+      "revision_id": "55555555-5555-4555-8555-555555555551",
       "created_at": "2026-07-17T10:00:00-04:00",
-      "created_by": "new-revision",
       "description": "Initial mix",
-      "status": "approved",
-      "folder": "04_Revisions/Revision_01"
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 2,
+      "revision_id": "55555555-5555-4555-8555-555555555552",
+      "created_at": "2026-07-18T10:00:00-04:00",
+      "description": "Client notes addressed",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 3,
+      "revision_id": "55555555-5555-4555-8555-555555555553",
+      "created_at": "2026-07-20T11:00:00-04:00",
+      "description": "Final vocal balance",
+      "approval": {
+        "approved_at": "2026-07-20T14:00:00-04:00",
+        "approved_by": "Client"
+      }
     }
   ]
 }

--- a/examples/studio.json
+++ b/examples/studio.json
@@ -1,40 +1,31 @@
 {
   "metadata": {
     "schema": "mixing-studio",
+    "schema_version": "1.1.0",
     "document_id": "11111111-1111-4111-8111-111111111111",
-    "created_by": "new-studio",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:00:00-04:00",
+    "last_modified_at": "2026-07-14T20:00:00-04:00"
   },
+  "studio_id": "mixing-studio",
   "studio_name": "Mixing Studio",
-  "workspace_root": "~/Music/Mixes",
-  "default_daw": "Logic Pro",
-  "default_mix_engineer": "Jake",
-  "audio_defaults": {
-    "sample_rate": 48000,
-    "bit_depth": 24,
-    "file_format": "WAV"
+  "root_path": "/Users/jake/Music/Mixes",
+  "defaults": {
+    "mix_engineer": "Jake",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
   },
-  "delivery_defaults": {
-    "method": "Cloud transfer",
-    "deliverables": [
-      "main_mix",
-      "instrumental"
-    ]
-  },
-  "naming": {
-    "revision_prefix": "Revision_",
-    "revision_padding": 2,
-    "working_print_prefix": "WORK ",
-    "project_name_pattern": "{{PROJECT_NAME}}",
-    "daw_project_name_pattern": "{{ARTIST}} - {{PROJECT_NAME}}",
-    "deliverable_name_pattern": "{{ARTIST}} - {{PROJECT_NAME}} - {{DELIVERABLE}}"
-  },
-  "behavior": {
-    "open_created_folders": true,
-    "confirm_destructive_actions": true,
-    "non_interactive_defaults_allowed": true
+  "cli": {
+    "change_directory_after_create": false
   }
 }

--- a/schemas/client-profile-snapshot.schema.json
+++ b/schemas/client-profile-snapshot.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/v1.1/client-profile-snapshot.schema.json",
+  "title": "JL Mixing Client Profile Snapshot v1.1",
+  "type": "object",
+  "required": [
+    "metadata",
+    "source_client",
+    "defaults"
+  ],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": [
+        "schema",
+        "schema_version",
+        "document_id",
+        "created_with",
+        "created_at"
+      ],
+      "properties": {
+        "schema": {
+          "const": "mixing-client-profile-snapshot"
+        },
+        "schema_version": {
+          "const": "1.1.0"
+        },
+        "document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "created_with": {
+          "type": "string",
+          "pattern": "^jl-mixing 1\\.1\\.[0-9]+$"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "source_client": {
+      "type": "object",
+      "required": [
+        "client_document_id",
+        "client_id",
+        "client_name"
+      ],
+      "properties": {
+        "client_document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "client_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "client_name": {
+          "type": "string",
+          "pattern": "\\S"
+        }
+      },
+      "additionalProperties": false
+    },
+    "defaults": {
+      "type": "object",
+      "required": [
+        "artist",
+        "audio",
+        "delivery"
+      ],
+      "properties": {
+        "artist": {
+          "type": "string"
+        },
+        "audio": {
+          "type": "object",
+          "required": [
+            "sample_rate",
+            "bit_depth",
+            "file_format"
+          ],
+          "properties": {
+            "sample_rate": {
+              "type": "integer",
+              "enum": [
+                44100,
+                48000,
+                88200,
+                96000,
+                176400,
+                192000
+              ]
+            },
+            "bit_depth": {
+              "type": "integer",
+              "enum": [
+                16,
+                24,
+                32
+              ]
+            },
+            "file_format": {
+              "type": "string",
+              "enum": [
+                "WAV",
+                "AIFF"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "delivery": {
+          "type": "object",
+          "required": [
+            "method",
+            "requested_deliverables"
+          ],
+          "properties": {
+            "method": {
+              "type": "string",
+              "pattern": "\\S"
+            },
+            "requested_deliverables": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "main_mix",
+                  "instrumental",
+                  "acapella",
+                  "tv_mix",
+                  "performance_mix",
+                  "stems",
+                  "master"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/client.schema.json
+++ b/schemas/client.schema.json
@@ -1,15 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.jlaudio.local/jl-mixing/client.schema.json",
-  "title": "JL Mixing Client Profile",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/v1.1/client.schema.json",
+  "title": "JL Mixing Client Profile v1.1",
   "type": "object",
   "required": [
     "metadata",
     "client_id",
     "client_name",
-    "audio_defaults",
-    "delivery_defaults",
-    "revision_defaults"
+    "defaults"
   ],
   "properties": {
     "metadata": {
@@ -18,7 +16,6 @@
         "schema",
         "schema_version",
         "document_id",
-        "created_by",
         "created_with",
         "created_at",
         "last_modified_at"
@@ -28,20 +25,15 @@
           "const": "mixing-client"
         },
         "schema_version": {
-          "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "const": "1.1.0"
         },
         "document_id": {
           "type": "string",
           "format": "uuid"
         },
-        "created_by": {
-          "type": "string",
-          "minLength": 1
-        },
         "created_with": {
           "type": "string",
-          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^jl-mixing 1\\.1\\.[0-9]+$"
         },
         "created_at": {
           "type": "string",
@@ -60,112 +52,89 @@
     },
     "client_name": {
       "type": "string",
-      "minLength": 1
+      "pattern": "\\S"
     },
-    "artist_name": {
-      "type": "string"
-    },
-    "contact": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "phone": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
-    },
-    "company": {
-      "type": "string"
-    },
-    "audio_defaults": {
+    "defaults": {
       "type": "object",
       "required": [
-        "sample_rate",
-        "bit_depth",
-        "file_format"
+        "artist",
+        "audio",
+        "delivery"
       ],
       "properties": {
-        "sample_rate": {
-          "type": "integer",
-          "enum": [
-            44100,
-            48000,
-            88200,
-            96000,
-            176400,
-            192000
-          ]
+        "artist": {
+          "type": "string"
         },
-        "bit_depth": {
-          "type": "integer",
-          "enum": [
-            16,
-            24,
-            32
-          ]
+        "audio": {
+          "type": "object",
+          "required": [
+            "sample_rate",
+            "bit_depth",
+            "file_format"
+          ],
+          "properties": {
+            "sample_rate": {
+              "type": "integer",
+              "enum": [
+                44100,
+                48000,
+                88200,
+                96000,
+                176400,
+                192000
+              ]
+            },
+            "bit_depth": {
+              "type": "integer",
+              "enum": [
+                16,
+                24,
+                32
+              ]
+            },
+            "file_format": {
+              "type": "string",
+              "enum": [
+                "WAV",
+                "AIFF"
+              ]
+            }
+          },
+          "additionalProperties": false
         },
-        "file_format": {
-          "type": "string",
-          "enum": [
-            "WAV",
-            "AIFF"
-          ]
+        "delivery": {
+          "type": "object",
+          "required": [
+            "method",
+            "requested_deliverables"
+          ],
+          "properties": {
+            "method": {
+              "type": "string",
+              "pattern": "\\S"
+            },
+            "requested_deliverables": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "main_mix",
+                  "instrumental",
+                  "acapella",
+                  "tv_mix",
+                  "performance_mix",
+                  "stems",
+                  "master"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
-    },
-    "delivery_defaults": {
-      "type": "object",
-      "required": [
-        "method",
-        "deliverables"
-      ],
-      "properties": {
-        "method": {
-          "type": "string",
-          "minLength": 1
-        },
-        "deliverables": {
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "enum": [
-              "main_mix",
-              "instrumental",
-              "acapella",
-              "tv_mix",
-              "performance_mix",
-              "stems",
-              "master"
-            ]
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "revision_defaults": {
-      "type": "object",
-      "required": [
-        "included_revisions"
-      ],
-      "properties": {
-        "included_revisions": {
-          "type": "integer",
-          "minimum": 0
-        }
-      },
-      "additionalProperties": false
-    },
-    "notes": {
-      "type": "string"
     }
   },
   "additionalProperties": false

--- a/schemas/delivery-manifest.schema.json
+++ b/schemas/delivery-manifest.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.jlaudio.local/jl-mixing/delivery-manifest.schema.json",
-  "title": "JL Mixing Delivery Manifest",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/v1.1/delivery-manifest.schema.json",
+  "title": "JL Mixing Delivery Manifest v1.1",
   "type": "object",
   "required": [
     "metadata",
     "project",
     "client",
-    "approved_revision",
+    "revision",
     "delivery",
     "files"
   ],
@@ -18,36 +18,25 @@
         "schema",
         "schema_version",
         "document_id",
-        "created_by",
         "created_with",
-        "created_at",
-        "last_modified_at"
+        "created_at"
       ],
       "properties": {
         "schema": {
           "const": "mixing-delivery"
         },
         "schema_version": {
-          "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "const": "1.1.0"
         },
         "document_id": {
           "type": "string",
           "format": "uuid"
         },
-        "created_by": {
-          "type": "string",
-          "minLength": 1
-        },
         "created_with": {
           "type": "string",
-          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^jl-mixing 1\\.1\\.[0-9]+$"
         },
         "created_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "last_modified_at": {
           "type": "string",
           "format": "date-time"
         }
@@ -72,7 +61,7 @@
         },
         "project_name": {
           "type": "string",
-          "minLength": 1
+          "pattern": "\\S"
         }
       },
       "additionalProperties": false
@@ -95,35 +84,57 @@
       },
       "additionalProperties": false
     },
-    "approved_revision": {
-      "type": "integer",
-      "minimum": 1
+    "revision": {
+      "type": "object",
+      "required": [
+        "number",
+        "revision_id",
+        "description",
+        "approval"
+      ],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revision_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "description": {
+          "type": "string",
+          "pattern": "\\S"
+        },
+        "approval": {
+          "type": "object",
+          "required": [
+            "approved_at",
+            "approved_by"
+          ],
+          "properties": {
+            "approved_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "approved_by": {
+              "type": "string",
+              "pattern": "\\S"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "delivery": {
       "type": "object",
       "required": [
-        "method",
-        "delivered_at",
-        "delivered_by",
-        "notes"
+        "method"
       ],
       "properties": {
         "method": {
           "type": "string",
-          "minLength": 1
-        },
-        "delivered_at": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "date-time"
-        },
-        "delivered_by": {
-          "type": "string"
-        },
-        "notes": {
-          "type": "string"
+          "pattern": "\\S"
         }
       },
       "additionalProperties": false
@@ -135,94 +146,37 @@
         "type": "object",
         "required": [
           "path",
-          "deliverable_type"
+          "deliverable_type",
+          "size_bytes",
+          "sha256"
         ],
         "properties": {
           "path": {
             "type": "string",
-            "minLength": 1
+            "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*//).+$"
           },
           "deliverable_type": {
             "type": "string",
             "enum": [
-              "main_mix",
+              "stems",
               "instrumental",
               "acapella",
               "tv_mix",
               "performance_mix",
-              "stems",
               "master",
-              "other"
+              "main_mix",
+              "unclassified"
             ]
           },
-          "label": {
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "sha256": {
             "type": "string",
-            "minLength": 1
-          },
-          "sample_rate": {
-            "type": "integer",
-            "minimum": 1
-          },
-          "bit_depth": {
-            "type": "integer",
-            "enum": [
-              16,
-              24,
-              32
-            ]
-          },
-          "file_format": {
-            "type": "string"
-          },
-          "channels": {
-            "type": "integer",
-            "minimum": 1
-          },
-          "duration_seconds": {
-            "type": "number",
-            "minimum": 0
-          },
-          "file_size_bytes": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "checksum": {
-            "type": "object",
-            "required": [
-              "algorithm",
-              "value"
-            ],
-            "properties": {
-              "algorithm": {
-                "const": "sha256"
-              },
-              "value": {
-                "type": "string",
-                "pattern": "^[a-fA-F0-9]{64}$"
-              }
-            },
-            "additionalProperties": false
+            "pattern": "^[0-9a-f]{64}$"
           }
         },
-        "allOf": [
-          {
-            "if": {
-              "properties": {
-                "deliverable_type": {
-                  "const": "other"
-                }
-              },
-              "required": [
-                "deliverable_type"
-              ]
-            },
-            "then": {
-              "required": [
-                "label"
-              ]
-            }
-          }
-        ],
         "additionalProperties": false
       }
     }

--- a/schemas/legacy/v1.0.4/README.md
+++ b/schemas/legacy/v1.0.4/README.md
@@ -1,0 +1,9 @@
+# Transitional v1.0.4 Schemas
+
+These schemas preserve the exact validation contracts used by commands that
+have not yet been migrated during staged v1.1 development. The canonical v1.1
+schemas are the five files in the parent `schemas/` directory.
+
+Each command feature branch must move its command to the canonical v1.1 schema
+and exact-identity validation. This legacy directory must not be treated as a
+v1.1 workspace compatibility layer or migration feature.

--- a/schemas/legacy/v1.0.4/client.schema.json
+++ b/schemas/legacy/v1.0.4/client.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/client.schema.json",
+  "title": "JL Mixing Client Profile",
+  "type": "object",
+  "required": [
+    "metadata",
+    "client_id",
+    "client_name",
+    "audio_defaults",
+    "delivery_defaults",
+    "revision_defaults"
+  ],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": [
+        "schema",
+        "schema_version",
+        "document_id",
+        "created_by",
+        "created_with",
+        "created_at",
+        "last_modified_at"
+      ],
+      "properties": {
+        "schema": {
+          "const": "mixing-client"
+        },
+        "schema_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "created_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_with": {
+          "type": "string",
+          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_modified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "client_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "client_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artist_name": {
+      "type": "string"
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "company": {
+      "type": "string"
+    },
+    "audio_defaults": {
+      "type": "object",
+      "required": [
+        "sample_rate",
+        "bit_depth",
+        "file_format"
+      ],
+      "properties": {
+        "sample_rate": {
+          "type": "integer",
+          "enum": [
+            44100,
+            48000,
+            88200,
+            96000,
+            176400,
+            192000
+          ]
+        },
+        "bit_depth": {
+          "type": "integer",
+          "enum": [
+            16,
+            24,
+            32
+          ]
+        },
+        "file_format": {
+          "type": "string",
+          "enum": [
+            "WAV",
+            "AIFF"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "delivery_defaults": {
+      "type": "object",
+      "required": [
+        "method",
+        "deliverables"
+      ],
+      "properties": {
+        "method": {
+          "type": "string",
+          "minLength": 1
+        },
+        "deliverables": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "main_mix",
+              "instrumental",
+              "acapella",
+              "tv_mix",
+              "performance_mix",
+              "stems",
+              "master"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "revision_defaults": {
+      "type": "object",
+      "required": [
+        "included_revisions"
+      ],
+      "properties": {
+        "included_revisions": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/legacy/v1.0.4/delivery-manifest.schema.json
+++ b/schemas/legacy/v1.0.4/delivery-manifest.schema.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/delivery-manifest.schema.json",
+  "title": "JL Mixing Delivery Manifest",
+  "type": "object",
+  "required": [
+    "metadata",
+    "project",
+    "client",
+    "approved_revision",
+    "delivery",
+    "files"
+  ],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": [
+        "schema",
+        "schema_version",
+        "document_id",
+        "created_by",
+        "created_with",
+        "created_at",
+        "last_modified_at"
+      ],
+      "properties": {
+        "schema": {
+          "const": "mixing-delivery"
+        },
+        "schema_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "created_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_with": {
+          "type": "string",
+          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_modified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "project": {
+      "type": "object",
+      "required": [
+        "project_document_id",
+        "project_id",
+        "project_name"
+      ],
+      "properties": {
+        "project_document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "project_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "project_name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "client": {
+      "type": "object",
+      "required": [
+        "client_document_id",
+        "client_id"
+      ],
+      "properties": {
+        "client_document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "client_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "approved_revision": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "delivery": {
+      "type": "object",
+      "required": [
+        "method",
+        "delivered_at",
+        "delivered_by",
+        "notes"
+      ],
+      "properties": {
+        "method": {
+          "type": "string",
+          "minLength": 1
+        },
+        "delivered_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "delivered_by": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "deliverable_type"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "deliverable_type": {
+            "type": "string",
+            "enum": [
+              "main_mix",
+              "instrumental",
+              "acapella",
+              "tv_mix",
+              "performance_mix",
+              "stems",
+              "master",
+              "other"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sample_rate": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "bit_depth": {
+            "type": "integer",
+            "enum": [
+              16,
+              24,
+              32
+            ]
+          },
+          "file_format": {
+            "type": "string"
+          },
+          "channels": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "duration_seconds": {
+            "type": "number",
+            "minimum": 0
+          },
+          "file_size_bytes": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "checksum": {
+            "type": "object",
+            "required": [
+              "algorithm",
+              "value"
+            ],
+            "properties": {
+              "algorithm": {
+                "const": "sha256"
+              },
+              "value": {
+                "type": "string",
+                "pattern": "^[a-fA-F0-9]{64}$"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "deliverable_type": {
+                  "const": "other"
+                }
+              },
+              "required": [
+                "deliverable_type"
+              ]
+            },
+            "then": {
+              "required": [
+                "label"
+              ]
+            }
+          }
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/legacy/v1.0.4/project-manifest.schema.json
+++ b/schemas/legacy/v1.0.4/project-manifest.schema.json
@@ -1,0 +1,352 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/project-manifest.schema.json",
+  "title": "JL Mixing Project Manifest",
+  "type": "object",
+  "required": [
+    "metadata",
+    "project_id",
+    "project_name",
+    "project_type",
+    "client",
+    "artist",
+    "audio",
+    "daw",
+    "delivery",
+    "state",
+    "revisions"
+  ],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": [
+        "schema",
+        "schema_version",
+        "document_id",
+        "created_by",
+        "created_with",
+        "created_at",
+        "last_modified_at"
+      ],
+      "properties": {
+        "schema": {
+          "const": "mixing-project"
+        },
+        "schema_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "created_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_with": {
+          "type": "string",
+          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_modified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "project_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "project_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "project_type": {
+      "type": "string",
+      "enum": [
+        "mixing",
+        "podcast",
+        "audiobook",
+        "dialogue_edit",
+        "live_recording",
+        "other"
+      ]
+    },
+    "client": {
+      "type": "object",
+      "required": [
+        "client_document_id",
+        "client_id"
+      ],
+      "properties": {
+        "client_document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "client_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "artist": {
+      "type": "string",
+      "minLength": 1
+    },
+    "album": {
+      "type": "string"
+    },
+    "producer": {
+      "type": "string"
+    },
+    "mix_engineer": {
+      "type": "string"
+    },
+    "music": {
+      "type": "object",
+      "properties": {
+        "bpm": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "exclusiveMinimum": 0
+        },
+        "key": {
+          "type": "string"
+        },
+        "time_signature": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "audio": {
+      "type": "object",
+      "required": [
+        "sample_rate",
+        "bit_depth",
+        "file_format"
+      ],
+      "properties": {
+        "sample_rate": {
+          "type": "integer",
+          "enum": [
+            44100,
+            48000,
+            88200,
+            96000,
+            176400,
+            192000
+          ]
+        },
+        "bit_depth": {
+          "type": "integer",
+          "enum": [
+            16,
+            24,
+            32
+          ]
+        },
+        "file_format": {
+          "type": "string",
+          "enum": [
+            "WAV",
+            "AIFF"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "daw": {
+      "type": "object",
+      "required": [
+        "name",
+        "template",
+        "project_path"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "template": {
+          "type": "string"
+        },
+        "project_path": {
+          "const": "03_DAW_Project/Project"
+        }
+      },
+      "additionalProperties": false
+    },
+    "delivery": {
+      "type": "object",
+      "required": [
+        "method",
+        "requested_deliverables"
+      ],
+      "properties": {
+        "method": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requested_deliverables": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "main_mix",
+              "instrumental",
+              "acapella",
+              "tv_mix",
+              "performance_mix",
+              "stems",
+              "master"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "schedule": {
+      "type": "object",
+      "properties": {
+        "deadline": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        }
+      },
+      "additionalProperties": false
+    },
+    "creative_direction": {
+      "type": "string"
+    },
+    "state": {
+      "type": "object",
+      "required": [
+        "status",
+        "current_revision",
+        "approved",
+        "approved_revision",
+        "approved_at",
+        "approved_by",
+        "delivered",
+        "delivered_at",
+        "completed_at"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "completed"
+          ]
+        },
+        "current_revision": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "approved": {
+          "type": "boolean"
+        },
+        "approved_revision": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "approved_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "approved_by": {
+          "type": "string"
+        },
+        "delivered": {
+          "type": "boolean"
+        },
+        "delivered_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "completed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "revisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "revision_id",
+          "created_at",
+          "created_by",
+          "description",
+          "status",
+          "folder"
+        ],
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "revision_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "const": "new-revision"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "approved",
+              "superseded"
+            ]
+          },
+          "folder": {
+            "type": "string",
+            "pattern": "^04_Revisions/Revision_[0-9]+$"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/legacy/v1.0.4/studio.schema.json
+++ b/schemas/legacy/v1.0.4/studio.schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/studio.schema.json",
+  "title": "JL Mixing Studio Configuration",
+  "type": "object",
+  "required": [
+    "metadata",
+    "studio_name",
+    "workspace_root",
+    "default_daw",
+    "default_mix_engineer",
+    "audio_defaults",
+    "delivery_defaults",
+    "naming",
+    "behavior"
+  ],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": [
+        "schema",
+        "schema_version",
+        "document_id",
+        "created_by",
+        "created_with",
+        "created_at",
+        "last_modified_at"
+      ],
+      "properties": {
+        "schema": {
+          "const": "mixing-studio"
+        },
+        "schema_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "document_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "created_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_with": {
+          "type": "string",
+          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_modified_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "studio_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workspace_root": {
+      "type": "string",
+      "minLength": 1
+    },
+    "default_daw": {
+      "type": "string",
+      "minLength": 1
+    },
+    "default_mix_engineer": {
+      "type": "string"
+    },
+    "audio_defaults": {
+      "type": "object",
+      "required": [
+        "sample_rate",
+        "bit_depth",
+        "file_format"
+      ],
+      "properties": {
+        "sample_rate": {
+          "type": "integer",
+          "enum": [
+            44100,
+            48000,
+            88200,
+            96000,
+            176400,
+            192000
+          ]
+        },
+        "bit_depth": {
+          "type": "integer",
+          "enum": [
+            16,
+            24,
+            32
+          ]
+        },
+        "file_format": {
+          "type": "string",
+          "enum": [
+            "WAV",
+            "AIFF"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "delivery_defaults": {
+      "type": "object",
+      "required": [
+        "method",
+        "deliverables"
+      ],
+      "properties": {
+        "method": {
+          "type": "string",
+          "minLength": 1
+        },
+        "deliverables": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "main_mix",
+              "instrumental",
+              "acapella",
+              "tv_mix",
+              "performance_mix",
+              "stems",
+              "master"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "naming": {
+      "type": "object",
+      "required": [
+        "revision_prefix",
+        "revision_padding",
+        "working_print_prefix",
+        "project_name_pattern",
+        "daw_project_name_pattern",
+        "deliverable_name_pattern"
+      ],
+      "properties": {
+        "revision_prefix": {
+          "type": "string"
+        },
+        "revision_padding": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4
+        },
+        "working_print_prefix": {
+          "type": "string"
+        },
+        "project_name_pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "daw_project_name_pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "deliverable_name_pattern": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "behavior": {
+      "type": "object",
+      "required": [
+        "open_created_folders",
+        "confirm_destructive_actions",
+        "non_interactive_defaults_allowed"
+      ],
+      "properties": {
+        "open_created_folders": {
+          "type": "boolean"
+        },
+        "confirm_destructive_actions": {
+          "type": "boolean"
+        },
+        "non_interactive_defaults_allowed": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/project-manifest.schema.json
+++ b/schemas/project-manifest.schema.json
@@ -1,18 +1,22 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.jlaudio.local/jl-mixing/project-manifest.schema.json",
-  "title": "JL Mixing Project Manifest",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/v1.1/project-manifest.schema.json",
+  "title": "JL Mixing Project Manifest v1.1",
   "type": "object",
   "required": [
     "metadata",
     "project_id",
     "project_name",
-    "project_type",
     "client",
     "artist",
+    "album",
+    "producer",
+    "mix_engineer",
+    "music",
     "audio",
-    "daw",
     "delivery",
+    "schedule",
+    "creative_direction",
     "state",
     "revisions"
   ],
@@ -23,7 +27,6 @@
         "schema",
         "schema_version",
         "document_id",
-        "created_by",
         "created_with",
         "created_at",
         "last_modified_at"
@@ -33,20 +36,15 @@
           "const": "mixing-project"
         },
         "schema_version": {
-          "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "const": "1.1.0"
         },
         "document_id": {
           "type": "string",
           "format": "uuid"
         },
-        "created_by": {
-          "type": "string",
-          "minLength": 1
-        },
         "created_with": {
           "type": "string",
-          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^jl-mixing 1\\.1\\.[0-9]+$"
         },
         "created_at": {
           "type": "string",
@@ -65,18 +63,7 @@
     },
     "project_name": {
       "type": "string",
-      "minLength": 1
-    },
-    "project_type": {
-      "type": "string",
-      "enum": [
-        "mixing",
-        "podcast",
-        "audiobook",
-        "dialogue_edit",
-        "live_recording",
-        "other"
-      ]
+      "pattern": "\\S"
     },
     "client": {
       "type": "object",
@@ -98,7 +85,7 @@
     },
     "artist": {
       "type": "string",
-      "minLength": 1
+      "pattern": "\\S"
     },
     "album": {
       "type": "string"
@@ -111,13 +98,22 @@
     },
     "music": {
       "type": "object",
+      "required": [
+        "bpm",
+        "key",
+        "time_signature"
+      ],
       "properties": {
         "bpm": {
-          "type": [
-            "number",
-            "null"
-          ],
-          "exclusiveMinimum": 0
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number",
+              "exclusiveMinimum": 0
+            }
+          ]
         },
         "key": {
           "type": "string"
@@ -165,27 +161,6 @@
       },
       "additionalProperties": false
     },
-    "daw": {
-      "type": "object",
-      "required": [
-        "name",
-        "template",
-        "project_path"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "template": {
-          "type": "string"
-        },
-        "project_path": {
-          "const": "03_DAW_Project/Project"
-        }
-      },
-      "additionalProperties": false
-    },
     "delivery": {
       "type": "object",
       "required": [
@@ -195,7 +170,7 @@
       "properties": {
         "method": {
           "type": "string",
-          "minLength": 1
+          "pattern": "\\S"
         },
         "requested_deliverables": {
           "type": "array",
@@ -219,13 +194,20 @@
     },
     "schedule": {
       "type": "object",
+      "required": [
+        "deadline"
+      ],
       "properties": {
         "deadline": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "date"
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "format": "date"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -236,64 +218,36 @@
     "state": {
       "type": "object",
       "required": [
-        "status",
         "current_revision",
-        "approved",
         "approved_revision",
-        "approved_at",
-        "approved_by",
-        "delivered",
-        "delivered_at",
-        "completed_at"
+        "delivered_revision"
       ],
       "properties": {
-        "status": {
-          "type": "string",
-          "enum": [
-            "active",
-            "completed"
-          ]
-        },
         "current_revision": {
           "type": "integer",
           "minimum": 0
         },
-        "approved": {
-          "type": "boolean"
-        },
         "approved_revision": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "minimum": 1
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer",
+              "minimum": 1
+            }
+          ]
         },
-        "approved_at": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "date-time"
-        },
-        "approved_by": {
-          "type": "string"
-        },
-        "delivered": {
-          "type": "boolean"
-        },
-        "delivered_at": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "date-time"
-        },
-        "completed_at": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "date-time"
+        "delivered_revision": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer",
+              "minimum": 1
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -306,10 +260,8 @@
           "number",
           "revision_id",
           "created_at",
-          "created_by",
           "description",
-          "status",
-          "folder"
+          "approval"
         ],
         "properties": {
           "number": {
@@ -324,24 +276,47 @@
             "type": "string",
             "format": "date-time"
           },
-          "created_by": {
-            "const": "new-revision"
-          },
           "description": {
             "type": "string",
-            "minLength": 1
+            "pattern": "\\S"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "open",
-              "approved",
-              "superseded"
+          "approval": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "approved_at",
+                  "approved_by"
+                ],
+                "properties": {
+                  "approved_at": {
+                    "type": "null"
+                  },
+                  "approved_by": {
+                    "type": "null"
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": [
+                  "approved_at",
+                  "approved_by"
+                ],
+                "properties": {
+                  "approved_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "approved_by": {
+                    "type": "string",
+                    "pattern": "\\S"
+                  }
+                },
+                "additionalProperties": false
+              }
             ]
-          },
-          "folder": {
-            "type": "string",
-            "pattern": "^04_Revisions/Revision_[0-9]+$"
           }
         },
         "additionalProperties": false

--- a/schemas/studio.schema.json
+++ b/schemas/studio.schema.json
@@ -1,18 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.jlaudio.local/jl-mixing/studio.schema.json",
-  "title": "JL Mixing Studio Configuration",
+  "$id": "https://schemas.jlaudio.local/jl-mixing/v1.1/studio.schema.json",
+  "title": "JL Mixing Studio Configuration v1.1",
   "type": "object",
   "required": [
     "metadata",
+    "studio_id",
     "studio_name",
-    "workspace_root",
-    "default_daw",
-    "default_mix_engineer",
-    "audio_defaults",
-    "delivery_defaults",
-    "naming",
-    "behavior"
+    "root_path",
+    "defaults",
+    "cli"
   ],
   "properties": {
     "metadata": {
@@ -21,7 +18,6 @@
         "schema",
         "schema_version",
         "document_id",
-        "created_by",
         "created_with",
         "created_at",
         "last_modified_at"
@@ -31,20 +27,15 @@
           "const": "mixing-studio"
         },
         "schema_version": {
-          "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "const": "1.1.0"
         },
         "document_id": {
           "type": "string",
           "format": "uuid"
         },
-        "created_by": {
-          "type": "string",
-          "minLength": 1
-        },
         "created_with": {
           "type": "string",
-          "pattern": "^jl-mixing [0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^jl-mixing 1\\.1\\.[0-9]+$"
         },
         "created_at": {
           "type": "string",
@@ -57,141 +48,107 @@
       },
       "additionalProperties": false
     },
+    "studio_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
     "studio_name": {
       "type": "string",
-      "minLength": 1
+      "pattern": "\\S"
     },
-    "workspace_root": {
+    "root_path": {
       "type": "string",
-      "minLength": 1
+      "pattern": "^/"
     },
-    "default_daw": {
-      "type": "string",
-      "minLength": 1
-    },
-    "default_mix_engineer": {
-      "type": "string"
-    },
-    "audio_defaults": {
+    "defaults": {
       "type": "object",
       "required": [
-        "sample_rate",
-        "bit_depth",
-        "file_format"
+        "mix_engineer",
+        "audio",
+        "delivery"
       ],
       "properties": {
-        "sample_rate": {
-          "type": "integer",
-          "enum": [
-            44100,
-            48000,
-            88200,
-            96000,
-            176400,
-            192000
-          ]
-        },
-        "bit_depth": {
-          "type": "integer",
-          "enum": [
-            16,
-            24,
-            32
-          ]
-        },
-        "file_format": {
-          "type": "string",
-          "enum": [
-            "WAV",
-            "AIFF"
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "delivery_defaults": {
-      "type": "object",
-      "required": [
-        "method",
-        "deliverables"
-      ],
-      "properties": {
-        "method": {
-          "type": "string",
-          "minLength": 1
-        },
-        "deliverables": {
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "enum": [
-              "main_mix",
-              "instrumental",
-              "acapella",
-              "tv_mix",
-              "performance_mix",
-              "stems",
-              "master"
-            ]
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "naming": {
-      "type": "object",
-      "required": [
-        "revision_prefix",
-        "revision_padding",
-        "working_print_prefix",
-        "project_name_pattern",
-        "daw_project_name_pattern",
-        "deliverable_name_pattern"
-      ],
-      "properties": {
-        "revision_prefix": {
+        "mix_engineer": {
           "type": "string"
         },
-        "revision_padding": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 4
+        "audio": {
+          "type": "object",
+          "required": [
+            "sample_rate",
+            "bit_depth",
+            "file_format"
+          ],
+          "properties": {
+            "sample_rate": {
+              "type": "integer",
+              "enum": [
+                44100,
+                48000,
+                88200,
+                96000,
+                176400,
+                192000
+              ]
+            },
+            "bit_depth": {
+              "type": "integer",
+              "enum": [
+                16,
+                24,
+                32
+              ]
+            },
+            "file_format": {
+              "type": "string",
+              "enum": [
+                "WAV",
+                "AIFF"
+              ]
+            }
+          },
+          "additionalProperties": false
         },
-        "working_print_prefix": {
-          "type": "string"
-        },
-        "project_name_pattern": {
-          "type": "string",
-          "minLength": 1
-        },
-        "daw_project_name_pattern": {
-          "type": "string",
-          "minLength": 1
-        },
-        "deliverable_name_pattern": {
-          "type": "string",
-          "minLength": 1
+        "delivery": {
+          "type": "object",
+          "required": [
+            "method",
+            "requested_deliverables"
+          ],
+          "properties": {
+            "method": {
+              "type": "string",
+              "pattern": "\\S"
+            },
+            "requested_deliverables": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "main_mix",
+                  "instrumental",
+                  "acapella",
+                  "tv_mix",
+                  "performance_mix",
+                  "stems",
+                  "master"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "behavior": {
+    "cli": {
       "type": "object",
       "required": [
-        "open_created_folders",
-        "confirm_destructive_actions",
-        "non_interactive_defaults_allowed"
+        "change_directory_after_create"
       ],
       "properties": {
-        "open_created_folders": {
-          "type": "boolean"
-        },
-        "confirm_destructive_actions": {
-          "type": "boolean"
-        },
-        "non_interactive_defaults_allowed": {
+        "change_directory_after_create": {
           "type": "boolean"
         }
       },

--- a/templates/Delivery_Notes.md
+++ b/templates/Delivery_Notes.md
@@ -1,0 +1,1 @@
+# Delivery Notes

--- a/templates/Intake_Report.md
+++ b/templates/Intake_Report.md
@@ -1,0 +1,5 @@
+# Intake Report
+
+<!-- BEGIN AUTOMATED SECTION -->
+No intake validation has been run.
+<!-- END AUTOMATED SECTION -->

--- a/templates/Preparation_Report.md
+++ b/templates/Preparation_Report.md
@@ -1,0 +1,1 @@
+# Preparation Report

--- a/templates/Project_Notes.md
+++ b/templates/Project_Notes.md
@@ -1,0 +1,1 @@
+# Project Notes

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,7 @@
+# Template Layout During v1.1 Development
+
+The six Markdown files directly in this directory are the canonical v1.1
+project templates. Existing nested templates remain temporarily for commands
+that have not yet been migrated from v1.0.4. Each command feature branch will
+switch to the canonical files and remove obsolete nested templates when they
+are no longer referenced.

--- a/templates/Recall_Sheet.md
+++ b/templates/Recall_Sheet.md
@@ -1,0 +1,1 @@
+# Recall Sheet

--- a/templates/Revision_Notes.md
+++ b/templates/Revision_Notes.md
@@ -1,0 +1,3 @@
+# Revision {{REVISION_NUMBER}} Notes
+
+Description: {{REVISION_DESCRIPTION}}

--- a/tests/fixtures/invalid-client-profile-snapshot.json
+++ b/tests/fixtures/invalid-client-profile-snapshot.json
@@ -1,0 +1,30 @@
+{
+  "metadata": {
+    "schema": "mixing-client-profile-snapshot",
+    "schema_version": "1.1.0",
+    "document_id": "33333333-3333-4333-8333-333333333333",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00",
+    "last_modified_at": "2026-07-14T20:10:00-04:00"
+  },
+  "source_client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme",
+    "client_name": "Acme Records"
+  },
+  "defaults": {
+    "artist": "The Example Band",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/invalid-client.json
+++ b/tests/fixtures/invalid-client.json
@@ -1,8 +1,30 @@
 {
   "metadata": {
     "schema": "mixing-client",
-    "schema_version": "1.0.0"
+    "schema_version": "1.1.0",
+    "document_id": "22222222-2222-4222-8222-222222222222",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:05:00-04:00",
+    "last_modified_at": "2026-07-14T20:05:00-04:00"
   },
-  "client_id": "Invalid Client ID",
-  "client_name": ""
+  "client_id": "acme",
+  "client_name": "Acme Records",
+  "defaults": {
+    "artist": "The Example Band",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  },
+  "revision_defaults": {
+    "included_revisions": 2
+  }
 }

--- a/tests/fixtures/invalid-delivery-manifest.json
+++ b/tests/fixtures/invalid-delivery-manifest.json
@@ -1,0 +1,51 @@
+{
+  "metadata": {
+    "schema": "mixing-delivery",
+    "schema_version": "1.1.0",
+    "document_id": "66666666-6666-4666-8666-666666666666",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-20T15:30:00-04:00"
+  },
+  "project": {
+    "project_document_id": "44444444-4444-4444-8444-444444444444",
+    "project_id": "blue-sky",
+    "project_name": "Blue Sky"
+  },
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "revision": {
+    "number": 3,
+    "revision_id": "55555555-5555-4555-8555-555555555553",
+    "description": "Final vocal balance",
+    "approval": {
+      "approved_at": "2026-07-20T14:00:00-04:00",
+      "approved_by": "Client"
+    }
+  },
+  "delivery": {
+    "method": "Cloud transfer"
+  },
+  "files": [
+    {
+      "path": "Blue Sky Main Mix.wav",
+      "deliverable_type": "main_mix",
+      "size_bytes": 104857600,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    },
+    {
+      "path": "BlueSky_NoVox.wav",
+      "deliverable_type": "unclassified",
+      "size_bytes": 101234567,
+      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    {
+      "path": "Stems/Blue Sky Stem Drums.wav",
+      "deliverable_type": "stems",
+      "size_bytes": 53428800,
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "approved_revision": 3
+}

--- a/tests/fixtures/invalid-delivery-path.json
+++ b/tests/fixtures/invalid-delivery-path.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "schema": "mixing-delivery",
+    "schema_version": "1.1.0",
+    "document_id": "66666666-6666-4666-8666-666666666666",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-20T15:30:00-04:00"
+  },
+  "project": {
+    "project_document_id": "44444444-4444-4444-8444-444444444444",
+    "project_id": "blue-sky",
+    "project_name": "Blue Sky"
+  },
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "revision": {
+    "number": 3,
+    "revision_id": "55555555-5555-4555-8555-555555555553",
+    "description": "Final vocal balance",
+    "approval": {
+      "approved_at": "2026-07-20T14:00:00-04:00",
+      "approved_by": "Client"
+    }
+  },
+  "delivery": {
+    "method": "Cloud transfer"
+  },
+  "files": [
+    {
+      "path": "../Blue Sky Main Mix.wav",
+      "deliverable_type": "main_mix",
+      "size_bytes": 104857600,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    },
+    {
+      "path": "BlueSky_NoVox.wav",
+      "deliverable_type": "unclassified",
+      "size_bytes": 101234567,
+      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    {
+      "path": "Stems/Blue Sky Stem Drums.wav",
+      "deliverable_type": "stems",
+      "size_bytes": 53428800,
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ]
+}

--- a/tests/fixtures/invalid-delivery-uppercase-hash.json
+++ b/tests/fixtures/invalid-delivery-uppercase-hash.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "schema": "mixing-delivery",
+    "schema_version": "1.1.0",
+    "document_id": "66666666-6666-4666-8666-666666666666",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-20T15:30:00-04:00"
+  },
+  "project": {
+    "project_document_id": "44444444-4444-4444-8444-444444444444",
+    "project_id": "blue-sky",
+    "project_name": "Blue Sky"
+  },
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "revision": {
+    "number": 3,
+    "revision_id": "55555555-5555-4555-8555-555555555553",
+    "description": "Final vocal balance",
+    "approval": {
+      "approved_at": "2026-07-20T14:00:00-04:00",
+      "approved_by": "Client"
+    }
+  },
+  "delivery": {
+    "method": "Cloud transfer"
+  },
+  "files": [
+    {
+      "path": "Blue Sky Main Mix.wav",
+      "deliverable_type": "main_mix",
+      "size_bytes": 104857600,
+      "sha256": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+    },
+    {
+      "path": "BlueSky_NoVox.wav",
+      "deliverable_type": "unclassified",
+      "size_bytes": 101234567,
+      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    {
+      "path": "Stems/Blue Sky Stem Drums.wav",
+      "deliverable_type": "stems",
+      "size_bytes": 53428800,
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ]
+}

--- a/tests/fixtures/invalid-project-approval-pair.json
+++ b/tests/fixtures/invalid-project-approval-pair.json
@@ -1,0 +1,78 @@
+{
+  "metadata": {
+    "schema": "mixing-project",
+    "schema_version": "1.1.0",
+    "document_id": "44444444-4444-4444-8444-444444444444",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00",
+    "last_modified_at": "2026-07-20T14:00:00-04:00"
+  },
+  "project_id": "blue-sky",
+  "project_name": "Blue Sky",
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "artist": "The Example Band",
+  "album": "",
+  "producer": "",
+  "mix_engineer": "Jake",
+  "music": {
+    "bpm": 112,
+    "key": "D major",
+    "time_signature": "4/4"
+  },
+  "audio": {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "file_format": "WAV"
+  },
+  "delivery": {
+    "method": "Cloud transfer",
+    "requested_deliverables": [
+      "main_mix",
+      "instrumental"
+    ]
+  },
+  "schedule": {
+    "deadline": null
+  },
+  "creative_direction": "Keep the verses intimate and let the choruses open up.",
+  "state": {
+    "current_revision": 3,
+    "approved_revision": 3,
+    "delivered_revision": 3
+  },
+  "revisions": [
+    {
+      "number": 1,
+      "revision_id": "55555555-5555-4555-8555-555555555551",
+      "created_at": "2026-07-17T10:00:00-04:00",
+      "description": "Initial mix",
+      "approval": {
+        "approved_at": "2026-07-17T12:00:00-04:00",
+        "approved_by": null
+      }
+    },
+    {
+      "number": 2,
+      "revision_id": "55555555-5555-4555-8555-555555555552",
+      "created_at": "2026-07-18T10:00:00-04:00",
+      "description": "Client notes addressed",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 3,
+      "revision_id": "55555555-5555-4555-8555-555555555553",
+      "created_at": "2026-07-20T11:00:00-04:00",
+      "description": "Final vocal balance",
+      "approval": {
+        "approved_at": "2026-07-20T14:00:00-04:00",
+        "approved_by": "Client"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/invalid-project-deadline.json
+++ b/tests/fixtures/invalid-project-deadline.json
@@ -1,0 +1,78 @@
+{
+  "metadata": {
+    "schema": "mixing-project",
+    "schema_version": "1.1.0",
+    "document_id": "44444444-4444-4444-8444-444444444444",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00",
+    "last_modified_at": "2026-07-20T14:00:00-04:00"
+  },
+  "project_id": "blue-sky",
+  "project_name": "Blue Sky",
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "artist": "The Example Band",
+  "album": "",
+  "producer": "",
+  "mix_engineer": "Jake",
+  "music": {
+    "bpm": 112,
+    "key": "D major",
+    "time_signature": "4/4"
+  },
+  "audio": {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "file_format": "WAV"
+  },
+  "delivery": {
+    "method": "Cloud transfer",
+    "requested_deliverables": [
+      "main_mix",
+      "instrumental"
+    ]
+  },
+  "schedule": {
+    "deadline": "2026-02-30"
+  },
+  "creative_direction": "Keep the verses intimate and let the choruses open up.",
+  "state": {
+    "current_revision": 3,
+    "approved_revision": 3,
+    "delivered_revision": 3
+  },
+  "revisions": [
+    {
+      "number": 1,
+      "revision_id": "55555555-5555-4555-8555-555555555551",
+      "created_at": "2026-07-17T10:00:00-04:00",
+      "description": "Initial mix",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 2,
+      "revision_id": "55555555-5555-4555-8555-555555555552",
+      "created_at": "2026-07-18T10:00:00-04:00",
+      "description": "Client notes addressed",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 3,
+      "revision_id": "55555555-5555-4555-8555-555555555553",
+      "created_at": "2026-07-20T11:00:00-04:00",
+      "description": "Final vocal balance",
+      "approval": {
+        "approved_at": "2026-07-20T14:00:00-04:00",
+        "approved_by": "Client"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/invalid-project-empty-artist.json
+++ b/tests/fixtures/invalid-project-empty-artist.json
@@ -1,0 +1,78 @@
+{
+  "metadata": {
+    "schema": "mixing-project",
+    "schema_version": "1.1.0",
+    "document_id": "44444444-4444-4444-8444-444444444444",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00",
+    "last_modified_at": "2026-07-20T14:00:00-04:00"
+  },
+  "project_id": "blue-sky",
+  "project_name": "Blue Sky",
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "artist": "",
+  "album": "",
+  "producer": "",
+  "mix_engineer": "Jake",
+  "music": {
+    "bpm": 112,
+    "key": "D major",
+    "time_signature": "4/4"
+  },
+  "audio": {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "file_format": "WAV"
+  },
+  "delivery": {
+    "method": "Cloud transfer",
+    "requested_deliverables": [
+      "main_mix",
+      "instrumental"
+    ]
+  },
+  "schedule": {
+    "deadline": null
+  },
+  "creative_direction": "Keep the verses intimate and let the choruses open up.",
+  "state": {
+    "current_revision": 3,
+    "approved_revision": 3,
+    "delivered_revision": 3
+  },
+  "revisions": [
+    {
+      "number": 1,
+      "revision_id": "55555555-5555-4555-8555-555555555551",
+      "created_at": "2026-07-17T10:00:00-04:00",
+      "description": "Initial mix",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 2,
+      "revision_id": "55555555-5555-4555-8555-555555555552",
+      "created_at": "2026-07-18T10:00:00-04:00",
+      "description": "Client notes addressed",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 3,
+      "revision_id": "55555555-5555-4555-8555-555555555553",
+      "created_at": "2026-07-20T11:00:00-04:00",
+      "description": "Final vocal balance",
+      "approval": {
+        "approved_at": "2026-07-20T14:00:00-04:00",
+        "approved_by": "Client"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/invalid-project-manifest.json
+++ b/tests/fixtures/invalid-project-manifest.json
@@ -1,0 +1,79 @@
+{
+  "metadata": {
+    "schema": "mixing-project",
+    "schema_version": "1.1.0",
+    "document_id": "44444444-4444-4444-8444-444444444444",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00",
+    "last_modified_at": "2026-07-20T14:00:00-04:00"
+  },
+  "project_id": "blue-sky",
+  "project_name": "Blue Sky",
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "artist": "The Example Band",
+  "album": "",
+  "producer": "",
+  "mix_engineer": "Jake",
+  "music": {
+    "bpm": 112,
+    "key": "D major",
+    "time_signature": "4/4"
+  },
+  "audio": {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "file_format": "WAV"
+  },
+  "delivery": {
+    "method": "Cloud transfer",
+    "requested_deliverables": [
+      "main_mix",
+      "instrumental"
+    ]
+  },
+  "schedule": {
+    "deadline": null
+  },
+  "creative_direction": "Keep the verses intimate and let the choruses open up.",
+  "state": {
+    "current_revision": 3,
+    "approved_revision": 3,
+    "delivered_revision": 3
+  },
+  "revisions": [
+    {
+      "number": 1,
+      "revision_id": "55555555-5555-4555-8555-555555555551",
+      "created_at": "2026-07-17T10:00:00-04:00",
+      "description": "Initial mix",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 2,
+      "revision_id": "55555555-5555-4555-8555-555555555552",
+      "created_at": "2026-07-18T10:00:00-04:00",
+      "description": "Client notes addressed",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 3,
+      "revision_id": "55555555-5555-4555-8555-555555555553",
+      "created_at": "2026-07-20T11:00:00-04:00",
+      "description": "Final vocal balance",
+      "approval": {
+        "approved_at": "2026-07-20T14:00:00-04:00",
+        "approved_by": "Client"
+      }
+    }
+  ],
+  "project_type": "mixing"
+}

--- a/tests/fixtures/invalid-studio-duplicate-deliverables.json
+++ b/tests/fixtures/invalid-studio-duplicate-deliverables.json
@@ -1,0 +1,31 @@
+{
+  "metadata": {
+    "schema": "mixing-studio",
+    "schema_version": "1.1.0",
+    "document_id": "11111111-1111-4111-8111-111111111111",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:00:00-04:00",
+    "last_modified_at": "2026-07-14T20:00:00-04:00"
+  },
+  "studio_id": "mixing-studio",
+  "studio_name": "Mixing Studio",
+  "root_path": "/Users/jake/Music/Mixes",
+  "defaults": {
+    "mix_engineer": "Jake",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "main_mix"
+      ]
+    }
+  },
+  "cli": {
+    "change_directory_after_create": false
+  }
+}

--- a/tests/fixtures/invalid-studio.json
+++ b/tests/fixtures/invalid-studio.json
@@ -1,0 +1,32 @@
+{
+  "metadata": {
+    "schema": "mixing-studio",
+    "schema_version": "1.1.0",
+    "document_id": "11111111-1111-4111-8111-111111111111",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:00:00-04:00",
+    "last_modified_at": "2026-07-14T20:00:00-04:00"
+  },
+  "studio_id": "mixing-studio",
+  "studio_name": "Mixing Studio",
+  "root_path": "/Users/jake/Music/Mixes",
+  "defaults": {
+    "mix_engineer": "Jake",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  },
+  "cli": {
+    "change_directory_after_create": false
+  },
+  "default_daw": "Logic Pro"
+}

--- a/tests/fixtures/legacy-v1.0.4/client.json
+++ b/tests/fixtures/legacy-v1.0.4/client.json
@@ -1,0 +1,36 @@
+{
+  "metadata": {
+    "schema": "mixing-client",
+    "document_id": "22222222-2222-4222-8222-222222222222",
+    "created_by": "new-client",
+    "schema_version": "1.0.0",
+    "created_with": "jl-mixing 1.0.0",
+    "created_at": "2026-07-13T12:00:00-04:00",
+    "last_modified_at": "2026-07-13T12:00:00-04:00"
+  },
+  "client_id": "acme",
+  "client_name": "Acme",
+  "artist_name": "",
+  "contact": {
+    "name": "",
+    "email": "",
+    "phone": ""
+  },
+  "company": "",
+  "audio_defaults": {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "file_format": "WAV"
+  },
+  "delivery_defaults": {
+    "method": "Cloud transfer",
+    "deliverables": [
+      "main_mix",
+      "instrumental"
+    ]
+  },
+  "revision_defaults": {
+    "included_revisions": 2
+  },
+  "notes": ""
+}

--- a/tests/fixtures/legacy-v1.0.4/delivery-manifest.json
+++ b/tests/fixtures/legacy-v1.0.4/delivery-manifest.json
@@ -1,0 +1,43 @@
+{
+  "metadata": {
+    "schema": "mixing-delivery",
+    "document_id": "55555555-5555-4555-8555-555555555555",
+    "created_by": "create-delivery",
+    "schema_version": "1.0.0",
+    "created_with": "jl-mixing 1.0.0",
+    "created_at": "2026-07-13T12:00:00-04:00",
+    "last_modified_at": "2026-07-13T12:00:00-04:00"
+  },
+  "project": {
+    "project_document_id": "33333333-3333-4333-8333-333333333333",
+    "project_id": "blue-sky",
+    "project_name": "Blue Sky"
+  },
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "approved_revision": 1,
+  "delivery": {
+    "method": "Cloud transfer",
+    "delivered_at": null,
+    "delivered_by": "",
+    "notes": ""
+  },
+  "files": [
+    {
+      "path": "Acme - Blue Sky - Main Mix.wav",
+      "deliverable_type": "main_mix",
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV",
+      "channels": 2,
+      "duration_seconds": 243.52,
+      "file_size_bytes": 70133760
+    },
+    {
+      "path": "Stems/",
+      "deliverable_type": "stems"
+    }
+  ]
+}

--- a/tests/fixtures/legacy-v1.0.4/project-manifest.json
+++ b/tests/fixtures/legacy-v1.0.4/project-manifest.json
@@ -1,0 +1,70 @@
+{
+  "metadata": {
+    "schema": "mixing-project",
+    "document_id": "33333333-3333-4333-8333-333333333333",
+    "created_by": "new-mix",
+    "schema_version": "1.0.0",
+    "created_with": "jl-mixing 1.0.0",
+    "created_at": "2026-07-13T12:00:00-04:00",
+    "last_modified_at": "2026-07-13T12:00:00-04:00"
+  },
+  "project_id": "blue-sky",
+  "project_name": "Blue Sky",
+  "project_type": "mixing",
+  "client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme"
+  },
+  "artist": "Acme",
+  "album": "",
+  "producer": "",
+  "mix_engineer": "Jake",
+  "music": {
+    "bpm": 112,
+    "key": "D major",
+    "time_signature": "4/4"
+  },
+  "audio": {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "file_format": "WAV"
+  },
+  "daw": {
+    "name": "Logic Pro",
+    "template": "",
+    "project_path": "03_DAW_Project/Project"
+  },
+  "delivery": {
+    "method": "Cloud transfer",
+    "requested_deliverables": [
+      "main_mix",
+      "instrumental"
+    ]
+  },
+  "schedule": {
+    "deadline": null
+  },
+  "creative_direction": "Keep the verses intimate and let the choruses open up.",
+  "state": {
+    "status": "active",
+    "current_revision": 1,
+    "approved": true,
+    "approved_revision": 1,
+    "approved_at": "2026-07-18T14:30:00-04:00",
+    "approved_by": "Client",
+    "delivered": false,
+    "delivered_at": null,
+    "completed_at": null
+  },
+  "revisions": [
+    {
+      "number": 1,
+      "revision_id": "44444444-4444-4444-8444-444444444444",
+      "created_at": "2026-07-17T10:00:00-04:00",
+      "created_by": "new-revision",
+      "description": "Initial mix",
+      "status": "approved",
+      "folder": "04_Revisions/Revision_01"
+    }
+  ]
+}

--- a/tests/fixtures/legacy-v1.0.4/studio.json
+++ b/tests/fixtures/legacy-v1.0.4/studio.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "schema": "mixing-studio",
+    "document_id": "11111111-1111-4111-8111-111111111111",
+    "created_by": "new-studio",
+    "schema_version": "1.0.0",
+    "created_with": "jl-mixing 1.0.0",
+    "created_at": "2026-07-13T12:00:00-04:00",
+    "last_modified_at": "2026-07-13T12:00:00-04:00"
+  },
+  "studio_name": "Mixing Studio",
+  "workspace_root": "~/Music/Mixes",
+  "default_daw": "Logic Pro",
+  "default_mix_engineer": "Jake",
+  "audio_defaults": {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "file_format": "WAV"
+  },
+  "delivery_defaults": {
+    "method": "Cloud transfer",
+    "deliverables": [
+      "main_mix",
+      "instrumental"
+    ]
+  },
+  "naming": {
+    "revision_prefix": "Revision_",
+    "revision_padding": 2,
+    "working_print_prefix": "WORK ",
+    "project_name_pattern": "{{PROJECT_NAME}}",
+    "daw_project_name_pattern": "{{ARTIST}} - {{PROJECT_NAME}}",
+    "deliverable_name_pattern": "{{ARTIST}} - {{PROJECT_NAME}} - {{DELIVERABLE}}"
+  },
+  "behavior": {
+    "open_created_folders": true,
+    "confirm_destructive_actions": true,
+    "non_interactive_defaults_allowed": true
+  }
+}

--- a/tests/fixtures/valid-client-profile-snapshot.json
+++ b/tests/fixtures/valid-client-profile-snapshot.json
@@ -1,0 +1,29 @@
+{
+  "metadata": {
+    "schema": "mixing-client-profile-snapshot",
+    "schema_version": "1.1.0",
+    "document_id": "33333333-3333-4333-8333-333333333333",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00"
+  },
+  "source_client": {
+    "client_document_id": "22222222-2222-4222-8222-222222222222",
+    "client_id": "acme",
+    "client_name": "Acme Records"
+  },
+  "defaults": {
+    "artist": "The Example Band",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/valid-client.json
+++ b/tests/fixtures/valid-client.json
@@ -1,36 +1,27 @@
 {
   "metadata": {
     "schema": "mixing-client",
+    "schema_version": "1.1.0",
     "document_id": "22222222-2222-4222-8222-222222222222",
-    "created_by": "new-client",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:05:00-04:00",
+    "last_modified_at": "2026-07-14T20:05:00-04:00"
   },
   "client_id": "acme",
-  "client_name": "Acme",
-  "artist_name": "",
-  "contact": {
-    "name": "",
-    "email": "",
-    "phone": ""
-  },
-  "company": "",
-  "audio_defaults": {
-    "sample_rate": 48000,
-    "bit_depth": 24,
-    "file_format": "WAV"
-  },
-  "delivery_defaults": {
-    "method": "Cloud transfer",
-    "deliverables": [
-      "main_mix",
-      "instrumental"
-    ]
-  },
-  "revision_defaults": {
-    "included_revisions": 2
-  },
-  "notes": ""
+  "client_name": "Acme Records",
+  "defaults": {
+    "artist": "The Example Band",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  }
 }

--- a/tests/fixtures/valid-delivery-manifest.json
+++ b/tests/fixtures/valid-delivery-manifest.json
@@ -1,15 +1,13 @@
 {
   "metadata": {
     "schema": "mixing-delivery",
-    "document_id": "55555555-5555-4555-8555-555555555555",
-    "created_by": "create-delivery",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "schema_version": "1.1.0",
+    "document_id": "66666666-6666-4666-8666-666666666666",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-20T15:30:00-04:00"
   },
   "project": {
-    "project_document_id": "33333333-3333-4333-8333-333333333333",
+    "project_document_id": "44444444-4444-4444-8444-444444444444",
     "project_id": "blue-sky",
     "project_name": "Blue Sky"
   },
@@ -17,27 +15,36 @@
     "client_document_id": "22222222-2222-4222-8222-222222222222",
     "client_id": "acme"
   },
-  "approved_revision": 1,
+  "revision": {
+    "number": 3,
+    "revision_id": "55555555-5555-4555-8555-555555555553",
+    "description": "Final vocal balance",
+    "approval": {
+      "approved_at": "2026-07-20T14:00:00-04:00",
+      "approved_by": "Client"
+    }
+  },
   "delivery": {
-    "method": "Cloud transfer",
-    "delivered_at": null,
-    "delivered_by": "",
-    "notes": ""
+    "method": "Cloud transfer"
   },
   "files": [
     {
-      "path": "Acme - Blue Sky - Main Mix.wav",
+      "path": "Blue Sky Main Mix.wav",
       "deliverable_type": "main_mix",
-      "sample_rate": 48000,
-      "bit_depth": 24,
-      "file_format": "WAV",
-      "channels": 2,
-      "duration_seconds": 243.52,
-      "file_size_bytes": 70133760
+      "size_bytes": 104857600,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     },
     {
-      "path": "Stems/",
-      "deliverable_type": "stems"
+      "path": "BlueSky_NoVox.wav",
+      "deliverable_type": "unclassified",
+      "size_bytes": 101234567,
+      "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    {
+      "path": "Stems/Blue Sky Stem Drums.wav",
+      "deliverable_type": "stems",
+      "size_bytes": 53428800,
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
     }
   ]
 }

--- a/tests/fixtures/valid-project-manifest.json
+++ b/tests/fixtures/valid-project-manifest.json
@@ -1,21 +1,19 @@
 {
   "metadata": {
     "schema": "mixing-project",
-    "document_id": "33333333-3333-4333-8333-333333333333",
-    "created_by": "new-mix",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "schema_version": "1.1.0",
+    "document_id": "44444444-4444-4444-8444-444444444444",
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:10:00-04:00",
+    "last_modified_at": "2026-07-20T14:00:00-04:00"
   },
   "project_id": "blue-sky",
   "project_name": "Blue Sky",
-  "project_type": "mixing",
   "client": {
     "client_document_id": "22222222-2222-4222-8222-222222222222",
     "client_id": "acme"
   },
-  "artist": "Acme",
+  "artist": "The Example Band",
   "album": "",
   "producer": "",
   "mix_engineer": "Jake",
@@ -29,11 +27,6 @@
     "bit_depth": 24,
     "file_format": "WAV"
   },
-  "daw": {
-    "name": "Logic Pro",
-    "template": "",
-    "project_path": "03_DAW_Project/Project"
-  },
   "delivery": {
     "method": "Cloud transfer",
     "requested_deliverables": [
@@ -46,25 +39,40 @@
   },
   "creative_direction": "Keep the verses intimate and let the choruses open up.",
   "state": {
-    "status": "active",
-    "current_revision": 1,
-    "approved": true,
-    "approved_revision": 1,
-    "approved_at": "2026-07-18T14:30:00-04:00",
-    "approved_by": "Client",
-    "delivered": false,
-    "delivered_at": null,
-    "completed_at": null
+    "current_revision": 3,
+    "approved_revision": 3,
+    "delivered_revision": 3
   },
   "revisions": [
     {
       "number": 1,
-      "revision_id": "44444444-4444-4444-8444-444444444444",
+      "revision_id": "55555555-5555-4555-8555-555555555551",
       "created_at": "2026-07-17T10:00:00-04:00",
-      "created_by": "new-revision",
       "description": "Initial mix",
-      "status": "approved",
-      "folder": "04_Revisions/Revision_01"
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 2,
+      "revision_id": "55555555-5555-4555-8555-555555555552",
+      "created_at": "2026-07-18T10:00:00-04:00",
+      "description": "Client notes addressed",
+      "approval": {
+        "approved_at": null,
+        "approved_by": null
+      }
+    },
+    {
+      "number": 3,
+      "revision_id": "55555555-5555-4555-8555-555555555553",
+      "created_at": "2026-07-20T11:00:00-04:00",
+      "description": "Final vocal balance",
+      "approval": {
+        "approved_at": "2026-07-20T14:00:00-04:00",
+        "approved_by": "Client"
+      }
     }
   ]
 }

--- a/tests/fixtures/valid-studio.json
+++ b/tests/fixtures/valid-studio.json
@@ -1,40 +1,31 @@
 {
   "metadata": {
     "schema": "mixing-studio",
+    "schema_version": "1.1.0",
     "document_id": "11111111-1111-4111-8111-111111111111",
-    "created_by": "new-studio",
-    "schema_version": "1.0.0",
-    "created_with": "jl-mixing 1.0.0",
-    "created_at": "2026-07-13T12:00:00-04:00",
-    "last_modified_at": "2026-07-13T12:00:00-04:00"
+    "created_with": "jl-mixing 1.1.0",
+    "created_at": "2026-07-14T20:00:00-04:00",
+    "last_modified_at": "2026-07-14T20:00:00-04:00"
   },
+  "studio_id": "mixing-studio",
   "studio_name": "Mixing Studio",
-  "workspace_root": "~/Music/Mixes",
-  "default_daw": "Logic Pro",
-  "default_mix_engineer": "Jake",
-  "audio_defaults": {
-    "sample_rate": 48000,
-    "bit_depth": 24,
-    "file_format": "WAV"
+  "root_path": "/Users/jake/Music/Mixes",
+  "defaults": {
+    "mix_engineer": "Jake",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "Cloud transfer",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
   },
-  "delivery_defaults": {
-    "method": "Cloud transfer",
-    "deliverables": [
-      "main_mix",
-      "instrumental"
-    ]
-  },
-  "naming": {
-    "revision_prefix": "Revision_",
-    "revision_padding": 2,
-    "working_print_prefix": "WORK ",
-    "project_name_pattern": "{{PROJECT_NAME}}",
-    "daw_project_name_pattern": "{{ARTIST}} - {{PROJECT_NAME}}",
-    "deliverable_name_pattern": "{{ARTIST}} - {{PROJECT_NAME}} - {{DELIVERABLE}}"
-  },
-  "behavior": {
-    "open_created_folders": true,
-    "confirm_destructive_actions": true,
-    "non_interactive_defaults_allowed": true
+  "cli": {
+    "change_directory_after_create": false
   }
 }

--- a/tests/installation/test-installation.sh
+++ b/tests/installation/test-installation.sh
@@ -25,6 +25,9 @@ assert_file_exists "$prefix/share/jl-mixing/VERSION"
 assert_file_exists "$prefix/share/jl-mixing/.venv/bin/python"
 assert_file_exists "$prefix/bin/new-studio"
 assert_file_exists "$prefix/share/jl-mixing/tools/project-state.py"
+assert_file_exists "$prefix/share/jl-mixing/schemas/client-profile-snapshot.schema.json"
+assert_file_exists "$prefix/share/jl-mixing/templates/Intake_Report.md"
+assert_file_exists "$prefix/share/jl-mixing/templates/Revision_Notes.md"
 assert_success "installed help works" "$prefix/bin/new-studio" --help
 
 PATH="$prefix/bin:$PATH" new-studio --root "$workspace" --non-interactive >/dev/null

--- a/tests/installation/test-release-package.sh
+++ b/tests/installation/test-release-package.sh
@@ -25,6 +25,10 @@ assert_file_exists "$archive.sha256"
 assert_file_exists "$archive.inventory.txt"
 assert_contains "$(cat "$archive.inventory.txt")" 'tools/project-state.py' \
     "project-state tool included in release archive"
+assert_contains "$(cat "$archive.inventory.txt")" 'schemas/client-profile-snapshot.schema.json' \
+    "snapshot schema included in release archive"
+assert_contains "$(cat "$archive.inventory.txt")" 'templates/Intake_Report.md' \
+    "canonical Markdown templates included in release archive"
 assert_success "release archive verifies" "$ROOT/tools/verify-release-archive" "$archive"
 
 echo "[OK] release package ($TEST_COUNT assertions)"

--- a/tests/integration/integration-helper.sh
+++ b/tests/integration/integration-helper.sh
@@ -22,7 +22,7 @@ fixture_studio() {
         "$studio_root/DAWs/Logic Pro/Presets"
     jq --arg root "$studio_root" \
         '.workspace_root=$root | .default_mix_engineer="Jake"' \
-        "$ROOT/examples/studio.json" > "$studio_root/Studio/studio.json"
+        "$ROOT/tests/fixtures/legacy-v1.0.4/studio.json" > "$studio_root/Studio/studio.json"
 }
 
 # Create a valid Acme client beneath a fixture studio.
@@ -31,7 +31,7 @@ fixture_client() {
     studio_root="$1"
     client_root="$studio_root/Clients/Acme"
     mkdir -p "$client_root/Projects/Active" "$client_root/Projects/Completed"
-    cp "$ROOT/examples/client.json" "$client_root/client.json"
+    cp "$ROOT/tests/fixtures/legacy-v1.0.4/client.json" "$client_root/client.json"
     printf '%s\n' "$client_root"
 }
 
@@ -66,12 +66,12 @@ fixture_project() {
         fresh)
             jq '.state={status:"active",current_revision:0,approved:false,approved_revision:null,
                 approved_at:null,approved_by:"",delivered:false,delivered_at:null,completed_at:null} |
-                .revisions=[]' "$ROOT/examples/project-manifest.json" > "$manifest"
+                .revisions=[]' "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" > "$manifest"
             ;;
         open1)
             jq '.state={status:"active",current_revision:1,approved:false,approved_revision:null,
                 approved_at:null,approved_by:"",delivered:false,delivered_at:null,completed_at:null} |
-                .revisions[0].status="open"' "$ROOT/examples/project-manifest.json" > "$manifest"
+                .revisions[0].status="open"' "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" > "$manifest"
             mkdir -p "$project_root/04_Revisions/Revision_01/Prints"
             cp "$ROOT/templates/revision/Revision_Notes.md" "$project_root/04_Revisions/Revision_01/Revision_Notes.md"
             ;;
@@ -84,13 +84,13 @@ fixture_project() {
                     {number:2,revision_id:"66666666-6666-4666-8666-666666666666",
                      created_at:$timestamp,created_by:"new-revision",description:"Second mix",
                      status:"open",folder:"04_Revisions/Revision_02"}
-                ]' "$ROOT/examples/project-manifest.json" > "$manifest"
+                ]' "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" > "$manifest"
             mkdir -p "$project_root/04_Revisions/Revision_01/Prints" "$project_root/04_Revisions/Revision_02/Prints"
             cp "$ROOT/templates/revision/Revision_Notes.md" "$project_root/04_Revisions/Revision_01/Revision_Notes.md"
             cp "$ROOT/templates/revision/Revision_Notes.md" "$project_root/04_Revisions/Revision_02/Revision_Notes.md"
             ;;
         approved1|delivered1)
-            cp "$ROOT/examples/project-manifest.json" "$manifest"
+            cp "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" "$manifest"
             mkdir -p "$project_root/04_Revisions/Revision_01/Prints"
             cp "$ROOT/templates/revision/Revision_Notes.md" "$project_root/04_Revisions/Revision_01/Revision_Notes.md"
             if [ "$mode" = delivered1 ]; then

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -26,6 +26,7 @@ docs/SCOPE_FREEZE_V1.md
 docs/PROJECT_MAINTENANCE.md
 schemas/studio.schema.json
 schemas/client.schema.json
+schemas/client-profile-snapshot.schema.json
 schemas/project-manifest.schema.json
 schemas/delivery-manifest.schema.json
 templates/studio/studio.json.template
@@ -38,6 +39,12 @@ templates/project/Preparation_Report.md
 templates/project/Delivery_Notes.md
 templates/project/Recall_Sheet.md
 templates/revision/Revision_Notes.md
+templates/Intake_Report.md
+templates/Project_Notes.md
+templates/Preparation_Report.md
+templates/Revision_Notes.md
+templates/Delivery_Notes.md
+templates/Recall_Sheet.md
 packaging/requirements.txt
 packaging/RELEASE_README.md
 lib/common.sh
@@ -76,7 +83,7 @@ python3 - <<'PY'
 import json
 from pathlib import Path
 for directory in ('schemas', 'examples', 'tests/fixtures'):
-    for path in Path(directory).glob('*.json'):
+    for path in Path(directory).rglob('*.json'):
         json.loads(path.read_text())
 print('[OK] JSON syntax')
 PY

--- a/tests/unit/test-config.sh
+++ b/tests/unit/test-config.sh
@@ -11,8 +11,8 @@ require_test_command jq
 tmp="$(new_test_dir)"
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/Studio" "$tmp/Clients/Acme"
-cp "$ROOT/examples/studio.json" "$tmp/Studio/studio.json"
-cp "$ROOT/examples/client.json" "$tmp/Clients/Acme/client.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/studio.json" "$tmp/Studio/studio.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/client.json" "$tmp/Clients/Acme/client.json"
 
 # Assert: verify observable behavior rather than internal implementation.
 default_root="$(HOME="$tmp/home" JL_MIXING_ROOT='' jl_config_default_root)"

--- a/tests/unit/test-context.sh
+++ b/tests/unit/test-context.sh
@@ -12,9 +12,9 @@ tmp="$(new_test_dir)"
 trap 'rm -rf "$tmp"' EXIT
 project="$tmp/Clients/Acme/Projects/Active/Blue Sky"
 mkdir -p "$tmp/Studio" "$tmp/Clients/Acme" "$project/00_Admin" "$project/04_Revisions/Revision_01/Prints"
-cp "$ROOT/examples/studio.json" "$tmp/Studio/studio.json"
-cp "$ROOT/examples/client.json" "$tmp/Clients/Acme/client.json"
-cp "$ROOT/examples/project-manifest.json" "$project/00_Admin/project-manifest.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/studio.json" "$tmp/Studio/studio.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/client.json" "$tmp/Clients/Acme/client.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" "$project/00_Admin/project-manifest.json"
 
 # Assert: verify observable behavior rather than internal implementation.
 assert_eq "$project" "$(jl_context_project_root "$project/04_Revisions/Revision_01/Prints")" "project context upward"

--- a/tests/unit/test-json.sh
+++ b/tests/unit/test-json.sh
@@ -10,7 +10,7 @@ require_test_command jq
 # Arrange: build an isolated temporary fixture.
 tmp="$(new_test_dir)"
 trap 'rm -rf "$tmp"' EXIT
-cp "$ROOT/examples/client.json" "$tmp/client.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/client.json" "$tmp/client.json"
 
 # Assert: verify observable behavior rather than internal implementation.
 assert_success "valid JSON detected" jl_json_is_valid "$tmp/client.json"

--- a/tests/unit/test-metadata.sh
+++ b/tests/unit/test-metadata.sh
@@ -15,7 +15,7 @@ metadata="$(jl_metadata_create mixing-client new-client 1.0.0 11111111-1111-4111
 assert_eq "mixing-client" "$(printf '%s' "$metadata" | jq -r '.schema')" "metadata schema"
 expected_version="$(sed -n '1p' "$ROOT/VERSION")"
 assert_eq "jl-mixing $expected_version" "$(printf '%s' "$metadata" | jq -r '.created_with')" "created_with version"
-cp "$ROOT/examples/client.json" "$tmp/client.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/client.json" "$tmp/client.json"
 jl_metadata_touch "$tmp/client.json" 2026-07-14T12:00:00Z
 assert_eq "2026-07-14T12:00:00Z" "$(jl_json_get "$tmp/client.json" '.metadata.last_modified_at')" "metadata touch"
 assert_success "metadata validation" jl_metadata_validate "$tmp/client.json" mixing-client

--- a/tests/unit/test-revision.sh
+++ b/tests/unit/test-revision.sh
@@ -10,7 +10,7 @@ require_test_command jq
 # Arrange: build an isolated temporary fixture.
 tmp="$(new_test_dir)"
 trap 'rm -rf "$tmp"' EXIT
-cp "$ROOT/examples/project-manifest.json" "$tmp/project.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" "$tmp/project.json"
 
 # Assert: verify observable behavior rather than internal implementation.
 assert_eq "2" "$(jl_revision_next_number "$tmp/project.json")" "next revision number"

--- a/tests/unit/test-v11-artifacts.sh
+++ b/tests/unit/test-v11-artifacts.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -eu
+
+# Purpose: Verify the scope-frozen v1.1 schema, example, and Markdown artifacts.
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/tests/test-helper.sh"
+
+python3 - "$ROOT" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+root = Path(sys.argv[1])
+schema_names = [
+    "studio.schema.json",
+    "client.schema.json",
+    "client-profile-snapshot.schema.json",
+    "project-manifest.schema.json",
+    "delivery-manifest.schema.json",
+]
+example_names = [
+    "studio.json",
+    "client.json",
+    "client-profile-snapshot.json",
+    "project-manifest.json",
+    "delivery-manifest.json",
+]
+expected_identities = {
+    "studio.json": "mixing-studio",
+    "client.json": "mixing-client",
+    "client-profile-snapshot.json": "mixing-client-profile-snapshot",
+    "project-manifest.json": "mixing-project",
+    "delivery-manifest.json": "mixing-delivery",
+}
+
+
+def visit_objects(node, location="<root>"):
+    if isinstance(node, dict):
+        if node.get("type") == "object" and node.get("additionalProperties") is not False:
+            raise AssertionError(f"object schema is not strict at {location}")
+        for key, value in node.items():
+            visit_objects(value, f"{location}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            visit_objects(value, f"{location}[{index}]")
+
+
+for name in schema_names:
+    path = root / "schemas" / name
+    schema = json.loads(path.read_text(encoding="utf-8"))
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["additionalProperties"] is False
+    metadata = schema["properties"]["metadata"]
+    assert metadata["properties"]["schema_version"]["const"] == "1.1.0"
+    assert "created_by" not in metadata["properties"]
+    visit_objects(schema, name)
+
+for name in example_names:
+    path = root / "examples" / name
+    document = json.loads(path.read_text(encoding="utf-8"))
+    metadata = document["metadata"]
+    assert metadata["schema"] == expected_identities[name]
+    assert metadata["schema_version"] == "1.1.0"
+    assert metadata["created_with"].startswith("jl-mixing 1.1.")
+    assert "created_by" not in metadata
+
+expected_templates = {
+    "Intake_Report.md": (
+        "# Intake Report\n\n"
+        "<!-- BEGIN AUTOMATED SECTION -->\n"
+        "No intake validation has been run.\n"
+        "<!-- END AUTOMATED SECTION -->\n"
+    ),
+    "Project_Notes.md": "# Project Notes\n",
+    "Preparation_Report.md": "# Preparation Report\n",
+    "Revision_Notes.md": (
+        "# Revision {{REVISION_NUMBER}} Notes\n\n"
+        "Description: {{REVISION_DESCRIPTION}}\n"
+    ),
+    "Delivery_Notes.md": "# Delivery Notes\n",
+    "Recall_Sheet.md": "# Recall Sheet\n",
+}
+for name, expected in expected_templates.items():
+    actual = (root / "templates" / name).read_text(encoding="utf-8")
+    assert actual == expected, f"unexpected canonical template content: {name}"
+
+print("[OK] v1.1 schema and template artifacts")
+PY
+pass "canonical v1.1 artifacts are strict and complete"
+
+echo "[OK] v1.1 artifacts ($TEST_COUNT assertions)"

--- a/tests/unit/test-validation.sh
+++ b/tests/unit/test-validation.sh
@@ -20,7 +20,7 @@ assert_success "valid sample rate" jl_validate_sample_rate 48000
 assert_failure "invalid sample rate" jl_validate_sample_rate 12345
 assert_success "valid revision status" jl_validate_revision_status superseded
 assert_success "valid project type" jl_validate_project_type podcast
-cp "$ROOT/examples/project-manifest.json" "$tmp/project.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" "$tmp/project.json"
 assert_success "single approved revision" jl_validate_single_approved_revision "$tmp/project.json"
 entry='{"path":"Stems/","deliverable_type":"stems"}'
 assert_success "folder delivery entry" jl_validate_delivery_entry "$entry"

--- a/tools/validate-json.py
+++ b/tools/validate-json.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Validate JSON documents against the project's Draft 2020-12 schemas.
+"""Validate canonical v1.1 examples and rejection fixtures.
 
-The basic test workflow treats a missing ``jsonschema`` package as a visible
-skip. Strict development/CI mode treats it as a failure. The eventual Batch 4
-installer provides a private pinned Python environment, so normal end users do
-not need to activate or manage a virtual environment themselves.
+The tool validates local Draft 2020-12 schemas only. Basic development mode
+may skip semantic validation when ``jsonschema`` is unavailable; strict/CI
+mode treats that missing dependency as a failure.
 """
 
 from argparse import ArgumentParser
@@ -13,13 +12,10 @@ from pathlib import Path
 import sys
 from typing import Iterable
 
-# A pair always represents (schema, instance document).
 ValidationPair = tuple[Path, Path]
 
 
 def parser() -> ArgumentParser:
-    """Build the CLI parser used by Makefile targets and direct validation."""
-
     result = ArgumentParser(
         description="Validate JL Mixing JSON examples or one explicit document."
     )
@@ -34,11 +30,15 @@ def parser() -> ArgumentParser:
 
 
 def default_pairs(root: Path) -> list[ValidationPair]:
-    """Return the four canonical schema/example pairs shipped by the project."""
+    """Return the five canonical v1.1 schema/example pairs."""
 
     return [
         (root / "schemas/studio.schema.json", root / "examples/studio.json"),
         (root / "schemas/client.schema.json", root / "examples/client.json"),
+        (
+            root / "schemas/client-profile-snapshot.schema.json",
+            root / "examples/client-profile-snapshot.json",
+        ),
         (
             root / "schemas/project-manifest.schema.json",
             root / "examples/project-manifest.json",
@@ -50,57 +50,104 @@ def default_pairs(root: Path) -> list[ValidationPair]:
     ]
 
 
-def validate_pairs(pairs: Iterable[ValidationPair]) -> bool:
-    """Validate every pair and return ``True`` only when all documents pass.
+def negative_pairs(root: Path) -> list[ValidationPair]:
+    """Return fixtures that each add one forbidden v1.0-era field."""
 
-    Schema validity is checked before instance validation so a broken contract
-    cannot produce misleading document errors.
-    """
+    return [
+        (root / "schemas/studio.schema.json", root / "tests/fixtures/invalid-studio.json"),
+        (root / "schemas/client.schema.json", root / "tests/fixtures/invalid-client.json"),
+        (
+            root / "schemas/client-profile-snapshot.schema.json",
+            root / "tests/fixtures/invalid-client-profile-snapshot.json",
+        ),
+        (
+            root / "schemas/project-manifest.schema.json",
+            root / "tests/fixtures/invalid-project-manifest.json",
+        ),
+        (
+            root / "schemas/delivery-manifest.schema.json",
+            root / "tests/fixtures/invalid-delivery-manifest.json",
+        ),
+        (
+            root / "schemas/studio.schema.json",
+            root / "tests/fixtures/invalid-studio-duplicate-deliverables.json",
+        ),
+        (
+            root / "schemas/project-manifest.schema.json",
+            root / "tests/fixtures/invalid-project-approval-pair.json",
+        ),
+        (
+            root / "schemas/project-manifest.schema.json",
+            root / "tests/fixtures/invalid-project-empty-artist.json",
+        ),
+        (
+            root / "schemas/project-manifest.schema.json",
+            root / "tests/fixtures/invalid-project-deadline.json",
+        ),
+        (
+            root / "schemas/delivery-manifest.schema.json",
+            root / "tests/fixtures/invalid-delivery-path.json",
+        ),
+        (
+            root / "schemas/delivery-manifest.schema.json",
+            root / "tests/fixtures/invalid-delivery-uppercase-hash.json",
+        ),
+    ]
 
+
+def validator_for(schema_path: Path):
     from jsonschema import Draft202012Validator, FormatChecker
 
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def validate_pairs(pairs: Iterable[ValidationPair]) -> bool:
     failed = False
     for schema_path, document_path in pairs:
-        schema = json.loads(schema_path.read_text())
-        Draft202012Validator.check_schema(schema)
-
-        document = json.loads(document_path.read_text())
-        validator = Draft202012Validator(schema, format_checker=FormatChecker())
-        errors = sorted(
-            validator.iter_errors(document),
-            key=lambda error: list(error.path),
-        )
-
+        validator = validator_for(schema_path)
+        document = json.loads(document_path.read_text(encoding="utf-8"))
+        errors = sorted(validator.iter_errors(document), key=lambda error: list(error.path))
         if errors:
             failed = True
             for error in errors:
-                location = ".".join(
-                    str(item) for item in error.absolute_path
-                ) or "<root>"
+                location = ".".join(str(item) for item in error.absolute_path) or "<root>"
                 print(
                     f"[FAIL] {document_path.name} at {location}: {error.message}",
                     file=sys.stderr,
                 )
         else:
             print(f"[OK] Schema: {document_path.name}")
+    return not failed
 
+
+def validate_rejections(pairs: Iterable[ValidationPair]) -> bool:
+    failed = False
+    for schema_path, document_path in pairs:
+        validator = validator_for(schema_path)
+        document = json.loads(document_path.read_text(encoding="utf-8"))
+        errors = list(validator.iter_errors(document))
+        if not errors:
+            failed = True
+            print(
+                f"[FAIL] Rejection fixture unexpectedly passed: {document_path.name}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"[OK] Rejected invalid fixture: {document_path.name}")
     return not failed
 
 
 def main() -> int:
-    """Resolve validation inputs, dependency policy, and process exit status."""
-
     args = parser().parse_args()
     root = Path(__file__).resolve().parent.parent
-
-    # A caller must either provide both paths or neither; accepting half a pair
-    # would make it unclear which contract or document should be used.
     if bool(args.schema) != bool(args.document):
         print("--schema and --document must be supplied together.", file=sys.stderr)
         return 2
 
     try:
-        import jsonschema  # noqa: F401  # Imported here to support dependency-light tests.
+        import jsonschema  # noqa: F401
     except ModuleNotFoundError:
         message = "Python package 'jsonschema' is not installed."
         if args.strict:
@@ -113,13 +160,12 @@ def main() -> int:
         )
         return 0
 
-    pairs: list[ValidationPair]
     if args.schema and args.document:
-        pairs = [(args.schema, args.document)]
-    else:
-        pairs = default_pairs(root)
+        return 0 if validate_pairs([(args.schema, args.document)]) else 1
 
-    return 0 if validate_pairs(pairs) else 1
+    positive_ok = validate_pairs(default_pairs(root))
+    negative_ok = validate_rejections(negative_pairs(root))
+    return 0 if positive_ok and negative_ok else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Included
Five strict JSON Schema Draft 2020-12 schemas
New client-profile-snapshot.schema.json
Five canonical v1.1 JSON examples
Positive and negative schema fixtures
Six minimal canonical Markdown templates
Tests for strict objects, removed legacy fields, approval pairing, path safety, lowercase SHA-256, deadlines, and unique deliverables
Installation and release-package verification

The existing v1.0.4 command schemas are temporarily archived under:

schemas/legacy/v1.0.4/

Unmigrated commands point to those archived schemas so the development branch remains testable. This is not v1.0 workspace compatibility; each command feature branch will move to the canonical v1.1 schemas.