### PR TITLE
feat: migrate new-client to v1.1

### DIFF
--- a/bin/new-client
+++ b/bin/new-client
@@ -1,26 +1,33 @@
 #!/usr/bin/env bash
-# Create a client profile and the minimal Active/Completed project structure.
+# Create a JL Mixing Automation v1.1 client profile.
 #
-# Defaults are inherited from studio.json, while explicit command-line values
-# take precedence. Creation is transactional so partial clients are removed.
+# Client creation is transactional. The complete client directory is staged,
+# schema-validated, and committed only after all identity, collision, default,
+# and filesystem checks succeed. The command never adopts or overwrites an
+# existing client path.
 set -eu
 
-# Resolve the installation root from this launcher. Installed wrappers may
-# override it with JL_MIXING_HOME.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="${JL_MIXING_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-# Load shared services; command files intentionally keep reusable logic in lib/.
+# shellcheck source=lib/common.sh
 . "$APP_ROOT/lib/common.sh"
-. "$APP_ROOT/lib/config.sh"
+# shellcheck source=lib/context.sh
 . "$APP_ROOT/lib/context.sh"
+# shellcheck source=lib/filesystem.sh
 . "$APP_ROOT/lib/filesystem.sh"
+# shellcheck source=lib/json.sh
 . "$APP_ROOT/lib/json.sh"
+# shellcheck source=lib/metadata.sh
 . "$APP_ROOT/lib/metadata.sh"
+# shellcheck source=lib/naming.sh
 . "$APP_ROOT/lib/naming.sh"
+# shellcheck source=lib/templates.sh
 . "$APP_ROOT/lib/templates.sh"
+# shellcheck source=lib/transaction.sh
+. "$APP_ROOT/lib/transaction.sh"
+# shellcheck source=lib/validation.sh
 . "$APP_ROOT/lib/validation.sh"
 
-# Print command syntax and supported options, then return to the caller.
 usage() {
     cat <<'USAGE'
 Usage: new-client CLIENT_ID [options]
@@ -28,16 +35,108 @@ Usage: new-client CLIENT_ID [options]
 Options:
   --name NAME             Display name (default: title-cased client ID)
   --artist NAME           Default artist or program name
-  --sample-rate HZ        Client sample-rate default
-  --bit-depth BITS        Client bit-depth default
-  --file-format FORMAT    WAV or AIFF
-  --revision-limit COUNT  Included revision count
+  --sample-rate HZ        Default project sample rate
+  --bit-depth BITS        Default project bit depth
+  --file-format FORMAT    Default project format: WAV or AIFF
   --delivery-method TEXT  Default delivery method
-  --deliverables LIST     Comma-separated deliverable types
-  --non-interactive       Accept supplied values and defaults
-  --dry-run               Print the planned client without creating it
+  --deliverables LIST     Comma-separated requested deliverables
+  --cd                    Enter the new client directory after creation
+  --no-cd                 Remain in the current directory after creation
+  --dry-run               Show the planned client without creating it
   -h, --help              Show this help
 USAGE
+}
+
+removed_option_error() {
+    case "$1" in
+        --revision-limit)
+            jl_error "--revision-limit was removed in JL Mixing 1.1."
+            jl_error "The v1.1 revision workflow has no included-revision limit."
+            ;;
+        --non-interactive)
+            jl_error "--non-interactive was removed in JL Mixing 1.1."
+            jl_error "new-client already uses supplied values and inherited defaults without prompting."
+            ;;
+    esac
+    return "$JL_EXIT_ARGUMENTS"
+}
+
+# Print one path as a safely single-quoted shell argument. This output is only
+# guidance for the user; commands never evaluate it internally.
+shell_quote_path() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\"'\"'/g")"
+}
+
+# Parse a comma-separated deliverables option without silently dropping empty
+# entries. The canonical order supplied by the user is preserved.
+parse_deliverables_csv() {
+    local csv
+    csv="$1"
+    jl_json_require_jq || return $?
+
+    printf '%s' "$csv" | jq -R -c -e '
+        split(",") as $raw
+        | if ($raw | length) == 0 or any($raw[]; test("^[[:space:]]*$")) then
+              error("deliverables must not contain empty entries")
+          else
+              $raw | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
+          end
+        | if length == 0 then error("at least one deliverable is required") else . end
+        | if (unique | length) != length then error("duplicate deliverables are not allowed") else . end
+    ' 2>/dev/null || {
+        jl_error "Invalid --deliverables list: $csv"
+        return "$JL_EXIT_VALIDATION"
+    }
+}
+
+
+# Validate a non-empty requested-deliverables array against the canonical v1.1
+# enum while preserving the caller's array order.
+validate_deliverables_json() {
+    local values_json deliverable count unique_count
+    values_json="$1"
+    count="$(printf '%s' "$values_json" | jq -r 'length')" || return $?
+    [ "$count" -gt 0 ] || {
+        jl_error "At least one requested deliverable is required."
+        return "$JL_EXIT_VALIDATION"
+    }
+
+    while IFS= read -r deliverable; do
+        jl_validate_enum "$deliverable" \
+            main_mix instrumental acapella tv_mix performance_mix stems master || {
+            jl_error "Unsupported deliverable type: $deliverable"
+            return "$JL_EXIT_VALIDATION"
+        }
+    done <<EOF_DELIVERABLE_VALUES
+$(printf '%s' "$values_json" | jq -r '.[]')
+EOF_DELIVERABLE_VALUES
+
+    unique_count="$(printf '%s' "$values_json" | jq -r 'unique | length')" || return $?
+    if [ "$unique_count" -ne "$count" ]; then
+        jl_error "Requested deliverables must be unique."
+        return "$JL_EXIT_VALIDATION"
+    fi
+}
+
+# Write the committed destination to the private shell-wrapper result file.
+# The file must already be a writable, absolute, non-symlink regular file.
+write_directory_result() {
+    local result_file destination
+    result_file="$1"
+    destination="$2"
+
+    jl_path_validate_absolute "$result_file" || {
+        jl_error "Shell-integration result path must be absolute: $result_file"
+        return "$JL_EXIT_UNSAFE"
+    }
+    if [ ! -f "$result_file" ] || [ -L "$result_file" ] || [ ! -w "$result_file" ]; then
+        jl_error "Shell-integration result file is missing or unsafe: $result_file"
+        return "$JL_EXIT_UNSAFE"
+    fi
+    printf '%s\n' "$destination" > "$result_file" || {
+        jl_error "Unable to write shell-integration directory result: $result_file"
+        return "$JL_EXIT_GENERAL"
+    }
 }
 
 client_id=""
