### PR TITLE
feat: migrate new-mix to v1.1

### DIFF
--- a/bin/new-mix
+++ b/bin/new-mix
@@ -1,27 +1,35 @@
 #!/usr/bin/env bash
-# Create a new project beneath a client's Projects/Active directory.
+# Create a JL Mixing Automation v1.1 project workspace.
 #
-# The command resolves defaults, snapshots the client profile byte-for-byte,
-# renders project documents, optionally copies source files without modifying
-# them, and validates the completed project manifest before success.
+# Project creation is transactional. The command resolves and validates the
+# owning v1.1 studio/client records, builds the complete project in a hidden
+# sibling staging directory, validates both governing JSON documents and the
+# initial workflow state, then atomically commits the finished project.
 set -eu
 
-# Resolve the installation root from this launcher. Installed wrappers may
-# override it with JL_MIXING_HOME.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="${JL_MIXING_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-# Load shared services; command files intentionally keep reusable logic in lib/.
+# shellcheck source=lib/common.sh
 . "$APP_ROOT/lib/common.sh"
-. "$APP_ROOT/lib/config.sh"
+# shellcheck source=lib/context.sh
 . "$APP_ROOT/lib/context.sh"
+# shellcheck source=lib/filesystem.sh
 . "$APP_ROOT/lib/filesystem.sh"
+# shellcheck source=lib/json.sh
 . "$APP_ROOT/lib/json.sh"
+# shellcheck source=lib/metadata.sh
 . "$APP_ROOT/lib/metadata.sh"
+# shellcheck source=lib/naming.sh
 . "$APP_ROOT/lib/naming.sh"
+# shellcheck source=lib/project-state.sh
+. "$APP_ROOT/lib/project-state.sh"
+# shellcheck source=lib/templates.sh
 . "$APP_ROOT/lib/templates.sh"
+# shellcheck source=lib/transaction.sh
+. "$APP_ROOT/lib/transaction.sh"
+# shellcheck source=lib/validation.sh
 . "$APP_ROOT/lib/validation.sh"
 
-# Print command syntax and supported options, then return to the caller.
 usage() {
     cat <<'USAGE'
 Usage: new-mix --project PROJECT_NAME [options]
@@ -30,286 +38,848 @@ Options:
   --client ID_OR_PATH      Client ID or client-directory path
   --project NAME           Project display name (required)
   --project-id ID          Stable project slug (default: derived from name)
-  --project-type TYPE      mixing, podcast, audiobook, dialogue_edit,
-                           live_recording, or other
   --artist NAME            Artist or program name
   --album TITLE            Album or collection title
   --producer NAME          Producer name
   --engineer NAME          Mix engineer
   --bpm NUMBER             Tempo
   --key TEXT               Musical key
-  --time-signature TEXT    Time signature (default: 4/4)
+  --time-signature TEXT    Time signature
   --sample-rate HZ         Project sample rate
   --bit-depth BITS         Project bit depth
   --file-format FORMAT     WAV or AIFF
-  --daw NAME               DAW name
-  --template NAME_OR_PATH  DAW template to copy into the Project boundary
   --deadline YYYY-MM-DD    Project deadline
-  --deliverables LIST      Comma-separated deliverable types
+  --deliverables LIST      Comma-separated requested deliverables
   --description TEXT       Creative direction
-  --source PATH            Initial client delivery file or directory
-  --non-interactive        Accept supplied values and defaults
-  --dry-run                Print the planned project without creating it
+  --source PATH            Initial client-delivery file or directory
+  --cd                     Enter the project directory after creation
+  --no-cd                  Remain in the current directory after creation
+  --dry-run                Show the planned project without creating it
   -h, --help               Show this help
 USAGE
+}
+
+removed_option_error() {
+    case "$1" in
+        --project-type)
+            jl_error "--project-type was removed in JL Mixing 1.1."
+            jl_error "The v1.1 project manifest no longer stores a project type."
+            ;;
+        --daw)
+            jl_error "--daw was removed in JL Mixing 1.1."
+            jl_error "JL Mixing no longer manages DAW identity or configuration."
+            ;;
+        --template)
+            jl_error "--template was removed in JL Mixing 1.1."
+            jl_error "Manage native DAW projects and templates directly in 03_DAW_Project/."
+            ;;
+        --non-interactive)
+            jl_error "--non-interactive was removed in JL Mixing 1.1."
+            jl_error "new-mix already uses supplied values and inherited defaults without prompting."
+            ;;
+    esac
+    return "$JL_EXIT_ARGUMENTS"
+}
+
+# Print one path as a safely single-quoted shell argument. This output is only
+# copy-and-paste guidance; JL Mixing never evaluates it internally.
+shell_quote_path() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\"'\"'/g")"
+}
+
+# Parse a comma-separated deliverables option without silently dropping empty
+# values. The user's order is retained because it is meaningful planning data.
+parse_deliverables_csv() {
+    local csv
+    csv="$1"
+    jl_json_require_jq || return $?
+
+    printf '%s' "$csv" | jq -R -c -e '
+        split(",") as $raw
+        | if ($raw | length) == 0 or any($raw[]; test("^[[:space:]]*$")) then
+              error("deliverables must not contain empty entries")
+          else
+              $raw | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
+          end
+        | if length == 0 then error("at least one deliverable is required") else . end
+        | if (unique | length) != length then error("duplicate deliverables are not allowed") else . end
+    ' 2>/dev/null || {
+        jl_error "Invalid --deliverables list: $csv"
+        return "$JL_EXIT_VALIDATION"
+    }
+}
+
+validate_deliverables_json() {
+    local values_json deliverable count unique_count
+    values_json="$1"
+    count="$(printf '%s' "$values_json" | jq -r 'length')" || return $?
+    [ "$count" -gt 0 ] || {
+        jl_error "At least one requested deliverable is required."
+        return "$JL_EXIT_VALIDATION"
+    }
+
+    while IFS= read -r deliverable; do
+        jl_validate_enum "$deliverable" \
+            main_mix instrumental acapella tv_mix performance_mix stems master || {
+            jl_error "Unsupported deliverable type: $deliverable"
+            return "$JL_EXIT_VALIDATION"
+        }
+    done <<EOF_DELIVERABLE_VALUES
+$(printf '%s' "$values_json" | jq -r '.[]')
+EOF_DELIVERABLE_VALUES
+
+    unique_count="$(printf '%s' "$values_json" | jq -r 'unique | length')" || return $?
+    if [ "$unique_count" -ne "$count" ]; then
+        jl_error "Requested deliverables must be unique."
+        return "$JL_EXIT_VALIDATION"
+    fi
+}
+
+# Validate a real calendar date rather than accepting only a YYYY-MM-DD shape.
+validate_deadline() {
+    local value
+    value="$1"
+    jl_require_command python3 "Python 3 is required for date validation." || return $?
+    if ! python3 - "$value" <<'PY_DATE'
+from datetime import date
+import sys
+
+value = sys.argv[1]
+try:
+    parsed = date.fromisoformat(value)
+except ValueError:
+    raise SystemExit(5)
+if parsed.isoformat() != value:
+    raise SystemExit(5)
+PY_DATE
+    then
+        jl_error "Deadline must be a valid calendar date in YYYY-MM-DD form: $value"
+        return "$JL_EXIT_VALIDATION"
+    fi
+}
+
+# Resolve a client by explicit path, stable ID, or current-directory context.
+# Explicit paths can be used from outside the studio; stable IDs require an
+# otherwise discoverable studio root so the lookup remains unambiguous.
+resolve_client_and_studio() {
+    local reference reference_seen candidate matches match_count client_file
+    reference="$1"
+    reference_seen="$2"
+
+    if [ "$reference_seen" -eq 0 ]; then
+        client_root="$(jl_context_client_root_v11 "$PWD")" || {
+            jl_error "Run new-mix inside a client directory or supply --client CLIENT_ID_OR_PATH."
+            return "$JL_EXIT_CONTEXT"
+        }
+        studio_root="$(jl_context_studio_root_v11 "$client_root")" || return $?
+        return 0
+    fi
+
+    jl_assert_nonempty "$reference" "client reference" || return $?
+    candidate="$(jl_abspath_allow_missing "$reference")" || return $?
+    if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+        client_root="$(jl_context_resolve_client_v11 "$reference" "$PWD")" || return $?
+        studio_root="$(jl_context_studio_root_v11 "$client_root")" || return $?
+        return 0
+    fi
+
+    if ! jl_validate_slug "$reference"; then
+        jl_error "Client ID must be a lowercase slug, or --client must identify an existing path: $reference"
+        return "$JL_EXIT_VALIDATION"
+    fi
+
+    studio_root="$(jl_context_studio_root_v11 "$PWD")" || {
+        jl_error "A studio context is required to resolve client ID '$reference'."
+        return "$JL_EXIT_CONTEXT"
+    }
+    matches="$(find "$studio_root/Clients" -mindepth 2 -maxdepth 2 \
+        -type f -name client.json -print 2>/dev/null |
+        while IFS= read -r client_file; do
+            if [ "$(jl_json_get_optional "$client_file" '.client_id' '')" = "$reference" ]; then
+                dirname "$client_file"
+            fi
+            :
+        done)"
+    match_count="$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d ' ')"
+    if [ "$match_count" = 1 ]; then
+        client_root="$matches"
+        return 0
+    fi
+    if [ "$match_count" -gt 1 ]; then
+        jl_error "Multiple clients use the ID '$reference'."
+        return "$JL_EXIT_VALIDATION"
+    fi
+
+    jl_error "Client not found: $reference"
+    return "$JL_EXIT_CONTEXT"
+}
+
+# Write a deterministic source-import plan. The scan rejects symbolic links,
+# special filesystem objects, control characters, and case-insensitive path
+# collisions before the project staging directory exists.
+scan_source_to_plan() {
+    local source plan_file python_command
+    source="$1"
+    plan_file="$2"
+    python_command="$(jl_json_validator_python)" || {
+        jl_error "Python 3 is required for source-import validation."
+        return "$JL_EXIT_CONFIG"
+    }
+    "$python_command" "$APP_ROOT/tools/import-project-source.py"         scan "$source" "$plan_file" || {
+        jl_error "Unable to validate source import: $source"
+        return "$JL_EXIT_VALIDATION"
+    }
+}
+
+# Copy exactly the previously scanned source plan into the empty immutable
+# Original_Delivery staging directory. The helper rescans before copying so a
+# changed source tree cannot silently alter the import.
+copy_source_from_plan() {
+    local source destination plan_file python_command
+    source="$1"
+    destination="$2"
+    plan_file="$3"
+    python_command="$(jl_json_validator_python)" || {
+        jl_error "Python 3 is required for source importing."
+        return "$JL_EXIT_CONFIG"
+    }
+    "$python_command" "$APP_ROOT/tools/import-project-source.py"         copy "$source" "$destination" "$plan_file" || {
+        jl_error "Source import failed: $source"
+        return "$JL_EXIT_VALIDATION"
+    }
+}
+
+# Write the committed project destination to the private shell-wrapper result
+# file. The result file is created securely by the sourced shell wrapper.
+write_directory_result() {
+    local result_file destination
+    result_file="$1"
+    destination="$2"
+
+    jl_path_validate_absolute "$result_file" || return $?
+    if [ ! -f "$result_file" ] || [ -L "$result_file" ] || [ ! -w "$result_file" ]; then
+        jl_error "Shell-integration result file is missing or unsafe: $result_file"
+        return "$JL_EXIT_UNSAFE"
+    fi
+    printf '%s\n' "$destination" > "$result_file" || {
+        jl_error "Unable to write shell-integration directory result: $result_file"
+        return "$JL_EXIT_GENERAL"
+    }
 }
 
 client_ref=""
 project_name=""
 project_id=""