@@ -46,145 +145,352 @@ artist_name=""
 sample_rate=""
 bit_depth=""
 file_format=""
-revision_limit=""
 delivery_method=""
 deliverables_csv=""
+name_seen=0
+sample_rate_seen=0
+bit_depth_seen=0
+file_format_seen=0
+delivery_method_seen=0
+deliverables_seen=0
+cd_enabled_seen=0
+cd_disabled_seen=0
 dry_run=0
 
 if [ "$#" -gt 0 ]; then
     case "$1" in
-        -* ) ;;
-        * ) client_id="$1"; shift ;;
+        -*) ;;
+        *) client_id="$1"; shift ;;
     esac
 fi
 
-# Parse options explicitly so unknown or missing arguments fail predictably.
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --name) [ "$#" -ge 2 ] || jl_die "--name requires a value." "$JL_EXIT_ARGUMENTS"; client_name="$2"; shift 2 ;;
-        --artist) [ "$#" -ge 2 ] || jl_die "--artist requires a value." "$JL_EXIT_ARGUMENTS"; artist_name="$2"; shift 2 ;;
-        --sample-rate) [ "$#" -ge 2 ] || jl_die "--sample-rate requires a value." "$JL_EXIT_ARGUMENTS"; sample_rate="$2"; shift 2 ;;
-        --bit-depth) [ "$#" -ge 2 ] || jl_die "--bit-depth requires a value." "$JL_EXIT_ARGUMENTS"; bit_depth="$2"; shift 2 ;;
-        --file-format) [ "$#" -ge 2 ] || jl_die "--file-format requires a value." "$JL_EXIT_ARGUMENTS"; file_format="$2"; shift 2 ;;
-        --revision-limit) [ "$#" -ge 2 ] || jl_die "--revision-limit requires a value." "$JL_EXIT_ARGUMENTS"; revision_limit="$2"; shift 2 ;;
-        --delivery-method) [ "$#" -ge 2 ] || jl_die "--delivery-method requires a value." "$JL_EXIT_ARGUMENTS"; delivery_method="$2"; shift 2 ;;
-        --deliverables) [ "$#" -ge 2 ] || jl_die "--deliverables requires a value." "$JL_EXIT_ARGUMENTS"; deliverables_csv="$2"; shift 2 ;;
-        --non-interactive) shift ;;
-        --dry-run) dry_run=1; shift ;;
-        -h|--help) usage; exit 0 ;;
-        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS"; exit $? ;;
+        --name)
+            [ "$#" -ge 2 ] || jl_die "--name requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            client_name="$2"
+            name_seen=1
+            shift 2
+            ;;
+        --artist)
+            [ "$#" -ge 2 ] || jl_die "--artist requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            artist_name="$2"
+            shift 2
+            ;;
+        --sample-rate)
+            [ "$#" -ge 2 ] || jl_die "--sample-rate requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            sample_rate="$2"
+            sample_rate_seen=1
+            shift 2
+            ;;
+        --bit-depth)
+            [ "$#" -ge 2 ] || jl_die "--bit-depth requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            bit_depth="$2"
+            bit_depth_seen=1
+            shift 2
+            ;;
+        --file-format)
+            [ "$#" -ge 2 ] || jl_die "--file-format requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            file_format="$2"
+            file_format_seen=1
+            shift 2
+            ;;
+        --delivery-method)
+            [ "$#" -ge 2 ] || jl_die "--delivery-method requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            delivery_method="$2"
+            delivery_method_seen=1
+            shift 2
+            ;;
+        --deliverables)
+            [ "$#" -ge 2 ] || jl_die "--deliverables requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            deliverables_csv="$2"
+            deliverables_seen=1
+            shift 2
+            ;;
+        --cd)
+            cd_enabled_seen=1
+            shift
+            ;;
+        --no-cd)
+            cd_disabled_seen=1
+            shift
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --revision-limit|--non-interactive)
+            removed_option_error "$1"
+            exit $?
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --*)
+            jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS"
+            exit $?
+            ;;
+        *)
+            jl_die "Unexpected positional argument: $1" "$JL_EXIT_ARGUMENTS"
+            exit $?
+            ;;
     esac
 done
 