-project_type="mixing"
 artist=""
 album=""
 producer=""
 engineer=""
 bpm=""
 musical_key=""
-time_signature="4/4"
+time_signature=""
 sample_rate=""
 bit_depth=""
 file_format=""
-daw=""
-daw_template=""
 deadline=""
 deliverables_csv=""
 description=""
 source_path=""
+client_seen=0
+project_seen=0
+project_id_seen=0
+artist_seen=0
+engineer_seen=0
+sample_rate_seen=0
+bit_depth_seen=0
+file_format_seen=0
+deliverables_seen=0
+source_seen=0
+cd_enabled_seen=0
+cd_disabled_seen=0
 dry_run=0
 
-# Parse options explicitly so unknown or missing arguments fail predictably.
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --client) [ "$#" -ge 2 ] || jl_die "--client requires a value." "$JL_EXIT_ARGUMENTS"; client_ref="$2"; shift 2 ;;
-        --project) [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS"; project_name="$2"; shift 2 ;;
-        --project-id) [ "$#" -ge 2 ] || jl_die "--project-id requires a value." "$JL_EXIT_ARGUMENTS"; project_id="$2"; shift 2 ;;
-        --project-type) [ "$#" -ge 2 ] || jl_die "--project-type requires a value." "$JL_EXIT_ARGUMENTS"; project_type="$2"; shift 2 ;;
-        --artist) [ "$#" -ge 2 ] || jl_die "--artist requires a value." "$JL_EXIT_ARGUMENTS"; artist="$2"; shift 2 ;;
-        --album) [ "$#" -ge 2 ] || jl_die "--album requires a value." "$JL_EXIT_ARGUMENTS"; album="$2"; shift 2 ;;
-        --producer) [ "$#" -ge 2 ] || jl_die "--producer requires a value." "$JL_EXIT_ARGUMENTS"; producer="$2"; shift 2 ;;
-        --engineer) [ "$#" -ge 2 ] || jl_die "--engineer requires a value." "$JL_EXIT_ARGUMENTS"; engineer="$2"; shift 2 ;;
-        --bpm) [ "$#" -ge 2 ] || jl_die "--bpm requires a value." "$JL_EXIT_ARGUMENTS"; bpm="$2"; shift 2 ;;
-        --key) [ "$#" -ge 2 ] || jl_die "--key requires a value." "$JL_EXIT_ARGUMENTS"; musical_key="$2"; shift 2 ;;
-        --time-signature) [ "$#" -ge 2 ] || jl_die "--time-signature requires a value." "$JL_EXIT_ARGUMENTS"; time_signature="$2"; shift 2 ;;
-        --sample-rate) [ "$#" -ge 2 ] || jl_die "--sample-rate requires a value." "$JL_EXIT_ARGUMENTS"; sample_rate="$2"; shift 2 ;;
-        --bit-depth) [ "$#" -ge 2 ] || jl_die "--bit-depth requires a value." "$JL_EXIT_ARGUMENTS"; bit_depth="$2"; shift 2 ;;
-        --file-format) [ "$#" -ge 2 ] || jl_die "--file-format requires a value." "$JL_EXIT_ARGUMENTS"; file_format="$2"; shift 2 ;;
-        --daw) [ "$#" -ge 2 ] || jl_die "--daw requires a value." "$JL_EXIT_ARGUMENTS"; daw="$2"; shift 2 ;;
-        --template) [ "$#" -ge 2 ] || jl_die "--template requires a value." "$JL_EXIT_ARGUMENTS"; daw_template="$2"; shift 2 ;;
-        --deadline) [ "$#" -ge 2 ] || jl_die "--deadline requires a value." "$JL_EXIT_ARGUMENTS"; deadline="$2"; shift 2 ;;
-        --deliverables) [ "$#" -ge 2 ] || jl_die "--deliverables requires a value." "$JL_EXIT_ARGUMENTS"; deliverables_csv="$2"; shift 2 ;;
-        --description) [ "$#" -ge 2 ] || jl_die "--description requires a value." "$JL_EXIT_ARGUMENTS"; description="$2"; shift 2 ;;
-        --source) [ "$#" -ge 2 ] || jl_die "--source requires a value." "$JL_EXIT_ARGUMENTS"; source_path="$2"; shift 2 ;;
-        --non-interactive) shift ;;
-        --dry-run) dry_run=1; shift ;;
-        -h|--help) usage; exit 0 ;;
-        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS"; exit $? ;;
+        --client)
+            [ "$#" -ge 2 ] || jl_die "--client requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            client_ref="$2"
+            client_seen=1
+            shift 2
+            ;;
+        --project)
+            [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            project_name="$2"
+            project_seen=1
+            shift 2
+            ;;
+        --project-id)
+            [ "$#" -ge 2 ] || jl_die "--project-id requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            project_id="$2"
+            project_id_seen=1
+            shift 2
+            ;;
+        --artist)
+            [ "$#" -ge 2 ] || jl_die "--artist requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            artist="$2"
+            artist_seen=1
+            shift 2
+            ;;
+        --album)
+            [ "$#" -ge 2 ] || jl_die "--album requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            album="$2"
+            shift 2
+            ;;
+        --producer)
+            [ "$#" -ge 2 ] || jl_die "--producer requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            producer="$2"
+            shift 2
+            ;;
+        --engineer)
+            [ "$#" -ge 2 ] || jl_die "--engineer requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            engineer="$2"
+            engineer_seen=1
+            shift 2
+            ;;
+        --bpm)
+            [ "$#" -ge 2 ] || jl_die "--bpm requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            bpm="$2"
+            shift 2
+            ;;
+        --key)
+            [ "$#" -ge 2 ] || jl_die "--key requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            musical_key="$2"
+            shift 2
+            ;;
+        --time-signature)
+            [ "$#" -ge 2 ] || jl_die "--time-signature requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            time_signature="$2"
+            shift 2
+            ;;
+        --sample-rate)
+            [ "$#" -ge 2 ] || jl_die "--sample-rate requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            sample_rate="$2"
+            sample_rate_seen=1
+            shift 2
+            ;;
+        --bit-depth)
+            [ "$#" -ge 2 ] || jl_die "--bit-depth requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            bit_depth="$2"
+            bit_depth_seen=1
+            shift 2
+            ;;
+        --file-format)
+            [ "$#" -ge 2 ] || jl_die "--file-format requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            file_format="$2"
+            file_format_seen=1
+            shift 2
+            ;;
+        --deadline)
+            [ "$#" -ge 2 ] || jl_die "--deadline requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            deadline="$2"
+            shift 2
+            ;;
+        --deliverables)
+            [ "$#" -ge 2 ] || jl_die "--deliverables requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            deliverables_csv="$2"
+            deliverables_seen=1
+            shift 2
+            ;;
+        --description)
+            [ "$#" -ge 2 ] || jl_die "--description requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            description="$2"
+            shift 2
+            ;;
+        --source)
+            [ "$#" -ge 2 ] || jl_die "--source requires a value." "$JL_EXIT_ARGUMENTS" || exit $?
+            source_path="$2"
+            source_seen=1
+            shift 2
+            ;;
+        --cd)
+            cd_enabled_seen=1
+            shift
+            ;;
+        --no-cd)
+            cd_disabled_seen=1
+            shift
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --project-type|--daw|--template|--non-interactive)
+            removed_option_error "$1"
+            exit $?
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --*)
+            jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS"
+            exit $?
+            ;;
+        *)
+            jl_die "Unexpected positional argument: $1" "$JL_EXIT_ARGUMENTS"
+            exit $?
+            ;;
     esac
 done
 
-jl_validate_project_name "$project_name" || { jl_error "A valid --project name is required."; exit "$JL_EXIT_VALIDATION"; }
-jl_validate_project_type "$project_type" || { jl_error "Unsupported project type: $project_type"; exit "$JL_EXIT_VALIDATION"; }
+if [ "$cd_enabled_seen" -eq 1 ] && [ "$cd_disabled_seen" -eq 1 ]; then
+    jl_error "--cd and --no-cd cannot be used together."
+    exit "$JL_EXIT_ARGUMENTS"
+fi
+if [ "$dry_run" -eq 1 ] && { [ "$cd_enabled_seen" -eq 1 ] || [ "$cd_disabled_seen" -eq 1 ]; }; then
+    jl_error "--cd and --no-cd cannot be used with --dry-run."
+    exit "$JL_EXIT_ARGUMENTS"
+fi
 