-jl_assert_nonempty "$client_id" "client ID" || exit $?
-jl_validate_slug "$client_id" || { jl_error "Client ID must be a lowercase slug: $client_id"; exit "$JL_EXIT_VALIDATION"; }
-
-# Resolve and validate the studio before deriving client defaults.
-studio_root="$(jl_context_studio_root "$PWD")" || {
-    jl_error "Studio workspace not found. Run new-studio first or set JL_MIXING_ROOT."
-    exit "$JL_EXIT_CONTEXT"
-}
-studio_file="$studio_root/Studio/studio.json"
-
-[ -n "$client_name" ] || client_name="$(jl_title_from_slug "$client_id")"
-client_folder_name="$(jl_sanitize_component "$client_name")"
-jl_assert_nonempty "$client_folder_name" "client folder name" || exit $?
-
-sample_rate="${sample_rate:-$(jl_json_get "$studio_file" '.audio_defaults.sample_rate')}"
-bit_depth="${bit_depth:-$(jl_json_get "$studio_file" '.audio_defaults.bit_depth')}"
-file_format="${file_format:-$(jl_json_get "$studio_file" '.audio_defaults.file_format')}"
-revision_limit="${revision_limit:-2}"
-delivery_method="${delivery_method:-$(jl_json_get "$studio_file" '.delivery_defaults.method')}"
-
-jl_validate_sample_rate "$sample_rate" || { jl_error "Unsupported sample rate: $sample_rate"; exit "$JL_EXIT_VALIDATION"; }
-jl_validate_bit_depth "$bit_depth" || { jl_error "Unsupported bit depth: $bit_depth"; exit "$JL_EXIT_VALIDATION"; }
-file_format="$(printf '%s' "$file_format" | tr '[:lower:]' '[:upper:]')"
-jl_validate_file_format "$file_format" || { jl_error "Unsupported file format: $file_format"; exit "$JL_EXIT_VALIDATION"; }
-case "$revision_limit" in ''|*[!0-9]*) jl_error "Revision limit must be a nonnegative integer."; exit "$JL_EXIT_VALIDATION" ;; esac
-
-if [ -n "$deliverables_csv" ]; then
-    deliverables_json="$(jl_json_array_from_csv "$deliverables_csv")"
-else
-    deliverables_json="$(jl_json_get_json "$studio_file" '.delivery_defaults.deliverables')"
+if [ "$cd_enabled_seen" -eq 1 ] && [ "$cd_disabled_seen" -eq 1 ]; then
+    jl_error "--cd and --no-cd cannot be used together."
+    exit "$JL_EXIT_ARGUMENTS"
+fi
+if [ "$dry_run" -eq 1 ] && { [ "$cd_enabled_seen" -eq 1 ] || [ "$cd_disabled_seen" -eq 1 ]; }; then
+    jl_error "--cd and --no-cd cannot be used with --dry-run."
+    exit "$JL_EXIT_ARGUMENTS"
 fi
 