-studio_root="$(jl_context_studio_root "$PWD")" || {
-    jl_error "Studio workspace not found. Run new-studio first or set JL_MIXING_ROOT."
-    exit "$JL_EXIT_CONTEXT"
-}
+if [ "$project_seen" -eq 0 ]; then
+    jl_error "A --project name is required."
+    exit "$JL_EXIT_ARGUMENTS"
+fi
+project_name="$(jl_trim "$project_name")"
+artist="$(jl_trim "$artist")"
+album="$(jl_trim "$album")"
+producer="$(jl_trim "$producer")"
+engineer="$(jl_trim "$engineer")"
+musical_key="$(jl_trim "$musical_key")"
+time_signature="$(jl_trim "$time_signature")"
+description="$(jl_trim "$description")"
+jl_assert_nonempty "$project_name" "project name" || exit $?
+project_folder_name="$(jl_sanitize_folder_name "$project_name")" || exit $?
+
+if [ "$project_id_seen" -eq 0 ]; then
+    project_id="$(jl_project_id_from_name "$project_name")" || exit $?
+fi
+if ! jl_validate_slug "$project_id"; then
+    jl_error "Project ID must be a lowercase slug using single hyphens: $project_id"
+    exit "$JL_EXIT_VALIDATION"
+fi
+
+if [ -n "$bpm" ]; then
+    printf '%s' "$bpm" | grep -Eq '^[0-9]+([.][0-9]+)?$' || {
+        jl_error "BPM must be a positive number: $bpm"
+        exit "$JL_EXIT_VALIDATION"
+    }
+    awk "BEGIN { exit !($bpm > 0) }" || {
+        jl_error "BPM must be greater than zero: $bpm"
+        exit "$JL_EXIT_VALIDATION"
+    }
+fi
+if [ -n "$deadline" ]; then
+    validate_deadline "$deadline" || exit $?
+fi
+if [ "$sample_rate_seen" -eq 1 ]; then
+    jl_validate_sample_rate "$sample_rate" || {
+        jl_error "Unsupported sample rate: $sample_rate"
+        exit "$JL_EXIT_VALIDATION"
+    }
+fi
+if [ "$bit_depth_seen" -eq 1 ]; then
+    jl_validate_bit_depth "$bit_depth" || {
+        jl_error "Unsupported bit depth: $bit_depth"
+        exit "$JL_EXIT_VALIDATION"
+    }
+fi
+if [ "$file_format_seen" -eq 1 ]; then
+    file_format="$(printf '%s' "$file_format" | tr '[:lower:]' '[:upper:]')"
+    jl_validate_file_format "$file_format" || {
+        jl_error "Unsupported file format: $file_format"
+        exit "$JL_EXIT_VALIDATION"
+    }
+fi
+if [ "$deliverables_seen" -eq 1 ]; then
+    deliverables_json="$(parse_deliverables_csv "$deliverables_csv")" || exit $?
+    validate_deliverables_json "$deliverables_json" || exit $?
+fi
+
+resolve_client_and_studio "$client_ref" "$client_seen" || exit $?
 studio_file="$studio_root/Studio/studio.json"
-client_root="$(jl_context_find_client "$studio_root" "$client_ref")" || exit $?
 client_file="$client_root/client.json"
 