-while IFS= read -r deliverable; do
-    jl_validate_enum "$deliverable" main_mix instrumental acapella tv_mix performance_mix stems master || {
-        jl_error "Unsupported deliverable type: $deliverable"
+jl_assert_nonempty "$client_id" "client ID" || exit $?
+if ! jl_validate_slug "$client_id"; then
+    jl_error "Client ID must be a lowercase slug using single hyphens: $client_id"
+    exit "$JL_EXIT_VALIDATION"
+fi
+
+if [ "$name_seen" -eq 0 ]; then
+    client_name="$(jl_title_from_slug "$client_id")"
+fi
+client_name="$(jl_trim "$client_name")"
+artist_name="$(jl_trim "$artist_name")"
+delivery_method="$(jl_trim "$delivery_method")"
+jl_assert_nonempty "$client_name" "client name" || exit $?
+client_folder_name="$(jl_sanitize_folder_name "$client_name")" || exit $?
+
+# Reject invalid explicit values before the relatively expensive workspace and
+# schema validation steps. Inherited values are validated again after loading
+# the studio record.
+if [ "$sample_rate_seen" -eq 1 ]; then
+    jl_validate_sample_rate "$sample_rate" || {
+        jl_error "Unsupported sample rate: $sample_rate"
+        jl_error "Supported values: 44100, 48000, 88200, 96000, 176400, 192000"
         exit "$JL_EXIT_VALIDATION"
     }
-done < <(printf '%s' "$deliverables_json" | jq -r '.[]')
+fi
+if [ "$bit_depth_seen" -eq 1 ]; then
+    jl_validate_bit_depth "$bit_depth" || {
+        jl_error "Unsupported bit depth: $bit_depth"
+        jl_error "Supported values: 16, 24, 32"
+        exit "$JL_EXIT_VALIDATION"
+    }
+fi
+if [ "$file_format_seen" -eq 1 ]; then
+    file_format="$(printf '%s' "$file_format" | tr '[:lower:]' '[:upper:]')"
+    jl_validate_file_format "$file_format" || {
+        jl_error "Unsupported file format: $file_format"
+        jl_error "Supported values: WAV, AIFF"
+        exit "$JL_EXIT_VALIDATION"
+    }
+fi
+if [ "$delivery_method_seen" -eq 1 ]; then
+    jl_assert_nonempty "$delivery_method" "delivery method" || exit $?
+fi
+if [ "$deliverables_seen" -eq 1 ]; then
+    deliverables_json="$(parse_deliverables_csv "$deliverables_csv")" || exit $?
+    validate_deliverables_json "$deliverables_json" || exit $?
+fi
 
-# Refuse duplicate stable IDs even when the requested display name differs.
-duplicate_client=0
-while IFS= read -r existing_file; do
-    if [ "$(jl_json_get_optional "$existing_file" '.client_id' '')" = "$client_id" ]; then
-        duplicate_client=1
-        break
+studio_root="$(jl_context_studio_root_v11 "$PWD")" || exit $?
+studio_file="$studio_root/Studio/studio.json"
+clients_root="$studio_root/Clients"
+
+jl_json_validate_local_document \
+    "$studio_file" studio.schema.json mixing-studio 1.1.0 >/dev/null || exit $?
+jl_metadata_validate_v11 "$studio_file" mixing-studio mutable || exit $?
+jl_json_validate_unique_uuids "$studio_root" || exit $?
+
+if ! jl_fs_is_directory_no_symlink "$clients_root"; then
+    jl_error "Clients directory is missing or unsafe: $clients_root"
+    exit "$JL_EXIT_CONTEXT"
+fi
+if [ ! -w "$clients_root" ] || [ ! -x "$clients_root" ]; then
+    jl_error "Clients directory is not writable: $clients_root"
+    exit "$JL_EXIT_UNSAFE"
+fi
+jl_fs_assert_no_symlink_components "$studio_root" "$clients_root" || exit $?
+
+if [ "$sample_rate_seen" -eq 0 ]; then
+    sample_rate="$(jl_json_get "$studio_file" '.defaults.audio.sample_rate')"
+fi
+if [ "$bit_depth_seen" -eq 0 ]; then
+    bit_depth="$(jl_json_get "$studio_file" '.defaults.audio.bit_depth')"
+fi
+if [ "$file_format_seen" -eq 0 ]; then
+    file_format="$(jl_json_get "$studio_file" '.defaults.audio.file_format')"
+fi
+if [ "$delivery_method_seen" -eq 0 ]; then
+    delivery_method="$(jl_json_get "$studio_file" '.defaults.delivery.method')"
+fi
+
+jl_validate_sample_rate "$sample_rate" || {
+    jl_error "Unsupported sample rate: $sample_rate"
+    jl_error "Supported values: 44100, 48000, 88200, 96000, 176400, 192000"
+    exit "$JL_EXIT_VALIDATION"
+}
+jl_validate_bit_depth "$bit_depth" || {
+    jl_error "Unsupported bit depth: $bit_depth"
+    jl_error "Supported values: 16, 24, 32"
+    exit "$JL_EXIT_VALIDATION"
+}
+file_format="$(printf '%s' "$file_format" | tr '[:lower:]' '[:upper:]')"
+jl_validate_file_format "$file_format" || {
+    jl_error "Unsupported file format: $file_format"
+    jl_error "Supported values: WAV, AIFF"
+    exit "$JL_EXIT_VALIDATION"
+}
+jl_assert_nonempty "$delivery_method" "delivery method" || exit $?
+
+if [ "$deliverables_seen" -eq 0 ]; then
+    deliverables_json="$(jl_json_get_json "$studio_file" '.defaults.delivery.requested_deliverables')"
+    validate_deliverables_json "$deliverables_json" || exit $?
+fi
+
+jl_validate_client_id_available "$studio_root" "$client_id" || exit $?
+jl_fs_assert_no_case_insensitive_child_collision "$clients_root" "$client_folder_name" || exit $?
+
+client_root="$clients_root/$client_folder_name"
+if [ -e "$client_root" ] || [ -L "$client_root" ]; then
+    jl_error "Client destination already exists: $client_root"
+    exit "$JL_EXIT_UNSAFE"
+fi
+
+studio_default_cd="$(jq -r '.cli.change_directory_after_create' "$studio_file")"
+effective_cd=0
+if [ "$cd_enabled_seen" -eq 1 ]; then
+    effective_cd=1
+elif [ "$cd_disabled_seen" -eq 1 ]; then
+    effective_cd=0
+elif [ "$studio_default_cd" = true ]; then
+    effective_cd=1
+fi
+
+print_summary() {
+    local heading artist_display
+    heading="$1"
+    artist_display="${artist_name:-<not set>}"
+
+    printf '%s\n\n' "$heading"
+    printf 'Client ID:                  %s\n' "$client_id"
+    printf 'Client name:                %s\n' "$client_name"
+    printf 'Client folder:              %s\n' "$client_root"
+    printf 'Default artist:             %s\n' "$artist_display"
+    printf 'Audio format:               %s Hz / %s-bit / %s\n' "$sample_rate" "$bit_depth" "$file_format"
+    printf 'Delivery method:            %s\n' "$delivery_method"
+    printf 'Requested deliverables:     %s\n' "$(printf '%s' "$deliverables_json" | jq -r 'join(", ")')"
+    if [ "$effective_cd" -eq 1 ]; then
+        printf 'Automatic directory change: enabled\n'
+    else
+        printf 'Automatic directory change: disabled\n'
     fi
-done < <(find "$studio_root/Clients" -mindepth 2 -maxdepth 2 -name client.json -type f -print 2>/dev/null)
-if [ "$duplicate_client" -eq 1 ]; then
-    jl_error "A client with ID '$client_id' already exists."
-    exit "$JL_EXIT_UNSAFE"
-fi
+}
 
-client_root="$studio_root/Clients/$client_folder_name"
-if [ -e "$client_root" ]; then
-    jl_error "Refusing to overwrite existing client path: $client_root"
-    exit "$JL_EXIT_UNSAFE"
-fi
-
-# Dry-run reports the resolved client without touching the workspace.
 if [ "$dry_run" -eq 1 ]; then
-    printf 'Would create client: %s (%s)\n' "$client_name" "$client_id"
-    printf 'Location: %s\n' "$client_root"
+    print_summary "Dry run — no changes made."
+    cat <<'EOF_PLAN'
+
+Would create:
+  client.json
+  Projects/
+EOF_PLAN
+    printf '\nAfter creation:\n  cd '
+    shell_quote_path "$client_root"
+    printf '\n  new-mix --project "PROJECT NAME"\n'
     exit 0
 fi
 
-cleanup=1
-# Trap handler that removes a partially created workspace or entity after failure.
-cleanup_on_failure() {
-    status=$?
-    if [ "$status" -ne 0 ] && [ "$cleanup" -eq 1 ]; then
-        rm -rf "$client_root"
-    fi
-    exit "$status"
-}
-trap cleanup_on_failure EXIT HUP INT TERM
+schema_file="$(jl_json_schema_path client.schema.json)" || exit $?
+software_version="$(jl_software_version)" || exit $?
+case "$software_version" in
+    1.1.*) ;;
+    *)
+        jl_error "new-client requires a JL Mixing 1.1.x application version; found $software_version."
+        exit "$JL_EXIT_CONFIG"
+        ;;
+esac
 
-# Create the minimal client folder structure before rendering client.json.
-mkdir -p "$client_root/Projects/Active" "$client_root/Projects/Completed"
+stage_root=""
+cleanup_stage() {
+    local status
+    status=$?
+    if [ -n "$stage_root" ] && { [ -e "$stage_root" ] || [ -L "$stage_root" ]; }; then
+        jl_fs_remove_entry_no_follow "$stage_root" || true
+    fi
+    return "$status"
+}
+trap cleanup_stage EXIT
+trap 'exit 1' HUP INT TERM
+
+stage_root="$(jl_txn_stage_directory_near "$client_root")" || exit $?
+chmod 755 "$stage_root"
+mkdir -p "$stage_root/Projects"
+chmod 755 "$stage_root/Projects"
+
 created_at="$(jl_now_iso8601)"
-document_id="$(jl_uuid)"
+document_id="$(jl_uuid)" || exit $?
+jl_json_assert_document_id_available "$studio_root" "$document_id" || exit $?
+staged_client_file="$stage_root/client.json"
+
 jl_template_render_json \
     "$APP_ROOT/templates/client/client.json.template" \
-    "$client_root/client.json" \
+    "$staged_client_file" \
     DOCUMENT_ID "$document_id" \
-    SOFTWARE_VERSION "$(jl_software_version)" \
+    SOFTWARE_VERSION "$software_version" \
     CREATED_AT "$created_at" \
     CLIENT_ID "$client_id" \
-    CLIENT_NAME "$client_name"
+    CLIENT_NAME "$client_name" \
+    DEFAULT_ARTIST "$artist_name" \
+    DELIVERY_METHOD "$delivery_method" || exit $?
 
-jl_json_update "$client_root/client.json" \
-    '.artist_name = $artist |
-     .audio_defaults.sample_rate = $sample_rate |
-     .audio_defaults.bit_depth = $bit_depth |
-     .audio_defaults.file_format = $file_format |
-     .delivery_defaults.method = $delivery_method |
-     .delivery_defaults.deliverables = $deliverables |
-     .revision_defaults.included_revisions = $revision_limit' \
-    --arg artist "$artist_name" \
+jl_json_update "$staged_client_file" \
+    '.defaults.audio.sample_rate = $sample_rate |
+     .defaults.audio.bit_depth = $bit_depth |
+     .defaults.audio.file_format = $file_format |
+     .defaults.delivery.requested_deliverables = $deliverables' \
     --argjson sample_rate "$sample_rate" \
     --argjson bit_depth "$bit_depth" \
     --arg file_format "$file_format" \
-    --arg delivery_method "$delivery_method" \
-    --argjson deliverables "$deliverables_json" \
-    --argjson revision_limit "$revision_limit"
+    --argjson deliverables "$deliverables_json" || exit $?
 
-# Schema validation is the commit point for client creation.
-jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/client.schema.json" "$client_root/client.json"
-cleanup=0
-trap - EXIT HUP INT TERM
+jl_json_validate_schema "$schema_file" "$staged_client_file" >/dev/null || exit $?
+jl_metadata_validate_v11 "$staged_client_file" mixing-client mutable || exit $?
 
-printf 'Created client: %s\n' "$client_root"
-printf 'Next: cd %s && new-mix --project "Project Name"\n' "$client_root"
+jl_txn_commit_new_directory "$stage_root" "$client_root" || exit $?
+stage_root=""
+
+result_written=0
+if [ "$effective_cd" -eq 1 ] && [ -n "${JL_MIXING_CD_RESULT_FILE:-}" ]; then
+    write_directory_result "$JL_MIXING_CD_RESULT_FILE" "$client_root" || {
+        jl_error "Client creation succeeded, but automatic directory-change setup failed."
+        {
+            printf 'Run:\n  cd '
+            shell_quote_path "$client_root"
+            printf '\n'
+        } >&2
+        exit "$JL_EXIT_GENERAL"
+    }
+    result_written=1
+fi
+
+print_summary "Client created successfully."
+printf 'Configuration:               %s\n' "$client_root/client.json"
+
+if [ "$effective_cd" -eq 1 ] && [ "$result_written" -eq 0 ]; then
+    cat <<'EOF_WARNING'
+
+Automatic directory change could not be performed because JL Mixing shell
+integration is not active.
+EOF_WARNING
+fi
+
+printf '\nNext:\n'
+if [ "$effective_cd" -eq 0 ] || [ "$result_written" -eq 0 ]; then
+    printf '  cd '
+    shell_quote_path "$client_root"
+    printf '\n'
+fi
+printf '  new-mix --project "PROJECT NAME"\n'