-[ -n "$project_id" ] || project_id="$(jl_slugify "$project_name")"
-jl_validate_slug "$project_id" || { jl_error "Project ID must be a lowercase slug: $project_id"; exit "$JL_EXIT_VALIDATION"; }
-project_folder_name="$(jl_sanitize_component "$project_name")"
-jl_assert_nonempty "$project_folder_name" "project folder name" || exit $?
+jl_json_validate_local_document \
+    "$studio_file" studio.schema.json mixing-studio 1.1.0 >/dev/null || exit $?
+jl_metadata_validate_v11 "$studio_file" mixing-studio mutable || exit $?
+jl_json_validate_local_document \
+    "$client_file" client.schema.json mixing-client 1.1.0 >/dev/null || exit $?
+jl_metadata_validate_v11 "$client_file" mixing-client mutable || exit $?
+jl_json_validate_unique_uuids "$studio_root" || exit $?
+
+clients_root="$studio_root/Clients"
+projects_root="$client_root/Projects"
+case "$client_root" in
+    "$clients_root"/*) ;;
+    *)
+        jl_error "Selected client is not owned by the resolved studio: $client_root"
+        exit "$JL_EXIT_CONTEXT"
+        ;;
+esac
+jl_fs_assert_no_symlink_components "$studio_root" "$client_root" || exit $?
+if ! jl_fs_is_directory_no_symlink "$projects_root"; then
+    jl_error "Client Projects directory is missing or unsafe: $projects_root"
+    exit "$JL_EXIT_CONTEXT"
+fi
+if [ ! -w "$projects_root" ] || [ ! -x "$projects_root" ]; then
+    jl_error "Client Projects directory is not writable: $projects_root"
+    exit "$JL_EXIT_UNSAFE"
+fi
+jl_fs_assert_no_symlink_components "$studio_root" "$projects_root" || exit $?
 
 client_name="$(jl_json_get "$client_file" '.client_name')"
 client_id="$(jl_json_get "$client_file" '.client_id')"
 client_document_id="$(jl_json_get "$client_file" '.metadata.document_id')"
-if [ -z "$artist" ]; then
-    artist="$(jl_json_get_optional "$client_file" '.artist_name' '')"
-    [ -n "$artist" ] || artist="$client_name"
-fi
-[ -n "$engineer" ] || engineer="$(jl_json_get_optional "$studio_file" '.default_mix_engineer' '')"
-[ -n "$sample_rate" ] || sample_rate="$(jl_json_get "$client_file" '.audio_defaults.sample_rate')"
-[ -n "$bit_depth" ] || bit_depth="$(jl_json_get "$client_file" '.audio_defaults.bit_depth')"
-[ -n "$file_format" ] || file_format="$(jl_json_get "$client_file" '.audio_defaults.file_format')"
-[ -n "$daw" ] || daw="$(jl_json_get "$studio_file" '.default_daw')"
-delivery_method="$(jl_json_get "$client_file" '.delivery_defaults.method')"
-if [ -n "$deliverables_csv" ]; then
-    deliverables_json="$(jl_json_array_from_csv "$deliverables_csv")"
-else
-    deliverables_json="$(jl_json_get_json "$client_file" '.delivery_defaults.deliverables')"
-fi
 
-jl_validate_sample_rate "$sample_rate" || { jl_error "Unsupported sample rate: $sample_rate"; exit "$JL_EXIT_VALIDATION"; }
-jl_validate_bit_depth "$bit_depth" || { jl_error "Unsupported bit depth: $bit_depth"; exit "$JL_EXIT_VALIDATION"; }
-file_format="$(printf '%s' "$file_format" | tr '[:lower:]' '[:upper:]')"
-jl_validate_file_format "$file_format" || { jl_error "Unsupported file format: $file_format"; exit "$JL_EXIT_VALIDATION"; }
-while IFS= read -r deliverable; do
-    jl_validate_enum "$deliverable" main_mix instrumental acapella tv_mix performance_mix stems master || {
-        jl_error "Unsupported deliverable type: $deliverable"
-        exit "$JL_EXIT_VALIDATION"
-    }
-done < <(printf '%s' "$deliverables_json" | jq -r '.[]')
-if [ -n "$bpm" ]; then
-    printf '%s' "$bpm" | grep -Eq '^[0-9]+([.][0-9]+)?$' || { jl_error "BPM must be a positive number."; exit "$JL_EXIT_VALIDATION"; }
-    awk "BEGIN { exit !($bpm > 0) }" || { jl_error "BPM must be greater than zero."; exit "$JL_EXIT_VALIDATION"; }
+if [ "$artist_seen" -eq 0 ]; then
+    artist="$(jl_json_get_optional "$client_file" '.defaults.artist' '')"
 fi
-if [ -n "$deadline" ]; then
-    printf '%s' "$deadline" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' || { jl_error "Deadline must use YYYY-MM-DD."; exit "$JL_EXIT_VALIDATION"; }
-fi
-if [ -n "$source_path" ] && [ ! -e "$source_path" ]; then
-    jl_error "Source delivery not found: $source_path"
+artist="$(jl_trim "$artist")"
+if [ -z "$artist" ]; then
+    jl_error "Artist is required. Supply --artist or configure client.defaults.artist."
     exit "$JL_EXIT_VALIDATION"
 fi
+if [ "$engineer_seen" -eq 0 ]; then
+    engineer="$(jl_json_get_optional "$studio_file" '.defaults.mix_engineer' '')"
+fi
+engineer="$(jl_trim "$engineer")"
 
-# Stable project IDs are unique within a client, including completed projects.
-duplicate_project=0
-while IFS= read -r existing_manifest; do
-    if [ "$(jl_json_get_optional "$existing_manifest" '.project_id' '')" = "$project_id" ]; then
-        duplicate_project=1
-        break
+if [ "$sample_rate_seen" -eq 0 ]; then
+    sample_rate="$(jl_json_get_optional "$client_file" '.defaults.audio.sample_rate' '')"
+    [ -n "$sample_rate" ] || sample_rate="$(jl_json_get "$studio_file" '.defaults.audio.sample_rate')"
+fi
+if [ "$bit_depth_seen" -eq 0 ]; then
+    bit_depth="$(jl_json_get_optional "$client_file" '.defaults.audio.bit_depth' '')"
+    [ -n "$bit_depth" ] || bit_depth="$(jl_json_get "$studio_file" '.defaults.audio.bit_depth')"
+fi
+if [ "$file_format_seen" -eq 0 ]; then
+    file_format="$(jl_json_get_optional "$client_file" '.defaults.audio.file_format' '')"
+    [ -n "$file_format" ] || file_format="$(jl_json_get "$studio_file" '.defaults.audio.file_format')"
+fi
+file_format="$(printf '%s' "$file_format" | tr '[:lower:]' '[:upper:]')"
+jl_validate_sample_rate "$sample_rate" || { jl_error "Unsupported sample rate: $sample_rate"; exit "$JL_EXIT_VALIDATION"; }
+jl_validate_bit_depth "$bit_depth" || { jl_error "Unsupported bit depth: $bit_depth"; exit "$JL_EXIT_VALIDATION"; }
+jl_validate_file_format "$file_format" || { jl_error "Unsupported file format: $file_format"; exit "$JL_EXIT_VALIDATION"; }
+
+delivery_method="$(jl_json_get_optional "$client_file" '.defaults.delivery.method' '')"
+[ -n "$delivery_method" ] || delivery_method="$(jl_json_get "$studio_file" '.defaults.delivery.method')"
+delivery_method="$(jl_trim "$delivery_method")"
+jl_assert_nonempty "$delivery_method" "delivery method" || exit $?
+if [ "$deliverables_seen" -eq 0 ]; then
+    deliverables_json="$(jl_json_get_json "$client_file" '.defaults.delivery.requested_deliverables')"
+    if [ "$(printf '%s' "$deliverables_json" | jq -r 'length')" -eq 0 ]; then
+        deliverables_json="$(jl_json_get_json "$studio_file" '.defaults.delivery.requested_deliverables')"
     fi
-done < <(find "$client_root/Projects" -name project-manifest.json -type f -print 2>/dev/null)
-if [ "$duplicate_project" -eq 1 ]; then
-    jl_error "A project with ID '$project_id' already exists for this client."
+    validate_deliverables_json "$deliverables_json" || exit $?
+fi
+
+jl_validate_project_id_available "$client_root" "$project_id" || exit $?
+jl_fs_assert_no_case_insensitive_child_collision "$projects_root" "$project_folder_name" || exit $?
+project_root="$projects_root/$project_folder_name"
+if [ -e "$project_root" ] || [ -L "$project_root" ]; then
+    jl_error "Project destination already exists: $project_root"
     exit "$JL_EXIT_UNSAFE"
 fi
 
-project_root="$client_root/Projects/Active/$project_folder_name"
-if [ -e "$project_root" ]; then
-    jl_error "Refusing to overwrite existing project path: $project_root"
-    exit "$JL_EXIT_UNSAFE"
+studio_default_cd="$(jq -r '.cli.change_directory_after_create' "$studio_file")"
+effective_cd=0
+if [ "$cd_enabled_seen" -eq 1 ]; then
+    effective_cd=1
+elif [ "$cd_disabled_seen" -eq 1 ]; then
+    effective_cd=0
+elif [ "$studio_default_cd" = true ]; then
+    effective_cd=1
 fi
 
-resolved_template=""
-if [ -n "$daw_template" ]; then
-    if [ -e "$daw_template" ]; then
-        resolved_template="$(jl_abspath_allow_missing "$daw_template")"
-    elif [ -e "$studio_root/DAWs/$daw/Mix Templates/$daw_template" ]; then
-        resolved_template="$studio_root/DAWs/$daw/Mix Templates/$daw_template"
-    else
-        jl_error "DAW template not found: $daw_template"
+stage_root=""
+source_plan_dir=""
+source_plan_file=""
+cleanup_paths() {
+    local status
+    status=$?
+    if [ -n "$stage_root" ] && { [ -e "$stage_root" ] || [ -L "$stage_root" ]; }; then
+        jl_fs_remove_entry_no_follow "$stage_root" || true
+    fi
+    if [ -n "$source_plan_dir" ] && { [ -e "$source_plan_dir" ] || [ -L "$source_plan_dir" ]; }; then
+        jl_fs_remove_entry_no_follow "$source_plan_dir" || true
+    fi
+    return "$status"
+}
+trap cleanup_paths EXIT
+trap 'exit 1' HUP INT TERM
+
+if [ "$source_seen" -eq 1 ]; then
+    jl_assert_nonempty "$source_path" "source path" || exit $?
+    if [ -L "$source_path" ]; then
+        jl_error "Symbolic-link source paths are not allowed: $source_path"
+        exit "$JL_EXIT_UNSAFE"
+    fi
+    source_path="$(jl_abspath_allow_missing "$source_path")" || exit $?
+    if ! jl_fs_is_regular_file_no_symlink "$source_path" && ! jl_fs_is_directory_no_symlink "$source_path"; then
+        jl_error "Source must be an existing regular file or directory: $source_path"
         exit "$JL_EXIT_VALIDATION"
     fi
+    if jl_fs_is_directory_no_symlink "$source_path"; then
+        case "$projects_root/" in
+            "$source_path"/*)
+                jl_error "Source directory cannot contain the client Projects directory: $source_path"
+                exit "$JL_EXIT_UNSAFE"
+                ;;
+        esac
+    fi
+    source_plan_dir="$(jl_mktemp_dir jl-mixing-new-mix-source)" || exit $?
+    source_plan_file="$source_plan_dir/plan.json"
+    scan_source_to_plan "$source_path" "$source_plan_file" || exit $?
 fi
 
-# Dry-run reports all resolved choices before any project files are created.
+print_summary() {
+    local heading source_display
+    heading="$1"
+    source_display="${source_path:-<none>}"
+
+    printf '%s\n\n' "$heading"
+    printf 'Client:                     %s (%s)\n' "$client_name" "$client_id"
+    printf 'Project:                    %s\n' "$project_name"
+    printf 'Project ID:                 %s\n' "$project_id"
+    printf 'Project folder:             %s\n' "$project_root"
+    printf 'Artist:                     %s\n' "$artist"
+    printf 'Engineer:                   %s\n' "${engineer:-<not set>}"
+    printf 'Audio format:               %s Hz / %s-bit / %s\n' "$sample_rate" "$bit_depth" "$file_format"
+    printf 'Delivery method:            %s\n' "$delivery_method"
+    printf 'Requested deliverables:     %s\n' "$(printf '%s' "$deliverables_json" | jq -r 'join(", ")')"
+    printf 'Source:                     %s\n' "$source_display"
+    printf 'Initial state:              Setup\n'
+    printf 'Current revision:           0\n'
+    if [ "$effective_cd" -eq 1 ]; then
+        printf 'Automatic directory change: enabled\n'
+    else
+        printf 'Automatic directory change: disabled\n'
+    fi
+}
+
 if [ "$dry_run" -eq 1 ]; then
-    printf 'Would create project: %s\n' "$project_name"
-    printf 'Client:   %s (%s)\n' "$client_name" "$client_id"
-    printf 'Location: %s\n' "$project_root"
-    printf 'DAW:      %s\n' "$daw"
+    print_summary "Dry run — no changes made."
+    cat <<'EOF_PLAN'
+
+Would create:
+  00_Admin/
+  01_Client_Files/Original_Delivery/
+  01_Client_Files/References/
+  01_Client_Files/Documentation/
+  02_Audio_Preparation/Working_Audio/
+  02_Audio_Preparation/Rejected_Files/
+  03_DAW_Project/
+  04_Revisions/
+  05_Final_Delivery/Stems/
+  06_Recall/External_Files/
+  06_Recall/Screenshots/
+EOF_PLAN
+    if [ -n "$source_plan_file" ]; then
+        printf '\nWould copy into 01_Client_Files/Original_Delivery/:\n'
+        if [ "$(jq -r '.entries | length' "$source_plan_file")" -eq 0 ]; then
+            printf '  <source directory is empty>\n'
+        else
+            jq -r '.entries[] | "  " + .path + (if .type == "directory" then "/" else "" end)' "$source_plan_file"
+        fi
+    fi
+    printf '\nAfter creation:\n  cd '
+    shell_quote_path "$project_root"
+    printf '\n  new-revision --description "Initial mix"\n'
     exit 0
 fi
 
-cleanup=1
-# Trap handler that removes a partially created workspace or entity after failure.
-cleanup_on_failure() {
-    status=$?
-    if [ "$status" -ne 0 ] && [ "$cleanup" -eq 1 ]; then
-        rm -rf "$project_root"
-    fi
-    exit "$status"
-}
-trap cleanup_on_failure EXIT HUP INT TERM
+project_schema="$(jl_json_schema_path project-manifest.schema.json)" || exit $?
+snapshot_schema="$(jl_json_schema_path client-profile-snapshot.schema.json)" || exit $?
+software_version="$(jl_software_version)" || exit $?
+case "$software_version" in
+    1.1.*) ;;
+    *)
+        jl_error "new-mix requires a JL Mixing 1.1.x application version; found $software_version."
+        exit "$JL_EXIT_CONFIG"
+        ;;
+esac
 
-# Create the locked Version 1.0 project structure.
+stage_root="$(jl_txn_stage_directory_near "$project_root")" || exit $?
+chmod 755 "$stage_root"
 mkdir -p \
-    "$project_root/00_Admin" \
-    "$project_root/01_Client_Files/Original_Delivery" \
-    "$project_root/01_Client_Files/References" \
-    "$project_root/01_Client_Files/Documentation" \
-    "$project_root/02_Audio_Preparation/Working_Audio" \
-    "$project_root/02_Audio_Preparation/Rejected_Files" \
-    "$project_root/03_DAW_Project/Project" \
-    "$project_root/04_Revisions" \
-    "$project_root/05_Final_Delivery/Stems" \
-    "$project_root/06_Recall/External_Files" \
-    "$project_root/06_Recall/Screenshots"
-
-# Preserve an exact client profile snapshot for historical reproducibility.
-cp -p "$client_file" "$project_root/00_Admin/client-profile-snapshot.json"
+    "$stage_root/00_Admin" \
+    "$stage_root/01_Client_Files/Original_Delivery" \
+    "$stage_root/01_Client_Files/References" \
+    "$stage_root/01_Client_Files/Documentation" \
+    "$stage_root/02_Audio_Preparation/Working_Audio" \
+    "$stage_root/02_Audio_Preparation/Rejected_Files" \
+    "$stage_root/03_DAW_Project" \
+    "$stage_root/04_Revisions" \
+    "$stage_root/05_Final_Delivery/Stems" \
+    "$stage_root/06_Recall/External_Files" \
+    "$stage_root/06_Recall/Screenshots"
 
 created_at="$(jl_now_iso8601)"
-project_document_id="$(jl_uuid)"
-jl_template_render_json \
-    "$APP_ROOT/templates/project/project-manifest.json.template" \
-    "$project_root/00_Admin/project-manifest.json" \
-    DOCUMENT_ID "$project_document_id" \
-    SOFTWARE_VERSION "$(jl_software_version)" \
-    CREATED_AT "$created_at" \
-    PROJECT_ID "$project_id" \
-    PROJECT_NAME "$project_name" \
-    CLIENT_DOCUMENT_ID "$client_document_id" \
-    CLIENT_ID "$client_id" \
-    ARTIST "$artist" \
-    MIX_ENGINEER "$engineer"
+project_document_id="$(jl_uuid)" || exit $?
+snapshot_document_id="$(jl_uuid)" || exit $?
+while [ "$snapshot_document_id" = "$project_document_id" ]; do
+    snapshot_document_id="$(jl_uuid)" || exit $?
+done
+jl_json_assert_document_id_available "$studio_root" "$project_document_id" || exit $?
+jl_json_assert_document_id_available "$studio_root" "$snapshot_document_id" || exit $?
 
-if [ -n "$bpm" ]; then bpm_json="$bpm"; else bpm_json="null"; fi
-if [ -n "$deadline" ]; then deadline_json="$(jq -Rn --arg value "$deadline" '$value')"; else deadline_json="null"; fi
-jl_json_update "$project_root/00_Admin/project-manifest.json" \
-    '.project_type = $project_type |
-     .album = $album |
-     .producer = $producer |
-     .music.bpm = $bpm |
-     .music.key = $key |
-     .music.time_signature = $time_signature |
-     .audio.sample_rate = $sample_rate |
-     .audio.bit_depth = $bit_depth |
-     .audio.file_format = $file_format |
-     .daw.name = $daw |
-     .daw.template = $template |
-     .delivery.method = $delivery_method |
-     .delivery.requested_deliverables = $deliverables |
-     .schedule.deadline = $deadline |
-     .creative_direction = $description' \
-    --arg project_type "$project_type" \
+project_metadata="$(jl_metadata_create_v11_mutable \
+    mixing-project 1.1.0 "$project_document_id" "$created_at")" || exit $?
+snapshot_metadata="$(jl_metadata_create_v11_immutable \
+    mixing-client-profile-snapshot 1.1.0 "$snapshot_document_id" "$created_at")" || exit $?
+client_defaults_json="$(jl_json_get_json "$client_file" '.defaults')"
+if [ -n "$bpm" ]; then bpm_json="$bpm"; else bpm_json=null; fi
+if [ -n "$deadline" ]; then
+    deadline_json="$(jq -Rn --arg value "$deadline" '$value')"
+else
+    deadline_json=null
+fi
+
+staged_project_file="$stage_root/00_Admin/project-manifest.json"
+staged_snapshot_file="$stage_root/00_Admin/client-profile-snapshot.json"
+
+jq -n \
+    --argjson metadata "$project_metadata" \
+    --arg project_id "$project_id" \
+    --arg project_name "$project_name" \
+    --arg client_document_id "$client_document_id" \
+    --arg client_id "$client_id" \
+    --arg artist "$artist" \
     --arg album "$album" \
     --arg producer "$producer" \
+    --arg mix_engineer "$engineer" \
     --argjson bpm "$bpm_json" \
     --arg key "$musical_key" \
     --arg time_signature "$time_signature" \
     --argjson sample_rate "$sample_rate" \
     --argjson bit_depth "$bit_depth" \
     --arg file_format "$file_format" \
-    --arg daw "$daw" \
-    --arg template "$daw_template" \
     --arg delivery_method "$delivery_method" \
     --argjson deliverables "$deliverables_json" \
     --argjson deadline "$deadline_json" \
-    --arg description "$description"
+    --arg creative_direction "$description" \
+    '{
+        metadata: $metadata,
+        project_id: $project_id,
+        project_name: $project_name,
+        client: {
+            client_document_id: $client_document_id,
+            client_id: $client_id
+        },
+        artist: $artist,
+        album: $album,
+        producer: $producer,
+        mix_engineer: $mix_engineer,
+        music: {
+            bpm: $bpm,
+            key: $key,
+            time_signature: $time_signature
+        },
+        audio: {
+            sample_rate: $sample_rate,
+            bit_depth: $bit_depth,
+            file_format: $file_format
+        },
+        delivery: {
+            method: $delivery_method,
+            requested_deliverables: $deliverables
+        },
+        schedule: {deadline: $deadline},
+        creative_direction: $creative_direction,
+        state: {
+            current_revision: 0,
+            approved_revision: null,
+            delivered_revision: null
+        },
+        revisions: []
+    }' > "$staged_project_file" || exit $?
+chmod 644 "$staged_project_file"
 
-jl_template_render "$APP_ROOT/templates/project/Project_Notes.md" "$project_root/00_Admin/Project_Notes.md" \
-    PROJECT_NAME "$project_name" CLIENT_NAME "$client_name" ARTIST "$artist" \
-    PROJECT_TYPE "$project_type" MIX_ENGINEER "$engineer" CREATED_AT "$created_at"
-jl_template_render "$APP_ROOT/templates/project/Intake_Report.md" "$project_root/00_Admin/Intake_Report.md" \
-    PROJECT_NAME "$project_name" CLIENT_NAME "$client_name" GENERATED_AT "$created_at"
-jl_template_render "$APP_ROOT/templates/project/Preparation_Report.md" "$project_root/02_Audio_Preparation/Preparation_Report.md" \
-    PROJECT_NAME "$project_name" CLIENT_NAME "$client_name" CREATED_AT "$created_at"
-jl_template_render "$APP_ROOT/templates/project/Delivery_Notes.md" "$project_root/05_Final_Delivery/Delivery_Notes.md" \
-    PROJECT_NAME "$project_name" CLIENT_NAME "$client_name" APPROVED_REVISION "Not yet approved" \
-    CREATED_AT "$created_at" DELIVERY_METHOD "$delivery_method"
-jl_template_render "$APP_ROOT/templates/project/Recall_Sheet.md" "$project_root/06_Recall/Recall_Sheet.md" \
-    PROJECT_NAME "$project_name" CLIENT_NAME "$client_name" LAST_UPDATED "$created_at"
+jq -n \
+    --argjson metadata "$snapshot_metadata" \
+    --arg client_document_id "$client_document_id" \
+    --arg client_id "$client_id" \
+    --arg client_name "$client_name" \
+    --argjson defaults "$client_defaults_json" \
+    '{
+        metadata: $metadata,
+        source_client: {
+            client_document_id: $client_document_id,
+            client_id: $client_id,
+            client_name: $client_name
+        },
+        defaults: $defaults
+    }' > "$staged_snapshot_file" || exit $?
+chmod 644 "$staged_snapshot_file"
 
-# Optional source import copies content into immutable originals; it never moves input files.
-if [ -n "$source_path" ]; then
-    if [ -d "$source_path" ]; then
-        jl_fs_copy_directory_contents "$source_path" "$project_root/01_Client_Files/Original_Delivery"
-    else
-        cp -p "$source_path" "$project_root/01_Client_Files/Original_Delivery/"
-    fi
+jl_template_render "$APP_ROOT/templates/Intake_Report.md" \
+    "$stage_root/00_Admin/Intake_Report.md" || exit $?
+jl_template_render "$APP_ROOT/templates/Project_Notes.md" \
+    "$stage_root/00_Admin/Project_Notes.md" || exit $?
+jl_template_render "$APP_ROOT/templates/Preparation_Report.md" \
+    "$stage_root/02_Audio_Preparation/Preparation_Report.md" || exit $?
+jl_template_render "$APP_ROOT/templates/Delivery_Notes.md" \
+    "$stage_root/05_Final_Delivery/Delivery_Notes.md" || exit $?
+jl_template_render "$APP_ROOT/templates/Recall_Sheet.md" \
+    "$stage_root/06_Recall/Recall_Sheet.md" || exit $?
+
+if [ -n "$source_plan_file" ]; then
+    copy_source_from_plan \
+        "$source_path" "$stage_root/01_Client_Files/Original_Delivery" "$source_plan_file" || exit $?
 fi
 
-if [ -n "$resolved_template" ]; then
-    cp -Rp "$resolved_template" "$project_root/03_DAW_Project/Project/"
+jl_json_validate_schema "$project_schema" "$staged_project_file" >/dev/null || exit $?
+jl_metadata_validate_v11 "$staged_project_file" mixing-project mutable || exit $?
+jl_json_validate_schema "$snapshot_schema" "$staged_snapshot_file" >/dev/null || exit $?
+jl_metadata_validate_v11 "$staged_snapshot_file" mixing-client-profile-snapshot immutable || exit $?
+
+# Cross-document validation remains explicit because JSON Schema cannot verify
+# identity relationships between the owning client, snapshot, and project.
+if [ "$(jl_json_get "$staged_snapshot_file" '.source_client.client_document_id')" != "$client_document_id" ] || \
+   [ "$(jl_json_get "$staged_snapshot_file" '.source_client.client_id')" != "$client_id" ]; then
+    jl_error "Generated client snapshot does not match the owning client."
+    exit "$JL_EXIT_VALIDATION"
+fi
+if [ "$(jl_json_get "$staged_project_file" '.client.client_document_id')" != "$client_document_id" ] || \
+   [ "$(jl_json_get "$staged_project_file" '.client.client_id')" != "$client_id" ]; then
+    jl_error "Generated project manifest does not match the owning client."
+    exit "$JL_EXIT_VALIDATION"
+fi
+jl_project_validate_state "$stage_root" || exit $?
+
+jl_txn_commit_new_directory "$stage_root" "$project_root" || exit $?
+stage_root=""
+
+result_written=0
+if [ "$effective_cd" -eq 1 ] && [ -n "${JL_MIXING_CD_RESULT_FILE:-}" ]; then
+    write_directory_result "$JL_MIXING_CD_RESULT_FILE" "$project_root" || {
+        jl_error "Project creation succeeded, but automatic directory-change setup failed."
+        {
+            printf 'Run:\n  cd '
+            shell_quote_path "$project_root"
+            printf '\n'
+        } >&2
+        exit "$JL_EXIT_GENERAL"
+    }
+    result_written=1
 fi
 
-# The schema-valid manifest commits the otherwise provisional project tree.
-jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$project_root/00_Admin/project-manifest.json"
-cleanup=0
-trap - EXIT HUP INT TERM
+print_summary "Project created successfully."
+printf 'Manifest:                    %s\n' "$project_root/00_Admin/project-manifest.json"
+printf 'Client snapshot:             %s\n' "$project_root/00_Admin/client-profile-snapshot.json"
 
-printf 'Created project: %s\n' "$project_root"
-printf 'Next: copy client files to 01_Client_Files/Original_Delivery and run validate-intake\n'
+if [ "$effective_cd" -eq 1 ] && [ "$result_written" -eq 0 ]; then
+    cat <<'EOF_WARNING'
+
+Automatic directory change could not be performed because JL Mixing shell
+integration is not active.
+EOF_WARNING
+fi
+
+printf '\nNext:\n'
+if [ "$effective_cd" -eq 0 ] || [ "$result_written" -eq 0 ]; then
+    printf '  cd '
+    shell_quote_path "$project_root"
+    printf '\n'
+fi
+printf '  new-revision --description "Initial mix"\n'

--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,7 @@ docs
 tools/validate-json.py
 tools/build-intake-report.py
 tools/project-state.py
+tools/import-project-source.py
 packaging/requirements.txt
 uninstall.sh'
 
@@ -138,7 +139,7 @@ cp -R "$SOURCE_ROOT/schemas/." "$stage_dir/schemas/"
 cp -R "$SOURCE_ROOT/templates/." "$stage_dir/templates/"
 cp -R "$SOURCE_ROOT/docs/." "$stage_dir/docs/"
 cp "$SOURCE_ROOT/tools/validate-json.py" "$SOURCE_ROOT/tools/build-intake-report.py" \
-    "$SOURCE_ROOT/tools/project-state.py" "$stage_dir/tools/"
+    "$SOURCE_ROOT/tools/project-state.py" "$SOURCE_ROOT/tools/import-project-source.py" "$stage_dir/tools/"
 cp "$SOURCE_ROOT/packaging/requirements.txt" "$stage_dir/packaging/"
 cp "$SOURCE_ROOT/install.sh" "$SOURCE_ROOT/uninstall.sh" "$stage_dir/"
 
@@ -151,7 +152,7 @@ fi
 
 chmod +x "$stage_dir/install.sh" "$stage_dir/uninstall.sh" "$stage_dir/bin/"* \
     "$stage_dir/tools/validate-json.py" "$stage_dir/tools/build-intake-report.py" \
-    "$stage_dir/tools/project-state.py"
+    "$stage_dir/tools/project-state.py" "$stage_dir/tools/import-project-source.py"
 
 if [ -d "$app_dir" ]; then
     backup_dir="$(mktemp -d "$share_dir/.jl-mixing-backup.XXXXXX")"

--- a/tests/installation/test-installation.sh
+++ b/tests/installation/test-installation.sh
@@ -26,6 +26,7 @@ assert_file_exists "$prefix/share/jl-mixing/.venv/bin/python"
 assert_file_exists "$prefix/bin/new-studio"
 assert_file_exists "$prefix/bin/new-client"
 assert_file_exists "$prefix/share/jl-mixing/tools/project-state.py"
+assert_file_exists "$prefix/share/jl-mixing/tools/import-project-source.py"
 assert_file_exists "$prefix/share/jl-mixing/schemas/client-profile-snapshot.schema.json"
 assert_file_exists "$prefix/share/jl-mixing/templates/Intake_Report.md"
 assert_file_exists "$prefix/share/jl-mixing/templates/Revision_Notes.md"
@@ -45,6 +46,19 @@ assert_json_eq "1.1.0" "$installed_client" '.metadata.schema_version' \
     "installed new-client creates v1.1 schema"
 assert_dir_exists "$workspace/Clients/Installed Client/Projects"
 assert_path_not_exists "$workspace/Clients/Installed Client/Projects/Active"
+
+JL_MIXING_ROOT="$workspace" PATH="$prefix/bin:$PATH" \
+    new-mix --client installed-client --project "Installed Project" \
+    --artist "Installed Artist" >/dev/null
+installed_project="$workspace/Clients/Installed Client/Projects/Installed Project"
+installed_manifest="$installed_project/00_Admin/project-manifest.json"
+assert_file_exists "$installed_manifest"
+assert_file_exists "$installed_project/00_Admin/client-profile-snapshot.json"
+assert_json_eq "1.1.0" "$installed_manifest" '.metadata.schema_version' \
+    "installed new-mix creates v1.1 schema"
+assert_dir_exists "$installed_project/03_DAW_Project"
+assert_path_not_exists "$installed_project/03_DAW_Project/Project"
+assert_path_not_exists "$installed_project/05_Final_Delivery/delivery-manifest.json"
 
 # A sentinel in the application directory must disappear during upgrade, while
 # the independent studio workspace remains untouched.

--- a/tests/integration/test-new-mix.sh
+++ b/tests/integration/test-new-mix.sh
@@ -1,31 +1,288 @@
 #!/usr/bin/env bash
 set -eu
 
-# Purpose: Exercise project creation, source copying, snapshots, lookup, and duplicate protection.
+# Purpose: Exercise the complete v1.1 project-creation contract.
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=tests/integration/integration-helper.sh
 . "$ROOT/tests/integration/integration-helper.sh"
 
-# Arrange: build an isolated temporary fixture.
-tmp="$(new_test_dir)"
-trap 'rm -rf "$tmp"' EXIT
-studio_root="$tmp/studio"
-fixture_studio "$studio_root"
-client_root="$(fixture_client "$studio_root")"
-export JL_MIXING_ROOT="$studio_root"
-mkdir -p "$tmp/source"
-printf 'client source\n' > "$tmp/source/readme.txt"
+require_test_command jq
+require_test_command python3
+python3 -c 'import jsonschema' >/dev/null 2>&1 || {
+    if [ "${JL_TEST_STRICT:-0}" = "1" ]; then
+        fail "jsonschema is required for strict new-mix tests"
+    fi
+    echo "[SKIP] new-mix integration tests require jsonschema."
+    exit 0
+}
 
-(cd "$client_root" && "$ROOT/bin/new-mix" --project "Blue Sky" --source "$tmp/source" --non-interactive)
-project_root="$client_root/Projects/Active/Blue Sky"
-# Assert: verify observable behavior rather than internal implementation.
-assert_file_exists "$project_root/00_Admin/project-manifest.json"
-assert_dir_exists "$project_root/03_DAW_Project/Project"
-assert_file_exists "$project_root/01_Client_Files/Original_Delivery/readme.txt"
-assert_same_bytes "$client_root/client.json" "$project_root/00_Admin/client-profile-snapshot.json"
-assert_json_eq "Blue Sky" "$project_root/00_Admin/project-manifest.json" '.project_name' "project name"
-assert_json_eq "Logic Pro" "$project_root/00_Admin/project-manifest.json" '.daw.name' "project DAW"
-"$ROOT/bin/new-mix" --client acme --project "Second Project" --non-interactive
-assert_file_exists "$client_root/Projects/Active/Second Project/00_Admin/project-manifest.json"
-assert_failure "duplicate project is protected" "$ROOT/bin/new-mix" --client acme --project "Blue Sky" --non-interactive
+tmp="$(new_test_dir)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+studio_root="$tmp/studio"
+
+"$ROOT/bin/new-studio" \
+    --root "$studio_root" --name "JL Mix Studio" --engineer "Jake" >/dev/null
+JL_MIXING_ROOT="$studio_root" "$ROOT/bin/new-client" acme \
+    --name "Acme Records" --artist "The Acmes" >/dev/null
+client_root="$studio_root/Clients/Acme Records"
+client_file="$client_root/client.json"
+
+run_project() {
+    JL_MIXING_ROOT="$studio_root" "$ROOT/bin/new-mix" "$@"
+}
+
+# A project created from client context uses readable flattened paths, strict
+# v1.1 manifests, minimal Markdown templates, and a recursive immutable source
+# import without creating a revision or delivery manifest.
+mkdir -p "$tmp/source/Audio/Drums" "$tmp/source/Documentation/Empty Folder"
+printf 'kick audio\n' > "$tmp/source/Audio/Drums/Kick.wav"
+printf 'session notes\n' > "$tmp/source/Documentation/notes.txt"
+output="$(cd "$client_root" && "$ROOT/bin/new-mix" \
+    --project 'Blue Sky / Radio Mix' \
+    --project-id blue-sky-radio \
+    --album 'Blue Sky Album' \
+    --producer 'Pat Producer' \
+    --engineer 'Morgan Mixer' \
+    --bpm 122.5 \
+    --key 'D minor' \
+    --time-signature '6/8' \
+    --sample-rate 96000 \
+    --bit-depth 32 \
+    --file-format aiff \
+    --deadline 2026-12-31 \
+    --deliverables 'stems, main_mix' \
+    --description 'Wide, punchy, vocal-forward mix' \
+    --source "$tmp/source")"
+project_root="$client_root/Projects/Blue Sky - Radio Mix"
+manifest="$project_root/00_Admin/project-manifest.json"
+snapshot="$project_root/00_Admin/client-profile-snapshot.json"
+
+assert_dir_exists "$project_root"
+assert_dir_exists "$project_root/03_DAW_Project"
+assert_path_not_exists "$project_root/03_DAW_Project/Project"
+assert_dir_exists "$project_root/04_Revisions"
+assert_eq "" "$(find "$project_root/04_Revisions" -mindepth 1 -print -quit)" \
+    "no initial revision created"
+assert_dir_exists "$project_root/05_Final_Delivery/Stems"
+assert_path_not_exists "$project_root/05_Final_Delivery/delivery-manifest.json"
+assert_file_exists "$manifest"
+assert_file_exists "$snapshot"
+assert_file_exists "$project_root/00_Admin/Intake_Report.md"
+assert_file_exists "$project_root/00_Admin/Project_Notes.md"
+assert_file_exists "$project_root/02_Audio_Preparation/Preparation_Report.md"
+assert_file_exists "$project_root/05_Final_Delivery/Delivery_Notes.md"
+assert_file_exists "$project_root/06_Recall/Recall_Sheet.md"
+assert_same_bytes "$ROOT/templates/Intake_Report.md" "$project_root/00_Admin/Intake_Report.md"
+assert_same_bytes "$ROOT/templates/Project_Notes.md" "$project_root/00_Admin/Project_Notes.md"
+assert_same_bytes "$ROOT/templates/Preparation_Report.md" "$project_root/02_Audio_Preparation/Preparation_Report.md"
+assert_same_bytes "$ROOT/templates/Delivery_Notes.md" "$project_root/05_Final_Delivery/Delivery_Notes.md"
+assert_same_bytes "$ROOT/templates/Recall_Sheet.md" "$project_root/06_Recall/Recall_Sheet.md"
+assert_file_exists "$project_root/01_Client_Files/Original_Delivery/Audio/Drums/Kick.wav"
+assert_file_exists "$project_root/01_Client_Files/Original_Delivery/Documentation/notes.txt"
+assert_dir_exists "$project_root/01_Client_Files/Original_Delivery/Documentation/Empty Folder"
+assert_same_bytes "$tmp/source/Audio/Drums/Kick.wav" \
+    "$project_root/01_Client_Files/Original_Delivery/Audio/Drums/Kick.wav"
+assert_file_exists "$tmp/source/Audio/Drums/Kick.wav"
+
+assert_json_eq "mixing-project" "$manifest" '.metadata.schema' "project schema identity"
+assert_json_eq "1.1.0" "$manifest" '.metadata.schema_version' "project schema version"
+assert_json_eq "blue-sky-radio" "$manifest" '.project_id' "explicit project ID"
+assert_json_eq 'Blue Sky / Radio Mix' "$manifest" '.project_name' "display name preserved"
+assert_json_eq 'The Acmes' "$manifest" '.artist' "client artist default"
+assert_json_eq 'Blue Sky Album' "$manifest" '.album' "album override"
+assert_json_eq 'Pat Producer' "$manifest" '.producer' "producer override"
+assert_json_eq 'Morgan Mixer' "$manifest" '.mix_engineer' "engineer override"
+assert_json_eq '122.5' "$manifest" '.music.bpm' "BPM override"
+assert_json_eq 'D minor' "$manifest" '.music.key' "key override"
+assert_json_eq '6/8' "$manifest" '.music.time_signature' "time-signature override"
+assert_json_eq '96000' "$manifest" '.audio.sample_rate' "sample-rate override"
+assert_json_eq '32' "$manifest" '.audio.bit_depth' "bit-depth override"
+assert_json_eq 'AIFF' "$manifest" '.audio.file_format' "file-format normalization"
+assert_eq '["stems","main_mix"]' \
+    "$(jq -c '.delivery.requested_deliverables' "$manifest")" \
+    "requested deliverable order preserved"
+assert_json_eq '2026-12-31' "$manifest" '.schedule.deadline' "deadline override"
+assert_json_eq 'Wide, punchy, vocal-forward mix' "$manifest" '.creative_direction' \
+    "creative direction"
+assert_eq '{"current_revision":0,"approved_revision":null,"delivered_revision":null}' \
+    "$(jq -c '.state' "$manifest")" "initial three-pointer state"
+assert_eq '[]' "$(jq -c '.revisions' "$manifest")" "empty revision records"
+assert_eq "false" "$(jq -r 'has("project_type") or has("daw")' "$manifest")" \
+    "removed project and DAW metadata absent"
+assert_json_eq 'mixing-client-profile-snapshot' "$snapshot" '.metadata.schema' \
+    "snapshot schema identity"
+assert_eq "$(jq -c '.defaults' "$client_file")" "$(jq -c '.defaults' "$snapshot")" \
+    "client defaults copied exactly into snapshot"
+assert_json_eq "$(jq -r '.metadata.document_id' "$client_file")" "$snapshot" \
+    '.source_client.client_document_id' "snapshot client document reference"
+[ "$(jq -r '.metadata.document_id' "$manifest")" != \
+  "$(jq -r '.metadata.document_id' "$snapshot")" ] || fail "project and snapshot UUIDs must differ"
+pass "project and snapshot UUIDs are distinct"
+python3 "$ROOT/tools/validate-json.py" --strict \
+    --schema "$ROOT/schemas/project-manifest.schema.json" --document "$manifest" >/dev/null
+pass "generated project validates against canonical schema"
+python3 "$ROOT/tools/validate-json.py" --strict \
+    --schema "$ROOT/schemas/client-profile-snapshot.schema.json" --document "$snapshot" >/dev/null
+pass "generated snapshot validates against canonical schema"
+assert_eq 'Setup' "$(python3 "$ROOT/tools/project-state.py" derive "$project_root")" \
+    "initial derived state"
+assert_contains "$output" 'Project created successfully.' "success heading"
+assert_contains "$output" 'new-revision --description "Initial mix"' "next command"
+assert_contains "$output" "cd '$project_root'" "copy-and-paste cd"
+
+# Stable client-ID resolution and omitted project fields use the approved
+# client/studio defaults. No 4/4 time signature is assumed.
+output="$(cd "$studio_root" && "$ROOT/bin/new-mix" --client acme --project 'Default Project')"
+default_root="$client_root/Projects/Default Project"
+default_manifest="$default_root/00_Admin/project-manifest.json"
+assert_file_exists "$default_manifest"
+assert_json_eq 'default-project' "$default_manifest" '.project_id' "derived project ID"
+assert_json_eq 'The Acmes' "$default_manifest" '.artist' "inherited artist"
+assert_json_eq 'Jake' "$default_manifest" '.mix_engineer' "studio engineer default"
+assert_eq 'null' "$(jq -c '.music.bpm' "$default_manifest")" "default BPM is null"
+assert_json_eq '' "$default_manifest" '.music.key' "default key empty"
+assert_json_eq '' "$default_manifest" '.music.time_signature' "no assumed time signature"
+assert_json_eq '48000' "$default_manifest" '.audio.sample_rate' "client audio default"
+assert_json_eq 'Cloud transfer' "$default_manifest" '.delivery.method' "client delivery method"
+assert_eq 'null' "$(jq -c '.schedule.deadline' "$default_manifest")" "default deadline null"
+assert_json_eq '' "$default_manifest" '.creative_direction' "default creative direction empty"
+assert_contains "$output" 'Default Project' "ID-resolved project output"
+
+# An explicit client path works from outside the workspace. Dry-run performs
+# source validation and reports the complete plan without creating a project.
+dry_output="$(cd "$tmp" && "$ROOT/bin/new-mix" \
+    --client "$client_root/client.json" --project 'Dry Project' \
+    --source "$tmp/source" --dry-run)"
+assert_contains "$dry_output" 'Dry run — no changes made.' "dry-run heading"
+assert_contains "$dry_output" '03_DAW_Project/' "dry-run flattened DAW boundary"
+assert_contains "$dry_output" 'Audio/Drums/Kick.wav' "dry-run source plan"
+assert_contains "$dry_output" 'Initial state:              Setup' "dry-run state"
+assert_contains "$dry_output" 'new-revision --description "Initial mix"' "dry-run next step"
+assert_path_not_exists "$client_root/Projects/Dry Project"
+
+# Project IDs and readable destination folders are independently protected
+# against case-insensitive collisions without automatic suffixes.
+assert_failure "duplicate project ID is protected" \
+    run_project --client acme --project 'Different Name' --project-id blue-sky-radio
+assert_failure "case-insensitive project folder collision is protected" \
+    run_project --client acme --project 'DEFAULT PROJECT' --project-id another-id
+assert_path_not_exists "$client_root/Projects/Different Name"
+
+# Explicit validation failures occur before any project filesystem mutation.
+assert_failure "missing project option rejected" run_project --client acme
+assert_failure "empty project name rejected" run_project --client acme --project ''
+assert_failure "invalid explicit project ID rejected" \
+    run_project --client acme --project Bad --project-id Bad_ID
+assert_failure "nonpositive BPM rejected" run_project --client acme --project BadBpm --bpm 0
+assert_failure "invalid calendar deadline rejected" \
+    run_project --client acme --project BadDate --deadline 2026-02-30
+assert_failure "unsupported sample rate rejected" \
+    run_project --client acme --project BadRate --sample-rate 22050
+assert_failure "empty deliverables rejected" \
+    run_project --client acme --project NoDeliverables --deliverables ''
+assert_failure "duplicate deliverables rejected" \
+    run_project --client acme --project DuplicateTypes --deliverables 'stems,stems'
+assert_failure "unsupported deliverable rejected" \
+    run_project --client acme --project BadType --deliverables 'main_mix,other'
+assert_failure "unknown client ID rejected" \
+    run_project --client missing-client --project MissingClient
+assert_path_not_exists "$client_root/Projects/BadBpm"
+
+# Removed v1.0 options provide targeted migration diagnostics.
+for removed_option in --project-type --daw --template --non-interactive; do
+    set +e
+    removed_output="$(run_project --client acme --project Removed "$removed_option" value 2>&1)"
+    removed_status=$?
+    set -e
+    [ "$removed_status" -ne 0 ] || fail "$removed_option unexpectedly succeeded"
+    assert_contains "$removed_output" "$removed_option was removed in JL Mixing 1.1." \
+        "$removed_option diagnostic"
+done
+
+# Source imports reject symlinks and case-insensitive collisions before the
+# project transaction begins.
+ln -s "$tmp/source/Audio/Drums/Kick.wav" "$tmp/source/linked-kick.wav"
+assert_failure "nested source symlink rejected" \
+    run_project --client acme --project SymlinkSource --source "$tmp/source"
+assert_path_not_exists "$client_root/Projects/SymlinkSource"
+rm "$tmp/source/linked-kick.wav"
+
+case_source="$tmp/case-source"
+mkdir -p "$case_source"
+printf A > "$case_source/Print.wav"
+printf B > "$case_source/print.wav" 2>/dev/null || true
+if [ -f "$case_source/Print.wav" ] && [ -f "$case_source/print.wav" ] && \
+   [ "$(cat "$case_source/Print.wav")" != "$(cat "$case_source/print.wav")" ]; then
+    assert_failure "case-insensitive source collision rejected" \
+        run_project --client acme --project CaseSource --source "$case_source"
+else
+    pass "case-insensitive source collision fixture unavailable on this filesystem"
+fi
+assert_path_not_exists "$client_root/Projects/CaseSource"
+
+# Empty client artist defaults are valid client metadata, but project creation
+# requires a resolved non-empty artist.
+client_backup="$tmp/client-backup.json"
+cp "$client_file" "$client_backup"
+jq '.defaults.artist=""' "$client_file" > "$client_file.tmp"
+mv "$client_file.tmp" "$client_file"
+assert_failure "project requires a resolved artist" \
+    run_project --client acme --project MissingArtist
+cp "$client_backup" "$client_file"
+
+# Directory-changing behavior uses the secure private result channel only
+# after commit and falls back to a quoted command when integration is absent.
+cd_result="$tmp/cd-result"
+: > "$cd_result"
+chmod 600 "$cd_result"
+cd_output="$(JL_MIXING_CD_RESULT_FILE="$cd_result" \
+    run_project --client acme --project 'Cd Project' --cd)"
+cd_root="$client_root/Projects/Cd Project"
+assert_eq "$cd_root" "$(cat "$cd_result")" "explicit cd result path"
+case "$cd_output" in
+    *"cd '$cd_root'"*) fail "successful result channel printed redundant cd command" ;;
+    *) pass "successful result channel omits redundant cd command" ;;
+esac
+
+fallback_output="$(run_project --client acme --project 'Fallback Project' --cd)"
+fallback_root="$client_root/Projects/Fallback Project"
+assert_contains "$fallback_output" 'integration is not active.' "missing integration warning"
+assert_contains "$fallback_output" "cd '$fallback_root'" "fallback cd command"
+
+# The studio default can request directory changing, while --no-cd overrides
+# it for one command.
+jq '.cli.change_directory_after_create=true' "$studio_root/Studio/studio.json" \
+    > "$studio_root/Studio/studio.json.tmp"
+mv "$studio_root/Studio/studio.json.tmp" "$studio_root/Studio/studio.json"
+: > "$cd_result"
+JL_MIXING_CD_RESULT_FILE="$cd_result" \
+    run_project --client acme --project 'Default Cd Project' >/dev/null
+assert_eq "$client_root/Projects/Default Cd Project" "$(cat "$cd_result")" \
+    "studio default cd result"
+: > "$cd_result"
+JL_MIXING_CD_RESULT_FILE="$cd_result" \
+    run_project --client acme --project 'No Cd Project' --no-cd >/dev/null
+assert_eq '' "$(cat "$cd_result")" "explicit no-cd overrides studio default"
+assert_failure "--cd and --no-cd are mutually exclusive" \
+    run_project --client acme --project ConflictingCd --cd --no-cd
+assert_failure "--cd is incompatible with dry-run" \
+    run_project --client acme --project DryCd --cd --dry-run
+
+# A failure after the staged directory rename removes only the new project and
+# leaves all previously committed projects and source files untouched.
+assert_failure "injected commit failure rolls back project" \
+    env JL_MIXING_ROOT="$studio_root" JL_MIXING_FAIL_AT=after-directory-commit \
+        "$ROOT/bin/new-mix" --client acme --project 'Rollback Project' \
+        --source "$tmp/source"
+assert_path_not_exists "$client_root/Projects/Rollback Project"
+assert_file_exists "$manifest"
+assert_file_exists "$tmp/source/Audio/Drums/Kick.wav"
+
+# Recognizable v1.0 workspaces are rejected without modification.
+legacy_root="$tmp/legacy-studio"
+fixture_studio "$legacy_root"
+assert_failure "legacy workspace rejected" \
+    env JL_MIXING_ROOT="$legacy_root" "$ROOT/bin/new-mix" \
+        --client acme --project LegacyProject --artist Artist
 
 printf '[OK] new-mix (%s assertions)\n' "$TEST_COUNT"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -70,6 +70,7 @@ bin/create-delivery
 bin/complete-project
 tools/build-intake-report.py
 tools/project-state.py
+tools/import-project-source.py
 tools/build-release
 tools/verify-release-archive'
 

--- a/tests/unit/test-import-project-source.sh
+++ b/tests/unit/test-import-project-source.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -eu
+
+# Purpose: Verify no-follow source planning and copy behavior independently of
+# the slower command-level schema workflow.
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=tests/test-helper.sh
+. "$ROOT/tests/test-helper.sh"
+
+require_test_command python3
+
+tmp="$(new_test_dir)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+source_root="$tmp/source"
+destination="$tmp/destination"
+plan="$tmp/plan.json"
+mkdir -p "$source_root/Audio/Drums" "$source_root/Docs/Empty" "$destination"
+printf 'kick\n' > "$source_root/Audio/Drums/Kick.wav"
+printf 'notes\n' > "$source_root/Docs/notes.txt"
+
+python3 "$ROOT/tools/import-project-source.py" scan "$source_root" "$plan"
+assert_file_exists "$plan"
+assert_eq 'directory' "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_type"])' "$plan")" \
+    "directory source type"
+assert_contains "$(cat "$plan")" 'Audio/Drums/Kick.wav' "nested file planned"
+assert_contains "$(cat "$plan")" 'Docs/Empty' "empty directory planned"
+
+python3 "$ROOT/tools/import-project-source.py" copy "$source_root" "$destination" "$plan"
+assert_file_exists "$destination/Audio/Drums/Kick.wav"
+assert_file_exists "$destination/Docs/notes.txt"
+assert_dir_exists "$destination/Docs/Empty"
+assert_same_bytes "$source_root/Audio/Drums/Kick.wav" "$destination/Audio/Drums/Kick.wav"
+
+# A changed source tree cannot be copied using a stale plan.
+mkdir -p "$tmp/changed-destination"
+printf 'later\n' > "$source_root/later.txt"
+assert_failure "changed source rejected" \
+    python3 "$ROOT/tools/import-project-source.py" copy \
+        "$source_root" "$tmp/changed-destination" "$plan"
+rm "$source_root/later.txt"
+
+# Neither a source symlink nor a nested source symlink may be followed.
+ln -s "$source_root" "$tmp/source-link"
+assert_failure "source symlink rejected" \
+    python3 "$ROOT/tools/import-project-source.py" scan "$tmp/source-link" "$tmp/link-plan.json"
+ln -s "$source_root/Audio/Drums/Kick.wav" "$source_root/linked.wav"
+assert_failure "nested symlink rejected" \
+    python3 "$ROOT/tools/import-project-source.py" scan "$source_root" "$tmp/nested-link-plan.json"
+rm "$source_root/linked.wav"
+
+# Case-collision coverage is conditional because a case-insensitive filesystem
+# cannot create the fixture in the first place.
+case_source="$tmp/case-source"
+mkdir -p "$case_source"
+printf A > "$case_source/Print.wav"
+printf B > "$case_source/print.wav" 2>/dev/null || true
+if [ -f "$case_source/Print.wav" ] && [ -f "$case_source/print.wav" ] && \
+   [ "$(cat "$case_source/Print.wav")" != "$(cat "$case_source/print.wav")" ]; then
+    assert_failure "case-insensitive source collision rejected" \
+        python3 "$ROOT/tools/import-project-source.py" scan \
+            "$case_source" "$tmp/case-plan.json"
+else
+    pass "case-collision fixture unavailable on this filesystem"
+fi
+
+# One regular-file source is copied directly by basename.
+file_source="$tmp/Single Mix.wav"
+printf 'mix\n' > "$file_source"
+file_plan="$tmp/file-plan.json"
+file_destination="$tmp/file-destination"
+mkdir -p "$file_destination"
+python3 "$ROOT/tools/import-project-source.py" scan "$file_source" "$file_plan"
+python3 "$ROOT/tools/import-project-source.py" copy "$file_source" "$file_destination" "$file_plan"
+assert_file_exists "$file_destination/Single Mix.wav"
+assert_same_bytes "$file_source" "$file_destination/Single Mix.wav"
+
+printf '[OK] import-project-source (%s assertions)\n' "$TEST_COUNT"

--- a/tools/build-release
+++ b/tools/build-release
@@ -79,12 +79,14 @@ cp "$ROOT/packaging/RELEASE_README.md" "$package_root/README.md"
 cp -R "$ROOT/bin" "$ROOT/lib" "$ROOT/schemas" "$ROOT/templates" "$ROOT/docs" "$package_root/"
 mkdir -p "$package_root/tools" "$package_root/packaging"
 cp "$ROOT/tools/validate-json.py" "$ROOT/tools/build-intake-report.py" \
-    "$ROOT/tools/project-state.py" "$package_root/tools/"
+    "$ROOT/tools/project-state.py" "$ROOT/tools/import-project-source.py" \
+    "$package_root/tools/"
 cp "$ROOT/packaging/requirements.txt" "$package_root/packaging/"
 
 chmod +x "$package_root/install.sh" "$package_root/uninstall.sh" "$package_root/bin/"* \
     "$package_root/tools/validate-json.py" "$package_root/tools/build-intake-report.py" \
-    "$package_root/tools/project-state.py"
+    "$package_root/tools/project-state.py" \
+    "$package_root/tools/import-project-source.py"
 
 # Record the exact release contents for human review and archive verification.
 (

--- a/tools/import-project-source.py
+++ b/tools/import-project-source.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Safely plan and copy a new project's initial client delivery.
+
+The helper deliberately uses ``lstat``/``scandir`` so symbolic links are never
+followed. ``scan`` records the exact relative directory/file structure before
+project staging begins. ``copy`` rescans and compares that structure before
+copying, preventing a changed source tree from silently altering the import.
+"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser, Namespace
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+from typing import Any
+
+VALIDATION_ERROR = 5
+
+
+def parser() -> ArgumentParser:
+    result = ArgumentParser(description=__doc__)
+    subcommands = result.add_subparsers(dest="command", required=True)
+
+    scan = subcommands.add_parser("scan", help="validate a source and write a plan")
+    scan.add_argument("source", type=Path)
+    scan.add_argument("plan", type=Path)
+
+    copy = subcommands.add_parser("copy", help="copy a previously scanned source")
+    copy.add_argument("source", type=Path)
+    copy.add_argument("destination", type=Path)
+    copy.add_argument("plan", type=Path)
+    return result
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(VALIDATION_ERROR)
+
+
+def validate_component(name: str, path: Path) -> None:
+    """Reject control characters that make CLI/report output ambiguous."""
+
+    if any(ord(character) < 32 or ord(character) == 127 for character in name):
+        fail(f"Control characters are not allowed in source names: {path}")
+
+
+def classify(path: Path) -> str:
+    """Return file/directory without following a symbolic link."""
+
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        fail(f"Unable to inspect source path {path}: {error}")
+    if stat.S_ISLNK(mode):
+        fail(f"Symbolic links are not allowed in source imports: {path}")
+    if stat.S_ISREG(mode):
+        return "file"
+    if stat.S_ISDIR(mode):
+        return "directory"
+    fail(f"Unsupported source filesystem object: {path}")
+    raise AssertionError("unreachable")
+
+
+def build_plan(source: Path) -> dict[str, Any]:
+    """Return a deterministic, case-insensitive-collision-safe source plan."""
+
+    source_type = classify(source)
+    entries: list[dict[str, str]] = []
+    seen: dict[str, str] = {}
+
+    def add_entry(relative: Path, entry_type: str) -> None:
+        display = relative.as_posix()
+        key = display.casefold()
+        if key in seen:
+            fail(
+                "Case-insensitive source-path collision: "
+                f"{seen[key]!r} and {display!r}"
+            )
+        seen[key] = display
+        entries.append({"type": entry_type, "path": display})
+
+    if source_type == "file":
+        validate_component(source.name, source)
+        add_entry(Path(source.name), "file")
+    else:
+
+        def walk(directory: Path, relative_directory: Path) -> None:
+            try:
+                children = sorted(
+                    os.scandir(directory),
+                    key=lambda item: (item.name.casefold(), item.name),
+                )
+            except OSError as error:
+                fail(f"Unable to read source directory {directory}: {error}")
+            for child in children:
+                child_path = Path(child.path)
+                validate_component(child.name, child_path)
+                relative = relative_directory / child.name
+                entry_type = classify(child_path)
+                add_entry(relative, entry_type)
+                if entry_type == "directory":
+                    walk(child_path, relative)
+
+        walk(source, Path())
+
+    entries.sort(key=lambda item: (item["path"].casefold(), item["path"], item["type"]))
+    return {
+        "source_type": source_type,
+        "source": str(source),
+        "entries": entries,
+    }
+
+
+def write_plan(source: Path, plan_path: Path) -> None:
+    plan = build_plan(source)
+    plan_path.write_text(
+        json.dumps(plan, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def copy_from_plan(source: Path, destination: Path, plan_path: Path) -> None:
+    expected = json.loads(plan_path.read_text(encoding="utf-8"))
+    current = build_plan(source)
+    if (
+        current.get("source_type") != expected.get("source_type")
+        or current.get("entries") != expected.get("entries")
+    ):
+        fail("Source import changed after preflight; no project was created.")
+
+    if destination.is_symlink() or not destination.is_dir():
+        fail(f"Source-import destination is missing or unsafe: {destination}")
+    if any(destination.iterdir()):
+        fail(f"Source-import destination must be empty: {destination}")
+
+    source_type = current["source_type"]
+    entries = current["entries"]
+    directories = [item for item in entries if item["type"] == "directory"]
+    files = [item for item in entries if item["type"] == "file"]
+
+    # Create directories shallowest-first, then copy files without following
+    # links. Directory timestamps/modes are restored deepest-first afterward.
+    for item in sorted(
+        directories,
+        key=lambda value: (value["path"].count("/"), value["path"]),
+    ):
+        (destination / item["path"]).mkdir(parents=True, exist_ok=False)
+
+    for item in files:
+        relative = Path(item["path"])
+        source_file = source if source_type == "file" else source / relative
+        destination_file = destination / relative
+        destination_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_file, destination_file, follow_symlinks=False)
+
+    for item in sorted(
+        directories,
+        key=lambda value: value["path"].count("/"),
+        reverse=True,
+    ):
+        relative = Path(item["path"])
+        shutil.copystat(
+            source / relative,
+            destination / relative,
+            follow_symlinks=False,
+        )
+
+
+def main(args: Namespace) -> int:
+    if args.command == "scan":
+        write_plan(args.source, args.plan)
+    else:
+        copy_from_plan(args.source, args.destination, args.plan)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(parser().parse_args()))

--- a/tools/verify-release-archive
+++ b/tools/verify-release-archive
@@ -29,7 +29,7 @@ done
 
 for required in install.sh uninstall.sh VERSION LICENSE README.md RELEASE_MANIFEST.txt \
     bin lib schemas templates docs tools/validate-json.py tools/build-intake-report.py tools/project-state.py \
-    packaging/requirements.txt; do
+    tools/import-project-source.py packaging/requirements.txt; do
     [ -e "$package_root/$required" ] || {
         echo "Missing release content: $required" >&2
         exit 5


### PR DESCRIPTION
Strict v1.1 project-manifest.json
Immutable client-profile-snapshot.json
Flattened project location beneath Clients/<Client>/Projects/
Complete standard project directory tree
No initial revision or delivery manifest
Client selection by ID, path, or current-directory context
Client and studio default inheritance
Readable project-folder sanitization
Stable project IDs and case-insensitive collision checks
Recursive, symlink-safe --source copying
Transactional staged creation and rollback
Non-mutating dry-run
--cd and --no-cd support
Removed-option diagnostics
Next: new-revision --description "Initial mix" guidance
Installer and release-package integration for the new source-import helper