--- a/templates/client/client.json.template
+++ b/templates/client/client.json.template
@@ -1,20 +1,27 @@
 {
   "metadata": {
     "schema": "mixing-client",
-    "schema_version": "1.0.0",
+    "schema_version": "1.1.0",
     "document_id": "{{DOCUMENT_ID}}",
-    "created_by": "new-client",
     "created_with": "jl-mixing {{SOFTWARE_VERSION}}",
     "created_at": "{{CREATED_AT}}",
     "last_modified_at": "{{CREATED_AT}}"
   },
   "client_id": "{{CLIENT_ID}}",
   "client_name": "{{CLIENT_NAME}}",
-  "artist_name": "",
-  "contact": {"name": "", "email": "", "phone": ""},
-  "company": "",
-  "audio_defaults": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
-  "delivery_defaults": {"method": "Cloud transfer", "deliverables": ["main_mix", "instrumental"]},
-  "revision_defaults": {"included_revisions": 2},
-  "notes": ""
+  "defaults": {
+    "artist": "{{DEFAULT_ARTIST}}",
+    "audio": {
+      "sample_rate": 48000,
+      "bit_depth": 24,
+      "file_format": "WAV"
+    },
+    "delivery": {
+      "method": "{{DELIVERY_METHOD}}",
+      "requested_deliverables": [
+        "main_mix",
+        "instrumental"
+      ]
+    }
+  }
 }

--- a/tests/installation/test-installation.sh
+++ b/tests/installation/test-installation.sh
@@ -24,6 +24,7 @@ JL_MIXING_TEST_SYSTEM_SITE_PACKAGES=1 "$ROOT/install.sh" --prefix "$prefix" >/de
 assert_file_exists "$prefix/share/jl-mixing/VERSION"
 assert_file_exists "$prefix/share/jl-mixing/.venv/bin/python"
 assert_file_exists "$prefix/bin/new-studio"
+assert_file_exists "$prefix/bin/new-client"
 assert_file_exists "$prefix/share/jl-mixing/tools/project-state.py"
 assert_file_exists "$prefix/share/jl-mixing/schemas/client-profile-snapshot.schema.json"
 assert_file_exists "$prefix/share/jl-mixing/templates/Intake_Report.md"
@@ -35,6 +36,15 @@ assert_file_exists "$workspace/Studio/studio.json"
 assert_json_eq "1.1.0" "$workspace/Studio/studio.json" \
     '.metadata.schema_version' "installed new-studio creates v1.1 schema"
 assert_path_not_exists "$workspace/DAWs"
+
+JL_MIXING_ROOT="$workspace" PATH="$prefix/bin:$PATH" \
+    new-client installed-client --name "Installed Client" >/dev/null
+installed_client="$workspace/Clients/Installed Client/client.json"
+assert_file_exists "$installed_client"
+assert_json_eq "1.1.0" "$installed_client" '.metadata.schema_version' \
+    "installed new-client creates v1.1 schema"
+assert_dir_exists "$workspace/Clients/Installed Client/Projects"
+assert_path_not_exists "$workspace/Clients/Installed Client/Projects/Active"
 
 # A sentinel in the application directory must disappear during upgrade, while
 # the independent studio workspace remains untouched.

--- a/tests/integration/test-new-client.sh
+++ b/tests/integration/test-new-client.sh
@@ -1,27 +1,202 @@
 #!/usr/bin/env bash
 set -eu
 
-# Purpose: Exercise client creation, inherited values, lookup, and duplicate protection.
+# Purpose: Exercise the complete v1.1 client-creation contract.
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/tests/integration/integration-helper.sh"
 
-# Arrange: build an isolated temporary fixture.
+require_test_command jq
+require_test_command python3
+python3 -c 'import jsonschema' >/dev/null 2>&1 || {
+    if [ "${JL_TEST_STRICT:-0}" = "1" ]; then
+        fail "jsonschema is required for strict new-client tests"
+    fi
+    echo "[SKIP] new-client integration tests require jsonschema."
+    exit 0
+}
+
 tmp="$(new_test_dir)"
 trap 'rm -rf "$tmp"' EXIT
-studio_root="$tmp/studio"
-fixture_studio "$studio_root"
-export JL_MIXING_ROOT="$studio_root"
 
-(cd "$tmp" && "$ROOT/bin/new-client" acme --name "Acme Records" --artist "The Acmes" --non-interactive)
+create_studio() {
+    local root
+    root="$1"
+    shift
+    "$ROOT/bin/new-studio" --root "$root" --name "JL Mix Studio" --engineer "Jake" "$@" >/dev/null
+}
+
+run_client() {
+    local root
+    root="$1"
+    shift
+    JL_MIXING_ROOT="$root" "$ROOT/bin/new-client" "$@"
+}
+
+studio_root="$tmp/studio"
+create_studio "$studio_root"
+
+# Explicit values override studio defaults and produce the minimal flattened
+# client structure.
+output="$(run_client "$studio_root" acme \
+    --name "Acme Records" \
+    --artist "The Acmes" \
+    --sample-rate 96000 \
+    --bit-depth 32 \
+    --file-format aiff \
+    --delivery-method "Secure portal" \
+    --deliverables 'stems, main_mix')"
 client_root="$studio_root/Clients/Acme Records"
-# Assert: verify observable behavior rather than internal implementation.
-assert_file_exists "$client_root/client.json"
-assert_dir_exists "$client_root/Projects/Active"
-assert_dir_exists "$client_root/Projects/Completed"
-assert_json_eq "acme" "$client_root/client.json" '.client_id' "client ID"
-assert_json_eq "The Acmes" "$client_root/client.json" '.artist_name' "artist default"
-"$ROOT/bin/new-client" beta --name "Beta Audio" --non-interactive
-assert_file_exists "$studio_root/Clients/Beta Audio/client.json"
-assert_failure "duplicate client ID is protected" "$ROOT/bin/new-client" acme --name Other --non-interactive
+client_file="$client_root/client.json"
+assert_dir_exists "$client_root"
+assert_dir_exists "$client_root/Projects"
+assert_path_not_exists "$client_root/Projects/Active"
+assert_path_not_exists "$client_root/Projects/Completed"
+assert_file_exists "$client_file"
+assert_json_eq "mixing-client" "$client_file" '.metadata.schema' "client schema identity"
+assert_json_eq "1.1.0" "$client_file" '.metadata.schema_version' "client schema version"
+assert_json_eq "acme" "$client_file" '.client_id' "client ID"
+assert_json_eq "Acme Records" "$client_file" '.client_name' "client display name"
+assert_json_eq "The Acmes" "$client_file" '.defaults.artist' "artist default"
+assert_json_eq "96000" "$client_file" '.defaults.audio.sample_rate' "sample-rate override"
+assert_json_eq "32" "$client_file" '.defaults.audio.bit_depth' "bit-depth override"
+assert_json_eq "AIFF" "$client_file" '.defaults.audio.file_format' "file-format normalization"
+assert_json_eq "Secure portal" "$client_file" '.defaults.delivery.method' "delivery-method override"
+assert_eq '["stems","main_mix"]' "$(jq -c '.defaults.delivery.requested_deliverables' "$client_file")" \
+    "deliverable order preserved"
+assert_eq "false" "$(jq -r '.metadata | has("created_by")' "$client_file")" \
+    "removed created_by is absent"
+assert_contains "$output" 'Client created successfully.' "success heading"
+assert_contains "$output" 'new-mix --project "PROJECT NAME"' "next command retained"
+assert_contains "$output" "cd '$client_root'" "copy-and-paste cd retained"
+python3 "$ROOT/tools/validate-json.py" --strict \
+    --schema "$ROOT/schemas/client.schema.json" --document "$client_file" >/dev/null
+pass "generated client validates against canonical schema"
+
+# Omitted values inherit the studio snapshot and the display name derives from
+# the immutable slug.
+run_client "$studio_root" beta-audio >/dev/null
+beta_file="$studio_root/Clients/Beta Audio/client.json"
+assert_file_exists "$beta_file"
+assert_json_eq "Beta Audio" "$beta_file" '.client_name' "default display name"
+assert_json_eq "48000" "$beta_file" '.defaults.audio.sample_rate' "inherited sample rate"
+assert_json_eq "24" "$beta_file" '.defaults.audio.bit_depth' "inherited bit depth"
+assert_json_eq "WAV" "$beta_file" '.defaults.audio.file_format' "inherited file format"
+assert_json_eq "Cloud transfer" "$beta_file" '.defaults.delivery.method' "inherited delivery method"
+assert_eq '["main_mix","instrumental"]' \
+    "$(jq -c '.defaults.delivery.requested_deliverables' "$beta_file")" \
+    "inherited deliverables"
+
+# Readable folder sanitization is deterministic and does not change the stored
+# display name.
+run_client "$studio_root" smith-jones --name 'Smith / Jones Productions' >/dev/null
+sanitized_root="$studio_root/Clients/Smith - Jones Productions"
+assert_dir_exists "$sanitized_root"
+assert_json_eq 'Smith / Jones Productions' "$sanitized_root/client.json" '.client_name' \
+    "unsanitized display name preserved"
+
+# Duplicate IDs and case-insensitive folder collisions are rejected without
+# creating suffixes or partial clients.
+assert_failure "duplicate client ID is protected" \
+    run_client "$studio_root" acme --name "Another Name"
+assert_failure "case-insensitive folder collision is protected" \
+    run_client "$studio_root" another-acme --name "ACME RECORDS"
+assert_path_not_exists "$studio_root/Clients/Another Name"
+
+# Dry-run resolves inherited values and reports the complete plan without
+# generating a client directory.
+dry_output="$(run_client "$studio_root" dry-client --name 'Dry Client' --dry-run)"
+assert_contains "$dry_output" 'Dry run — no changes made.' "dry-run heading"
+assert_contains "$dry_output" 'client.json' "dry-run file plan"
+assert_contains "$dry_output" 'Projects/' "dry-run directory plan"
+assert_contains "$dry_output" 'new-mix --project "PROJECT NAME"' "dry-run next command"
+assert_path_not_exists "$studio_root/Clients/Dry Client"
+
+# Invalid identities, names, defaults, and deliverable lists fail before any
+# filesystem mutation.
+assert_failure "uppercase client ID rejected" run_client "$studio_root" Bad-ID
+assert_failure "consecutive client-ID hyphens rejected" run_client "$studio_root" bad--id
+assert_failure "empty explicit name rejected" run_client "$studio_root" empty-name --name ""
+assert_failure "reserved folder name rejected" run_client "$studio_root" reserved --name CON
+assert_failure "unsupported sample rate rejected" run_client "$studio_root" bad-rate --sample-rate 22050
+assert_failure "empty delivery method rejected" run_client "$studio_root" no-method --delivery-method ""
+assert_failure "empty deliverables rejected" run_client "$studio_root" no-deliverables --deliverables ""
+assert_failure "empty deliverable entry rejected" run_client "$studio_root" empty-entry --deliverables 'main_mix,,stems'
+assert_failure "duplicate deliverables rejected" run_client "$studio_root" duplicate-types --deliverables 'stems,stems'
+assert_failure "unsupported deliverable rejected" run_client "$studio_root" bad-type --deliverables 'main_mix,other'
+
+# Removed v1.0 options return targeted migration guidance.
+set +e
+removed_output="$(run_client "$studio_root" removed-limit --revision-limit 2 2>&1)"
+removed_status=$?
+set -e
+[ "$removed_status" -ne 0 ] || fail "removed --revision-limit unexpectedly succeeded"
+assert_contains "$removed_output" '--revision-limit was removed in JL Mixing 1.1.' \
+    "revision-limit diagnostic"
+set +e
+removed_output="$(run_client "$studio_root" removed-interactive --non-interactive 2>&1)"
+removed_status=$?
+set -e
+[ "$removed_status" -ne 0 ] || fail "removed --non-interactive unexpectedly succeeded"
+assert_contains "$removed_output" '--non-interactive was removed in JL Mixing 1.1.' \
+    "non-interactive diagnostic"
+
+# Per-command directory flags validate their combinations. A secure private
+# result file receives the committed absolute path only after success.
+assert_failure "--cd and --no-cd are mutually exclusive" \
+    run_client "$studio_root" conflicting-cd --cd --no-cd
+assert_failure "--cd is incompatible with dry-run" \
+    run_client "$studio_root" dry-cd --cd --dry-run
+cd_result="$tmp/cd-result"
+: > "$cd_result"
+chmod 600 "$cd_result"
+cd_output="$(JL_MIXING_CD_RESULT_FILE="$cd_result" run_client "$studio_root" cd-client --cd)"
+cd_client_root="$studio_root/Clients/Cd Client"
+assert_eq "$cd_client_root" "$(cat "$cd_result")" "explicit cd result path"
+assert_contains "$cd_output" 'new-mix --project "PROJECT NAME"' "cd-mode next command"
+case "$cd_output" in
+    *"cd '$cd_client_root'"*) fail "successful result channel printed redundant cd command" ;;
+    *) pass "successful result channel omits redundant cd command" ;;
+esac
+
+fallback_output="$(run_client "$studio_root" fallback-client --cd)"
+fallback_root="$studio_root/Clients/Fallback Client"
+assert_contains "$fallback_output" 'integration is not active.' "missing integration warning"
+assert_contains "$fallback_output" "cd '$fallback_root'" "fallback cd command"
+
+# Studio default directory behavior can be overridden explicitly.
+cd_studio="$tmp/cd-studio"
+create_studio "$cd_studio" --default-cd
+: > "$cd_result"
+JL_MIXING_CD_RESULT_FILE="$cd_result" run_client "$cd_studio" default-cd >/dev/null
+assert_eq "$cd_studio/Clients/Default Cd" "$(cat "$cd_result")" "studio default cd result"
+: > "$cd_result"
+JL_MIXING_CD_RESULT_FILE="$cd_result" run_client "$cd_studio" stay-put --no-cd >/dev/null
+assert_eq "" "$(cat "$cd_result")" "explicit no-cd overrides studio default"
+
+# Transaction failure after the staged-directory rename removes only the new
+# client and leaves all pre-existing clients unchanged.
+assert_failure "injected commit failure rolls back new client" \
+    env JL_MIXING_ROOT="$studio_root" JL_MIXING_FAIL_AT=after-directory-commit \
+        "$ROOT/bin/new-client" rollback-client
+assert_path_not_exists "$studio_root/Clients/Rollback Client"
+assert_file_exists "$client_file"
+
+# Existing files, directories, and symlinks at a case-insensitive destination
+# are never adopted or overwritten.
+touch "$studio_root/Clients/Occupied"
+assert_failure "existing file destination rejected" \
+    run_client "$studio_root" occupied-file --name Occupied
+rm -f "$studio_root/Clients/Occupied"
+ln -s "$tmp" "$studio_root/Clients/Linked Client"
+assert_failure "symlink destination rejected" \
+    run_client "$studio_root" linked-client --name 'Linked Client'
+[ -L "$studio_root/Clients/Linked Client" ] || fail "existing symlink was modified"
+pass "existing symlink preserved"
+
+# Recognizable v1.0 workspaces are rejected without modification.
+legacy_root="$tmp/legacy-studio"
+fixture_studio "$legacy_root"
+assert_failure "legacy workspace rejected" run_client "$legacy_root" legacy-client
+assert_path_not_exists "$legacy_root/Clients/Legacy Client"
 
 printf '[OK] new-client (%s assertions)\n' "$TEST_COUNT"


### PR DESCRIPTION
Migrates new-client to the strict v1.1 client schema
Creates the flattened client structure:
Clients/<Readable Client Name>/
├── client.json
└── Projects/
Removes Projects/Active/ and Projects/Completed/
Inherits audio and delivery defaults from studio.json
Supports explicit client-level overrides
Adds strict client-ID validation
Preserves readable client display names
Adds cross-platform folder-name sanitization
Enforces case-insensitive client-ID and folder collisions
Adds --cd and --no-cd
Supports the private shell-wrapper result channel
Adds transactional staging and rollback
Adds non-mutating dry-run behavior
Adds context-aware Next: and copy-and-paste cd guidance
Adds targeted diagnostics for removed --revision-limit and --non-interactive
Updates installed-command verification