### PR TITLE
feat: migrate revision workflow to v1.1

### DIFF
--- a/bin/approve-mix
+++ b/bin/approve-mix
@@ -1,125 +1,246 @@
 #!/usr/bin/env bash
-# Approve one revision and supersede any previously approved revision.
+# Record approval for one JL Mixing Automation v1.1 revision.
 #
-# Workflow:
-#   1. Resolve the project and revision.
-#   2. Update approval state transactionally.
-#   3. Validate the updated manifest and optionally append a human note.
-#
-# Safety: the original manifest is restored if any update or validation step fails.
+# Approval mutates only the project manifest. It never packages files, modifies
+# Revision_Notes.md, or changes current_revision/delivered_revision.
 set -eu
 
-# Resolve the installation root from this launcher. Installed wrappers may
-# override it with JL_MIXING_HOME.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="${JL_MIXING_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-# Load shared services; command files intentionally keep reusable logic in lib/.
+# shellcheck source=lib/common.sh
 . "$APP_ROOT/lib/common.sh"
+# shellcheck source=lib/context.sh
 . "$APP_ROOT/lib/context.sh"
+# shellcheck source=lib/filesystem.sh
+. "$APP_ROOT/lib/filesystem.sh"
+# shellcheck source=lib/json.sh
 . "$APP_ROOT/lib/json.sh"
+# shellcheck source=lib/metadata.sh
+. "$APP_ROOT/lib/metadata.sh"
+# shellcheck source=lib/platform.sh
 . "$APP_ROOT/lib/platform.sh"
+# shellcheck source=lib/project-state.sh
+. "$APP_ROOT/lib/project-state.sh"
+# shellcheck source=lib/revision.sh
 . "$APP_ROOT/lib/revision.sh"
+# shellcheck source=lib/transaction.sh
+. "$APP_ROOT/lib/transaction.sh"
 
-# Print command syntax and supported options, then return to the caller.
 usage() {
     cat <<'USAGE'
 Usage: approve-mix [options]
 
 Options:
-  --project PATH       Explicit project path
+  --project PATH       Explicit project directory
   --revision NUMBER    Revision to approve (default: current revision)
-  --approved-by NAME   Approver name (default: project mix engineer)
-  --notes TEXT         Append an explicit approval note to Revision_Notes.md
-  --date TIMESTAMP     ISO-8601 approval timestamp
-  --non-interactive    Accept defaults without prompting
-  --dry-run            Print the approval action without changing files
+  --approved-by NAME   Approver identity (default: Client)
+  --date TIMESTAMP     ISO-8601 approval timestamp (default: current time)
+  --dry-run            Show the approval change without modifying the project
   -h, --help           Show this help
 USAGE
 }
 
+removed_option_error() {
+    case "$1" in
+        --notes)
+            jl_error "--notes was removed in JL Mixing 1.1."
+            jl_error "Revision_Notes.md is user-managed and is not changed by approve-mix."
+            ;;
+        --non-interactive)
+            jl_error "--non-interactive was removed in JL Mixing 1.1."
+            jl_error "approve-mix already uses supplied values and defaults without prompting."
+            ;;
+    esac
+    return "$JL_EXIT_ARGUMENTS"
+}
+
+# Validate a timezone-qualified ISO-8601 timestamp and ensure it is not earlier
+# than the selected revision's creation timestamp.
+validate_approval_timestamp() {
+    local revision_created approval_timestamp python_command
+    revision_created="$1"
+    approval_timestamp="$2"
+    python_command="$(jl_json_validator_python)" || {
+        jl_error "Python 3 is required for approval-date validation."
+        return "$JL_EXIT_CONFIG"
+    }
+    if ! "$python_command" - "$revision_created" "$approval_timestamp" <<'PY_DATE'
+from datetime import datetime
+import sys
+
+
+def parse(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.utcoffset() is None:
+        raise ValueError("timestamp must include a UTC offset or Z")
+    return parsed
+
+try:
+    created = parse(sys.argv[1])
+    approved = parse(sys.argv[2])
+except ValueError as error:
+    print(error, file=sys.stderr)
+    raise SystemExit(5)
+if approved < created:
+    print("approval timestamp predates revision creation", file=sys.stderr)
+    raise SystemExit(5)
+PY_DATE
+    then
+        jl_error "Invalid approval timestamp: $approval_timestamp"
+        return "$JL_EXIT_VALIDATION"
+    fi
+}
+
 project_ref=""
 revision_number=""
-approved_by=""
-notes=""
+approved_by="Client"
 approval_date=""
+revision_seen=0
+date_seen=0
 dry_run=0
 
-# Parse options explicitly so unknown or missing arguments fail predictably.
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --project) [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS"; project_ref="$2"; shift 2 ;;
-        --revision) [ "$#" -ge 2 ] || jl_die "--revision requires a value." "$JL_EXIT_ARGUMENTS"; revision_number="$2"; shift 2 ;;
-        --approved-by) [ "$#" -ge 2 ] || jl_die "--approved-by requires a value." "$JL_EXIT_ARGUMENTS"; approved_by="$2"; shift 2 ;;
-        --notes) [ "$#" -ge 2 ] || jl_die "--notes requires a value." "$JL_EXIT_ARGUMENTS"; notes="$2"; shift 2 ;;
-        --date) [ "$#" -ge 2 ] || jl_die "--date requires a value." "$JL_EXIT_ARGUMENTS"; approval_date="$2"; shift 2 ;;
-        --non-interactive) shift ;;
+        --project)
+            [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS"
+            project_ref="$2"; shift 2
+            ;;
+        --revision)
+            [ "$#" -ge 2 ] || jl_die "--revision requires a value." "$JL_EXIT_ARGUMENTS"
+            revision_number="$2"; revision_seen=1; shift 2
+            ;;
+        --approved-by)
+            [ "$#" -ge 2 ] || jl_die "--approved-by requires a value." "$JL_EXIT_ARGUMENTS"
+            approved_by="$2"; shift 2
+            ;;
+        --date)
+            [ "$#" -ge 2 ] || jl_die "--date requires a value." "$JL_EXIT_ARGUMENTS"
+            approval_date="$2"; date_seen=1; shift 2
+            ;;
+        --notes|--non-interactive) removed_option_error "$1"; exit $? ;;
         --dry-run) dry_run=1; shift ;;
         -h|--help) usage; exit 0 ;;
-        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS"; exit $? ;;
+        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS" ;;
     esac
 done
 
-# Resolve the project and reject approval changes after completion.
-project_root="$(jl_context_resolve_project "$project_ref" "$PWD")" || exit $?
+project_root="$(jl_context_resolve_project_v11 "$project_ref" "$PWD")" || exit $?
+jl_context_validate_project_v11 "$project_root" || exit $?
 manifest="$project_root/00_Admin/project-manifest.json"
-[ "$(jl_json_get "$manifest" '.state.status')" = active ] || {
-    jl_error "Cannot approve a revision in a completed project."
+current_revision="$(jl_revision_current "$manifest")"
+if [ "$current_revision" -eq 0 ]; then
+    jl_error "No revision exists to approve."
     exit "$JL_EXIT_VALIDATION"
-}
+fi
 
-# Default to current_revision, then prove the requested revision exists on disk and in JSON.
-[ -n "$revision_number" ] || revision_number="$(jl_revision_current "$manifest")"
-case "$revision_number" in ''|*[!0-9]*|0) jl_error "Revision number must be a positive integer."; exit "$JL_EXIT_VALIDATION" ;; esac
-revision_folder="$(jq -er --argjson number "$revision_number" '.revisions[] | select(.number == $number) | .folder' "$manifest")" || {
+if [ "$revision_seen" -eq 0 ]; then
+    revision_number="$current_revision"
+fi
+case "$revision_number" in
+    ''|*[!0-9]*|0)
+        jl_error "Revision number must be a positive integer: $revision_number"
+        exit "$JL_EXIT_VALIDATION"
+        ;;
+esac
+revision_count="$(jq --argjson number "$revision_number" \
+    '[.revisions[] | select(.number == $number)] | length' "$manifest")"
+if [ "$revision_count" -ne 1 ]; then
     jl_error "Revision $revision_number does not exist."
     exit "$JL_EXIT_VALIDATION"
-}
-revision_root="$project_root/$revision_folder"
-[ -d "$revision_root" ] || { jl_error "Revision folder is missing: $revision_root"; exit "$JL_EXIT_VALIDATION"; }
+fi
+jl_context_revision_root_for_number "$project_root" "$revision_number" >/dev/null || exit $?
 
-[ -n "$approved_by" ] || approved_by="$(jl_json_get_optional "$manifest" '.mix_engineer' '')"
-[ -n "$approved_by" ] || approved_by="Engineer"
-[ -n "$approval_date" ] || approval_date="$(jl_now_iso8601)"
+approved_by="$(jl_trim "$approved_by")"
+jl_assert_nonempty "$approved_by" "approver" || exit $?
+current_approved="$(jl_json_get_optional "$manifest" '.state.approved_revision' '')"
+if [ -n "$current_approved" ] && [ "$current_approved" -eq "$revision_number" ]; then
+    jl_error "Revision $revision_number is already the approved revision."
+    printf 'No changes made.\n\nNext:\n  create-delivery\n'
+    exit "$JL_EXIT_VALIDATION"
+fi
 
-# Dry-run reports the exact approval event without mutating history.
+revision_created="$(jq -er --argjson number "$revision_number" \
+    '.revisions[] | select(.number == $number) | .created_at' "$manifest")"
+prior_approved_at="$(jq -r --argjson number "$revision_number" \
+    '.revisions[] | select(.number == $number) | .approval.approved_at // empty' "$manifest")"
+if [ "$date_seen" -eq 1 ]; then
+    approval_date="$(jl_trim "$approval_date")"
+    jl_assert_nonempty "$approval_date" "approval timestamp" || exit $?
+    validate_approval_timestamp "$revision_created" "$approval_date" || exit $?
+fi
+
+delivered_revision="$(jl_json_get_optional "$manifest" '.state.delivered_revision' '')"
+
 if [ "$dry_run" -eq 1 ]; then
-    printf 'Would approve revision %s by %s at %s\n' "$revision_number" "$approved_by" "$approval_date"
+    printf 'Dry run — no changes made.\n\n'
+    printf 'Project:                     %s\n' "$(jl_json_get "$manifest" '.project_name')"
+    printf 'Current revision:            %s\n' "$current_revision"
+    printf 'Selected revision:           %s\n' "$revision_number"
+    printf 'Current approved revision:   %s\n' "${current_approved:-<none>}"
+    printf 'Approver:                    %s\n' "$approved_by"
+    if [ "$date_seen" -eq 1 ]; then
+        printf 'Approval timestamp:          %s\n' "$approval_date"
+    else
+        printf 'Approval timestamp:          current time at execution\n'
+    fi
+    printf '\nWould update:\n'
+    printf '  state.approved_revision: %s → %s\n' "${current_approved:-null}" "$revision_number"
+    printf '  Revision %s approval metadata\n' "$revision_number"
+    printf '  metadata.last_modified_at\n'
+    if [ -n "$prior_approved_at" ]; then
+        printf '\nRevision %s was approved previously; its prior approval metadata would be replaced.\n' \
+            "$revision_number"
+    fi
+    printf '\nWould not change:\n'
+    printf '  state.current_revision: %s\n' "$current_revision"
+    printf '  state.delivered_revision: %s\n' "${delivered_revision:-null}"
+    printf '  Revision files\n'
+    printf '  Final delivery package\n'
     exit 0
 fi
 
-# Preserve the manifest because approval updates several related fields atomically.
-backup="$(jl_mktemp_file_near "$manifest")"
-cp -p "$manifest" "$backup"
-cleanup=1
-# Trap handler that restores transactional state when the command exits unsuccessfully.
-rollback_on_failure() {
-    exit_status=$?
-    if [ "$exit_status" -ne 0 ] && [ "$cleanup" -eq 1 ]; then
-        cp -p "$backup" "$manifest" 2>/dev/null || true
+approval_date="${approval_date:-$(jl_now_iso8601)}"
+validate_approval_timestamp "$revision_created" "$approval_date" || exit $?
+project_schema="$(jl_json_schema_path project-manifest.schema.json)" || exit $?
+staged_manifest="$(jl_mktemp_file_near "$manifest")" || exit $?
+cleanup_stage() {
+    local status
+    status=$?
+    if [ -n "${staged_manifest:-}" ] && { [ -e "$staged_manifest" ] || [ -L "$staged_manifest" ]; }; then
+        rm -f -- "$staged_manifest"
     fi
-    rm -f "$backup"
-    exit "$exit_status"
+    return "$status"
 }
-trap rollback_on_failure EXIT HUP INT TERM
+trap cleanup_stage EXIT
+trap 'exit 1' HUP INT TERM
 
-# Update approval and superseding state in one jq transformation, then validate it.
-jl_revision_approve "$manifest" "$revision_number" "$approved_by" "$approval_date"
-jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$manifest"
+cp -p "$manifest" "$staged_manifest"
+jl_revision_approve \
+    "$staged_manifest" "$revision_number" "$approved_by" "$approval_date" || exit $?
+jl_json_validate_schema "$project_schema" "$staged_manifest" >/dev/null || exit $?
+jl_metadata_validate_v11 "$staged_manifest" mixing-project mutable || exit $?
+jl_project_validate_revision_records "$staged_manifest" || exit $?
+jl_project_validate_state_pointers "$staged_manifest" || exit $?
 
-# Human approval notes are appended only after machine state validates.
-if [ -n "$notes" ]; then
-    cat >> "$revision_root/Revision_Notes.md" <<EOF_NOTE
+jl_txn_replace_file "$staged_manifest" "$manifest" \
+    jl_project_validate_state "$project_root" || exit $?
+staged_manifest=""
 
-### Approval
-
-**Approved:** $approval_date  
-**Approved by:** $approved_by
-
-$notes
-EOF_NOTE
+project_stage="$(jl_project_state_derive "$project_root")"
+printf 'Revision approved successfully.\n\n'
+printf 'Project:                     %s\n' "$(jl_json_get "$manifest" '.project_name')"
+printf 'Approved revision:           %s\n' "$revision_number"
+if [ "$revision_number" -ne "$current_revision" ]; then
+    printf 'Current revision:            %s\n' "$current_revision"
 fi
-
-cleanup=0
-rm -f "$backup"
-trap - EXIT HUP INT TERM
-printf 'Approved revision %s. Any previously approved revision is now superseded.\n' "$revision_number"
+printf 'Approved by:                 %s\n' "$approved_by"
+printf 'Approved at:                 %s\n' "$approval_date"
+printf 'Project state:               %s\n' "$project_stage"
+if [ "$revision_number" -ne "$current_revision" ]; then
+    printf '\nThe approved revision is older than the current working revision.\n'
+fi
+if [ -n "$delivered_revision" ] && [ "$delivered_revision" -ne "$revision_number" ]; then
+    printf '\nCurrent final delivery represents Revision %s.\n' "$delivered_revision"
+    printf 'Running create-delivery will require explicit replacement authorization.\n'
+fi
+printf '\nNext:\n  create-delivery\n'

--- a/bin/new-revision
+++ b/bin/new-revision
@@ -1,117 +1,323 @@
 #!/usr/bin/env bash
-# Create the next immutable numbered revision folder and manifest record.
+# Create the next JL Mixing Automation v1.1 revision.
 #
-# Folder creation and manifest mutation are treated as one transaction: both
-# are rolled back when template rendering or schema validation fails.
+# The new Revision_NN directory and updated project manifest are staged and
+# committed as one rollback-capable transaction. Existing approval and delivery
+# pointers remain unchanged when newer work begins.
 set -eu
 
-# Resolve the installation root from this launcher. Installed wrappers may
-# override it with JL_MIXING_HOME.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="${JL_MIXING_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-# Load shared services; command files intentionally keep reusable logic in lib/.
+# shellcheck source=lib/common.sh
 . "$APP_ROOT/lib/common.sh"
-. "$APP_ROOT/lib/config.sh"
+# shellcheck source=lib/context.sh
 . "$APP_ROOT/lib/context.sh"
+# shellcheck source=lib/filesystem.sh
+. "$APP_ROOT/lib/filesystem.sh"
+# shellcheck source=lib/json.sh
 . "$APP_ROOT/lib/json.sh"
+# shellcheck source=lib/metadata.sh
 . "$APP_ROOT/lib/metadata.sh"
-. "$APP_ROOT/lib/naming.sh"
+# shellcheck source=lib/platform.sh
 . "$APP_ROOT/lib/platform.sh"
+# shellcheck source=lib/project-state.sh
+. "$APP_ROOT/lib/project-state.sh"
+# shellcheck source=lib/revision.sh
 . "$APP_ROOT/lib/revision.sh"
+# shellcheck source=lib/templates.sh
 . "$APP_ROOT/lib/templates.sh"
+# shellcheck source=lib/transaction.sh
+. "$APP_ROOT/lib/transaction.sh"
 
-# Print command syntax and supported options, then return to the caller.
 usage() {
     cat <<'USAGE'
 Usage: new-revision [options]
 
 Options:
-  --project PATH       Explicit project path
-  --description TEXT   Revision summary
-  --non-interactive    Accept defaults without prompting
-  --dry-run            Print the planned revision without creating it
+  --project PATH       Explicit project directory
+  --description TEXT   Revision description
+  --source PATH        Mix-print file or directory of immediate files to copy
+  --cd                 Enter the new revision directory after creation
+  --no-cd              Remain in the current directory after creation
+  --dry-run            Show the planned revision without creating it
   -h, --help           Show this help
 USAGE
 }
 
+shell_quote_path() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\"'\"'/g")"
+}
+
+write_directory_result() {
+    local result_file destination
+    result_file="$1"
+    destination="$2"
+    jl_path_validate_absolute "$result_file" || return $?
+    if [ ! -f "$result_file" ] || [ -L "$result_file" ] || [ ! -w "$result_file" ]; then
+        jl_error "Shell-integration result file is missing or unsafe: $result_file"
+        return "$JL_EXIT_UNSAFE"
+    fi
+    printf '%s\n' "$destination" > "$result_file" || {
+        jl_error "Unable to write shell-integration directory result: $result_file"
+        return "$JL_EXIT_GENERAL"
+    }
+}
+
+scan_source_to_plan() {
+    local source plan_file python_command
+    source="$1"
+    plan_file="$2"
+    python_command="$(jl_json_validator_python)" || {
+        jl_error "Python 3 is required for revision source validation."
+        return "$JL_EXIT_CONFIG"
+    }
+    "$python_command" "$APP_ROOT/tools/import-revision-source.py" \
+        scan "$source" "$plan_file" || {
+        jl_error "Revision source validation failed: $source"
+        return "$JL_EXIT_VALIDATION"
+    }
+}
+
+copy_source_from_plan() {
+    local source destination plan_file python_command
+    source="$1"
+    destination="$2"
+    plan_file="$3"
+    python_command="$(jl_json_validator_python)" || {
+        jl_error "Python 3 is required for revision source copying."
+        return "$JL_EXIT_CONFIG"
+    }
+    "$python_command" "$APP_ROOT/tools/import-revision-source.py" \
+        copy "$source" "$destination" "$plan_file" || {
+        jl_error "Revision source copy failed: $source"
+        return "$JL_EXIT_VALIDATION"
+    }
+}
+
+removed_option_error() {
+    jl_error "--non-interactive was removed in JL Mixing 1.1."
+    jl_error "new-revision already uses supplied values and defaults without prompting."
+    return "$JL_EXIT_ARGUMENTS"
+}
+
 project_ref=""
 description=""
+source_ref=""
+description_seen=0
+source_seen=0
+cd_enabled_seen=0
+cd_disabled_seen=0
 dry_run=0
 
-# Parse options explicitly so unknown or missing arguments fail predictably.
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --project) [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS"; project_ref="$2"; shift 2 ;;
-        --description) [ "$#" -ge 2 ] || jl_die "--description requires a value." "$JL_EXIT_ARGUMENTS"; description="$2"; shift 2 ;;
-        --non-interactive) shift ;;
+        --project)
+            [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS"
+            project_ref="$2"; shift 2
+            ;;
+        --description)
+            [ "$#" -ge 2 ] || jl_die "--description requires a value." "$JL_EXIT_ARGUMENTS"
+            description="$2"; description_seen=1; shift 2
+            ;;
+        --source)
+            [ "$#" -ge 2 ] || jl_die "--source requires a value." "$JL_EXIT_ARGUMENTS"
+            source_ref="$2"; source_seen=1; shift 2
+            ;;
+        --cd) cd_enabled_seen=1; shift ;;
+        --no-cd) cd_disabled_seen=1; shift ;;
         --dry-run) dry_run=1; shift ;;
+        --non-interactive) removed_option_error; exit $? ;;
         -h|--help) usage; exit 0 ;;
-        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS"; exit $? ;;
+        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS" ;;
     esac
 done
 
-# Resolve project state and calculate the next revision from manifest history.
-project_root="$(jl_context_resolve_project "$project_ref" "$PWD")" || exit $?
+if [ "$cd_enabled_seen" -eq 1 ] && [ "$cd_disabled_seen" -eq 1 ]; then
+    jl_die "--cd and --no-cd are mutually exclusive." "$JL_EXIT_ARGUMENTS"
+fi
+if [ "$dry_run" -eq 1 ] && { [ "$cd_enabled_seen" -eq 1 ] || [ "$cd_disabled_seen" -eq 1 ]; }; then
+    jl_die "--cd and --no-cd cannot be combined with --dry-run." "$JL_EXIT_ARGUMENTS"
+fi
+
+project_root="$(jl_context_resolve_project_v11 "$project_ref" "$PWD")" || exit $?
+jl_context_validate_project_v11 "$project_root" || exit $?
 manifest="$project_root/00_Admin/project-manifest.json"
-status="$(jl_json_get "$manifest" '.state.status')"
-[ "$status" = active ] || { jl_error "Cannot create a revision for a completed project."; exit "$JL_EXIT_VALIDATION"; }
-
-number="$(jl_revision_next_number "$manifest")"
-[ -n "$description" ] || description="Revision $number"
-studio_root="$(jl_context_studio_root "$project_root")" || exit $?
+studio_root="$(jl_context_studio_root_v11 "$project_root")" || exit $?
 studio_file="$studio_root/Studio/studio.json"
-prefix="$(jl_json_get_optional "$studio_file" '.naming.revision_prefix' 'Revision_')"
-padding="$(jl_json_get_optional "$studio_file" '.naming.revision_padding' '2')"
-revision_name="$(jl_revision_name "$number" "$prefix" "$padding")"
-revision_root="$project_root/04_Revisions/$revision_name"
+revisions_root="$project_root/04_Revisions"
 
-if [ -e "$revision_root" ]; then
-    jl_error "Refusing to overwrite existing revision path: $revision_root"
+jl_fs_is_directory_no_symlink "$revisions_root" || {
+    jl_error "Revision root is missing or unsafe: $revisions_root"
+    exit "$JL_EXIT_CONTEXT"
+}
+[ -w "$revisions_root" ] || {
+    jl_error "Revision root is not writable: $revisions_root"
+    exit "$JL_EXIT_UNSAFE"
+}
+
+previous_revision="$(jl_revision_current "$manifest")"
+number="$(jl_revision_next_number "$manifest")" || exit $?
+if [ "$description_seen" -eq 1 ]; then
+    description="$(jl_trim "$description")"
+    jl_assert_nonempty "$description" "revision description" || exit $?
+elif [ "$number" -eq 1 ]; then
+    description="Initial mix"
+else
+    description="Revision $number"
+fi
+
+revision_name="$(jl_revision_name "$number")"
+revision_root="$revisions_root/$revision_name"
+jl_fs_assert_no_case_insensitive_child_collision "$revisions_root" "$revision_name" || exit $?
+if [ -e "$revision_root" ] || [ -L "$revision_root" ]; then
+    jl_error "Revision destination already exists: $revision_root"
     exit "$JL_EXIT_UNSAFE"
 fi
 
-# Dry-run verifies naming and numbering without creating a revision.
+source_path=""
+source_plan_dir=""
+source_plan_file=""
+cleanup_paths() {
+    local status
+    status=$?
+    if [ -n "$source_plan_dir" ] && [ -d "$source_plan_dir" ]; then
+        rm -rf -- "$source_plan_dir"
+    fi
+    if [ -n "${stage_root:-}" ] && { [ -e "$stage_root" ] || [ -L "$stage_root" ]; }; then
+        jl_fs_remove_entry_no_follow "$stage_root" || true
+    fi
+    if [ -n "${staged_manifest:-}" ] && { [ -e "$staged_manifest" ] || [ -L "$staged_manifest" ]; }; then
+        rm -f -- "$staged_manifest"
+    fi
+    return "$status"
+}
+trap cleanup_paths EXIT
+trap 'exit 1' HUP INT TERM
+
+if [ "$source_seen" -eq 1 ]; then
+    jl_assert_nonempty "$source_ref" "revision source" || exit $?
+    source_path="$(jl_abspath_allow_missing "$source_ref")" || exit $?
+    if [ ! -e "$source_path" ] && [ ! -L "$source_path" ]; then
+        jl_error "Revision source not found: $source_path"
+        exit "$JL_EXIT_CONTEXT"
+    fi
+    source_plan_dir="$(jl_mktemp_dir jl-mixing-new-revision-source)" || exit $?
+    source_plan_file="$source_plan_dir/plan.json"
+    scan_source_to_plan "$source_path" "$source_plan_file" || exit $?
+fi
+
+studio_default_cd="$(jq -r '.cli.change_directory_after_create' "$studio_file")"
+effective_cd=0
+if [ "$cd_enabled_seen" -eq 1 ]; then
+    effective_cd=1
+elif [ "$cd_disabled_seen" -eq 1 ]; then
+    effective_cd=0
+elif [ "$studio_default_cd" = true ]; then
+    effective_cd=1
+fi
+
+print_summary() {
+    local heading mode source_display
+    heading="$1"
+    mode="$2"
+    source_display="${source_path:-<none>}"
+    printf '%s\n\n' "$heading"
+    printf 'Project:                    %s\n' "$(jl_json_get "$manifest" '.project_name')"
+    if [ "$mode" = plan ]; then
+        printf 'Current revision:           %s\n' "$previous_revision"
+        printf 'New revision:               %s\n' "$number"
+    else
+        printf 'Revision:                   %s\n' "$number"
+    fi
+    printf 'Description:                %s\n' "$description"
+    printf 'Revision folder:            %s\n' "$revision_root"
+    printf 'Source:                     %s\n' "$source_display"
+    if [ "$effective_cd" -eq 1 ]; then
+        printf 'Automatic directory change: enabled\n'
+    else
+        printf 'Automatic directory change: disabled\n'
+    fi
+}
+
 if [ "$dry_run" -eq 1 ]; then
-    printf 'Would create revision %s at %s\n' "$number" "$revision_root"
+    print_summary "Dry run — no changes made." plan
+    printf '\nWould create:\n  %s/\n  %s/Revision_Notes.md\n' "$revision_name" "$revision_name"
+    if [ -n "$source_plan_file" ]; then
+        if [ "$(jq -r '.files | length' "$source_plan_file")" -eq 0 ]; then
+            printf '  <source directory contains no files>\n'
+        else
+            jq -r --arg revision "$revision_name" '.files[] | "  " + $revision + "/" + .' "$source_plan_file"
+        fi
+    fi
+    printf '\nWould update:\n'
+    printf '  state.current_revision: %s → %s\n' "$previous_revision" "$number"
+    printf '  revisions: append Revision %s\n' "$number"
+    printf '  metadata.last_modified_at\n'
+    printf '\nWould preserve:\n'
+    printf '  state.approved_revision: %s\n' "$(jl_json_get_json "$manifest" '.state.approved_revision')"
+    printf '  state.delivered_revision: %s\n' "$(jl_json_get_json "$manifest" '.state.delivered_revision')"
+    printf '\nAfter creation:\n  cd '
+    shell_quote_path "$revision_root"
+    printf '\n  approve-mix\n'
     exit 0
 fi
 
-# Preserve the manifest so folder and state changes can be rolled back together.
-backup="$(jl_mktemp_file_near "$manifest")"
-cp -p "$manifest" "$backup"
-cleanup=1
-# Trap handler that restores transactional state when the command exits unsuccessfully.
-rollback_on_failure() {
-    exit_status=$?
-    if [ "$exit_status" -ne 0 ] && [ "$cleanup" -eq 1 ]; then
-        cp -p "$backup" "$manifest" 2>/dev/null || true
-        rm -rf "$revision_root"
-    fi
-    rm -f "$backup"
-    exit "$exit_status"
-}
-trap rollback_on_failure EXIT HUP INT TERM
+project_schema="$(jl_json_schema_path project-manifest.schema.json)" || exit $?
+created_at="$(jl_now_iso8601)"
+revision_id="$(jl_uuid)" || exit $?
+jl_json_assert_uuid_available "$studio_root" "$revision_id" || exit $?
 
-# Create the self-contained revision and its human-owned notes template.
-mkdir -p "$revision_root/Prints"
-timestamp="$(jl_now_iso8601)"
-revision_id="$(jl_uuid)"
-project_name="$(jl_json_get "$manifest" '.project_name')"
-engineer="$(jl_json_get_optional "$manifest" '.mix_engineer' '')"
-
-jl_template_render "$APP_ROOT/templates/revision/Revision_Notes.md" "$revision_root/Revision_Notes.md" \
-    REVISION_NAME "$revision_name" \
+stage_root="$(jl_txn_stage_directory_near "$revision_root")" || exit $?
+chmod 755 "$stage_root"
+if [ -n "$source_plan_file" ]; then
+    copy_source_from_plan "$source_path" "$stage_root" "$source_plan_file" || exit $?
+fi
+jl_template_render "$APP_ROOT/templates/Revision_Notes.md" "$stage_root/Revision_Notes.md" \
     REVISION_NUMBER "$number" \
-    CREATED_AT "$timestamp" \
-    REVISION_ID "$revision_id" \
-    MIX_ENGINEER "$engineer" \
-    REVISION_DESCRIPTION "$description"
+    REVISION_DESCRIPTION "$description" || exit $?
 
-# Append the machine-readable record only after the folder and notes exist.
-jl_revision_append "$manifest" "$description" "$number" "$timestamp" "$revision_id" "$prefix" "$padding"
-jl_json_validate_schema "$APP_ROOT/schemas/legacy/v1.0.4/project-manifest.schema.json" "$manifest"
+staged_manifest="$(jl_mktemp_file_near "$manifest")" || exit $?
+cp -p "$manifest" "$staged_manifest"
+jl_revision_append \
+    "$staged_manifest" "$description" "$number" "$created_at" "$revision_id" || exit $?
+jl_json_validate_schema "$project_schema" "$staged_manifest" >/dev/null || exit $?
+jl_metadata_validate_v11 "$staged_manifest" mixing-project mutable || exit $?
+jl_project_validate_revision_records "$staged_manifest" || exit $?
+jl_project_validate_state_pointers "$staged_manifest" || exit $?
 
-cleanup=0
-rm -f "$backup"
-trap - EXIT HUP INT TERM
-printf 'Created revision %s for %s: %s\n' "$number" "$project_name" "$revision_root"
+jl_txn_commit_directory_and_file \
+    "$stage_root" "$revision_root" "$staged_manifest" "$manifest" \
+    jl_project_validate_state "$project_root" || exit $?
+stage_root=""
+staged_manifest=""
+
+result_written=0
+if [ "$effective_cd" -eq 1 ] && [ -n "${JL_MIXING_CD_RESULT_FILE:-}" ]; then
+    write_directory_result "$JL_MIXING_CD_RESULT_FILE" "$revision_root" || {
+        jl_error "Revision creation succeeded, but automatic directory-change setup failed."
+        {
+            printf 'Run:\n  cd '
+            shell_quote_path "$revision_root"
+            printf '\n'
+        } >&2
+        exit "$JL_EXIT_GENERAL"
+    }
+    result_written=1
+fi
+
+print_summary "Revision created successfully." success
+printf 'Project state:              %s\n' "$(jl_project_state_derive "$project_root")"
+if [ "$effective_cd" -eq 1 ] && [ "$result_written" -eq 0 ]; then
+    cat <<'EOF_WARNING'
+
+Automatic directory change could not be performed because JL Mixing shell
+integration is not active.
+EOF_WARNING
+fi
+printf '\nNext:\n'
+if [ "$effective_cd" -eq 0 ] || [ "$result_written" -eq 0 ]; then
+    printf '  cd '
+    shell_quote_path "$revision_root"
+    printf '\n'
+fi
+printf '  approve-mix\n'

--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ tools/validate-json.py
 tools/build-intake-report.py
 tools/project-state.py
 tools/import-project-source.py
+tools/import-revision-source.py
 packaging/requirements.txt
 uninstall.sh'
 
@@ -139,7 +140,8 @@ cp -R "$SOURCE_ROOT/schemas/." "$stage_dir/schemas/"
 cp -R "$SOURCE_ROOT/templates/." "$stage_dir/templates/"
 cp -R "$SOURCE_ROOT/docs/." "$stage_dir/docs/"
 cp "$SOURCE_ROOT/tools/validate-json.py" "$SOURCE_ROOT/tools/build-intake-report.py" \
-    "$SOURCE_ROOT/tools/project-state.py" "$SOURCE_ROOT/tools/import-project-source.py" "$stage_dir/tools/"
+    "$SOURCE_ROOT/tools/project-state.py" "$SOURCE_ROOT/tools/import-project-source.py" \
+    "$SOURCE_ROOT/tools/import-revision-source.py" "$stage_dir/tools/"
 cp "$SOURCE_ROOT/packaging/requirements.txt" "$stage_dir/packaging/"
 cp "$SOURCE_ROOT/install.sh" "$SOURCE_ROOT/uninstall.sh" "$stage_dir/"
 
@@ -152,7 +154,8 @@ fi
 
 chmod +x "$stage_dir/install.sh" "$stage_dir/uninstall.sh" "$stage_dir/bin/"* \
     "$stage_dir/tools/validate-json.py" "$stage_dir/tools/build-intake-report.py" \
-    "$stage_dir/tools/project-state.py" "$stage_dir/tools/import-project-source.py"
+    "$stage_dir/tools/project-state.py" "$stage_dir/tools/import-project-source.py" \
+    "$stage_dir/tools/import-revision-source.py"
 
 if [ -d "$app_dir" ]; then
     backup_dir="$(mktemp -d "$share_dir/.jl-mixing-backup.XXXXXX")"

--- a/lib/context.sh
+++ b/lib/context.sh
@@ -19,6 +19,8 @@ JL_CONTEXT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$JL_CONTEXT_LIB_DIR/config.sh"
 # shellcheck source=lib/naming.sh
 . "$JL_CONTEXT_LIB_DIR/naming.sh"
+# shellcheck source=lib/project-state.sh
+. "$JL_CONTEXT_LIB_DIR/project-state.sh"
 
 # Walk from a starting path toward / until a relative marker is found.
 jl_find_up() {
@@ -416,4 +418,58 @@ jl_context_delivery_root_v11() {
         return "$JL_EXIT_CONTEXT"
     fi
     printf '%s\n' "$delivery_root"
+}
+
+
+# Validate the complete governing v1.1 context for a project before a workflow
+# mutation. JSON Schema handles each document; this helper enforces identity
+# relationships and project-state/filesystem invariants across the documents.
+jl_context_validate_project_v11() {
+    local project_root manifest snapshot client_root client_file studio_root studio_file
+    local studio_schema client_schema project_schema snapshot_schema
+    local client_document_id client_id
+    project_root="$1"
+    manifest="$project_root/00_Admin/project-manifest.json"
+    snapshot="$project_root/00_Admin/client-profile-snapshot.json"
+
+    client_root="$(jl_context_client_root_v11 "$project_root")" || return $?
+    client_file="$client_root/client.json"
+    studio_root="$(jl_context_studio_root_v11 "$project_root")" || return $?
+    studio_file="$studio_root/Studio/studio.json"
+
+    studio_schema="$(jl_json_schema_path studio.schema.json)" || return $?
+    client_schema="$(jl_json_schema_path client.schema.json)" || return $?
+    project_schema="$(jl_json_schema_path project-manifest.schema.json)" || return $?
+    snapshot_schema="$(jl_json_schema_path client-profile-snapshot.schema.json)" || return $?
+    jl_json_validate_schema_pairs \
+        "$studio_schema" "$studio_file" \
+        "$client_schema" "$client_file" \
+        "$project_schema" "$manifest" \
+        "$snapshot_schema" "$snapshot" >/dev/null || return $?
+
+    jl_json_require_exact_schema_identity "$studio_file" mixing-studio 1.1.0 || return $?
+    jl_json_require_created_with_series "$studio_file" 1.1.0 || return $?
+    jl_json_require_exact_schema_identity "$client_file" mixing-client 1.1.0 || return $?
+    jl_json_require_created_with_series "$client_file" 1.1.0 || return $?
+    jl_json_require_exact_schema_identity "$manifest" mixing-project 1.1.0 || return $?
+    jl_json_require_created_with_series "$manifest" 1.1.0 || return $?
+    jl_json_require_exact_schema_identity \
+        "$snapshot" mixing-client-profile-snapshot 1.1.0 || return $?
+    jl_json_require_created_with_series "$snapshot" 1.1.0 || return $?
+
+    client_document_id="$(jl_json_get "$client_file" '.metadata.document_id')" || return $?
+    client_id="$(jl_json_get "$client_file" '.client_id')" || return $?
+    if [ "$(jl_json_get "$manifest" '.client.client_document_id')" != "$client_document_id" ] || \
+       [ "$(jl_json_get "$manifest" '.client.client_id')" != "$client_id" ]; then
+        jl_error "Project manifest client identity does not match the owning client."
+        return "$JL_EXIT_VALIDATION"
+    fi
+    if [ "$(jl_json_get "$snapshot" '.source_client.client_document_id')" != "$client_document_id" ] || \
+       [ "$(jl_json_get "$snapshot" '.source_client.client_id')" != "$client_id" ]; then
+        jl_error "Client profile snapshot does not match the owning client."
+        return "$JL_EXIT_VALIDATION"
+    fi
+
+    jl_project_validate_state "$project_root" || return $?
+    jl_json_validate_unique_uuids "$studio_root"
 }

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -447,6 +447,31 @@ jl_json_validate_schema() {
         --strict --schema "$schema_file" --document "$document_file"
 }
 
+# Validate multiple schema/document pairs in one Python process. Starting the
+# pinned JSON Schema runtime once keeps project-context validation responsive
+# while preserving strict local-schema behavior for every document.
+jl_json_validate_schema_pairs() {
+    local python_command
+    local -a validator_args
+
+    if [ "$#" -eq 0 ] || [ $(( $# % 2 )) -ne 0 ]; then
+        jl_error "Schema validation requires SCHEMA DOCUMENT pairs."
+        return "$JL_EXIT_ARGUMENTS"
+    fi
+    python_command="$(jl_json_validator_python)" || {
+        jl_error "Python 3 is required for JSON Schema validation."
+        return "$JL_EXIT_CONFIG"
+    }
+
+    validator_args=(--strict)
+    while [ "$#" -gt 0 ]; do
+        validator_args+=(--schema "$1" --document "$2")
+        shift 2
+    done
+    "$python_command" "$JL_JSON_REPO_ROOT/tools/validate-json.py" \
+        "${validator_args[@]}"
+}
+
 # Convert a comma-separated string into a compact JSON string array.
 # Empty input becomes an empty array. Whitespace around entries is removed.
 # Convert a comma-separated string into a trimmed JSON string array.

--- a/lib/revision.sh
+++ b/lib/revision.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Revision numbering and project-manifest state transitions.
+# Revision numbering and v1.1 project-manifest state transitions.
 #
-# Approval guarantees at most one approved revision by converting any previous
-# approval to superseded in the same atomic JSON transformation.
+# Revision status is derived from the three project state pointers. The manifest
+# stores immutable revision identity/creation data plus mutable approval fields;
+# it does not store status labels or directory paths.
 if [ "${JL_MIXING_REVISION_LOADED:-0}" = "1" ]; then
     return 0 2>/dev/null || exit 0
 fi
@@ -15,56 +16,70 @@ JL_REVISION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$JL_REVISION_LIB_DIR/json.sh"
 # shellcheck source=lib/metadata.sh
 . "$JL_REVISION_LIB_DIR/metadata.sh"
-# shellcheck source=lib/naming.sh
-. "$JL_REVISION_LIB_DIR/naming.sh"
 
-# Return one greater than the largest recorded revision number.
+# Return state.current_revision + 1 for an exact v1.1 project document.
+# Command callers validate all cross-record invariants before using this value.
 jl_revision_next_number() {
-    local manifest
+    local manifest current
     manifest="$1"
-    jl_json_require_schema_identity "$manifest" mixing-project 1 || return $?
-    jq -r '([.revisions[].number] | max // 0) + 1' "$manifest"
+    jl_json_require_exact_schema_identity "$manifest" mixing-project 1.1.0 || return $?
+    current="$(jl_json_get "$manifest" '.state.current_revision')" || return $?
+    case "$current" in
+        ''|*[!0-9]*)
+            jl_error "Invalid state.current_revision in: $manifest"
+            return "$JL_EXIT_VALIDATION"
+            ;;
+    esac
+    printf '%s\n' "$((current + 1))"
 }
 
-# Build one schema-compatible revision record as JSON.
+# Build one canonical v1.1 revision record as JSON.
 jl_revision_create_record() {
-    local number description revision_id timestamp prefix padding folder
+    local number description revision_id timestamp
     number="$1"
     description="$2"
     revision_id="${3:-$(jl_uuid)}"
     timestamp="${4:-$(jl_now_iso8601)}"
-    prefix="${5:-Revision_}"
-    padding="${6:-2}"
-    folder="04_Revisions/$(jl_revision_name "$number" "$prefix" "$padding")"
+
+    case "$number" in
+        ''|*[!0-9]*|0)
+            jl_error "Revision number must be a positive integer: $number"
+            return "$JL_EXIT_ARGUMENTS"
+            ;;
+    esac
+    [ -n "$(jl_trim "$description")" ] || {
+        jl_error "Revision description must not be empty."
+        return "$JL_EXIT_VALIDATION"
+    }
 
     jq -n \
         --argjson number "$number" \
         --arg revision_id "$revision_id" \
         --arg created_at "$timestamp" \
         --arg description "$description" \
-        --arg folder "$folder" \
         '{
             number: $number,
             revision_id: $revision_id,
             created_at: $created_at,
-            created_by: "new-revision",
             description: $description,
-            status: "open",
-            folder: $folder
+            approval: {
+                approved_at: null,
+                approved_by: null
+            }
         }'
 }
 
-# Append a revision record and update current_revision atomically.
+# Append one canonical revision record and advance current_revision. Approval
+# and delivery pointers are deliberately preserved when new work begins.
 jl_revision_append() {
-    local manifest description number timestamp revision_id prefix padding record
+    local manifest description number timestamp revision_id record
     manifest="$1"
     description="$2"
-    number="${3:-$(jl_revision_next_number "$manifest")}" 
+    number="${3:-$(jl_revision_next_number "$manifest")}"
     timestamp="${4:-$(jl_now_iso8601)}"
     revision_id="${5:-$(jl_uuid)}"
-    prefix="${6:-Revision_}"
-    padding="${7:-2}"
-    record="$(jl_revision_create_record "$number" "$description" "$revision_id" "$timestamp" "$prefix" "$padding")" || return $?
+    record="$(jl_revision_create_record \
+        "$number" "$description" "$revision_id" "$timestamp")" || return $?
 
     jl_json_update "$manifest" \
         '.revisions += [$revision] |
@@ -75,42 +90,84 @@ jl_revision_append() {
         --arg timestamp "$timestamp"
 }
 
-# Approve one revision and supersede any previously approved revision atomically.
+# Record approval for one revision and move only approved_revision. Historical
+# approval metadata on every other revision is retained unchanged.
 jl_revision_approve() {
-    local manifest number approved_by timestamp exists
+    local manifest number approved_by timestamp exists current_approved
     manifest="$1"
     number="$2"
     approved_by="$3"
     timestamp="${4:-$(jl_now_iso8601)}"
 
-    exists="$(jq --argjson number "$number" '[.revisions[] | select(.number == $number)] | length' "$manifest")" || return $?
+    jl_json_require_exact_schema_identity "$manifest" mixing-project 1.1.0 || return $?
+    case "$number" in
+        ''|*[!0-9]*|0)
+            jl_error "Revision number must be a positive integer: $number"
+            return "$JL_EXIT_ARGUMENTS"
+            ;;
+    esac
+    [ -n "$(jl_trim "$approved_by")" ] || {
+        jl_error "Approver must not be empty."
+        return "$JL_EXIT_VALIDATION"
+    }
+
+    exists="$(jq --argjson number "$number" \
+        '[.revisions[] | select(.number == $number)] | length' "$manifest")" || return $?
     if [ "$exists" -ne 1 ]; then
         jl_error "Revision $number does not exist exactly once."
         return "$JL_EXIT_VALIDATION"
     fi
 
+    current_approved="$(jl_json_get_optional "$manifest" '.state.approved_revision' '')"
+    if [ -n "$current_approved" ] && [ "$current_approved" -eq "$number" ]; then
+        jl_error "Revision $number is already the approved revision."
+        return "$JL_EXIT_VALIDATION"
+    fi
+
     jl_json_update "$manifest" \
         '.revisions |= map(
-            if .number == $number then .status = "approved"
-            elif .status == "approved" then .status = "superseded"
+            if .number == $number then
+                .approval.approved_at = $timestamp |
+                .approval.approved_by = $approved_by
             else . end
          ) |
-         .state.approved = true |
          .state.approved_revision = $number |
-         .state.approved_at = $timestamp |
-         .state.approved_by = $approved_by |
          .metadata.last_modified_at = $timestamp' \
         --argjson number "$number" \
         --arg timestamp "$timestamp" \
         --arg approved_by "$approved_by"
 }
 
-# Read the status of a numbered revision.
+# Return a revision status. v1.1 status is derived from pointers; the temporary
+# legacy branch keeps the old stored-status read so create-delivery remains
+# testable until its dedicated v1.1 migration branch.
 jl_revision_status() {
-    local manifest number
+    local manifest number schema_version current approved exists
     manifest="$1"
     number="$2"
-    jq -er --argjson number "$number" '.revisions[] | select(.number == $number) | .status' "$manifest"
+    schema_version="$(jl_json_get_optional "$manifest" '.metadata.schema_version' '')"
+
+    if [ "$schema_version" != 1.1.0 ]; then
+        jq -er --argjson number "$number" \
+            '.revisions[] | select(.number == $number) | .status' "$manifest"
+        return $?
+    fi
+
+    exists="$(jq --argjson number "$number" \
+        '[.revisions[] | select(.number == $number)] | length' "$manifest")" || return $?
+    [ "$exists" -eq 1 ] || {
+        jl_error "Revision $number does not exist exactly once."
+        return "$JL_EXIT_VALIDATION"
+    }
+    current="$(jl_json_get "$manifest" '.state.current_revision')" || return $?
+    approved="$(jl_json_get_optional "$manifest" '.state.approved_revision' '')"
+    if [ -n "$approved" ] && [ "$number" -eq "$approved" ]; then
+        printf '%s\n' approved
+    elif [ "$number" -eq "$current" ]; then
+        printf '%s\n' open
+    else
+        printf '%s\n' superseded
+    fi
 }
 
 # Read the current revision number from project state.

--- a/lib/transaction.sh
+++ b/lib/transaction.sh
@@ -57,50 +57,102 @@ jl_txn_stage_directory_near() {
     mktemp -d "$parent/.${base}.stage.XXXXXX"
 }
 
-# Reserve a nonexistent hidden backup path beside a destination. mktemp creates
-# the directory securely; removing that empty reservation leaves a unique name
-# for a later atomic rename.
-jl_txn_backup_path_near() {
-    local destination parent base reservation
+# Create a unique hidden backup container beside a destination. The original
+# entry is moved to the fixed child name ``original``. Keeping the container in
+# place avoids races and ambiguous ``mv`` behavior between files and
+# directories while a transaction is active.
+jl_txn_backup_container_near() {
+    local destination parent base
     destination="$1"
     parent="$(dirname "$destination")"
     base="$(basename "$destination")"
-    reservation="$(mktemp -d "$parent/.${base}.backup.XXXXXX")" || return $?
-    rmdir "$reservation" || return $?
-    printf '%s\n' "$reservation"
+    mktemp -d "$parent/.${base}.backup.XXXXXX"
 }
 
-# Move an existing entry to a unique sibling backup path. If the source does
-# not exist, print an empty line so callers can use one uniform rollback flow.
+# Move an existing entry into a unique sibling backup container. If the source
+# does not exist, print an empty line so callers can use one rollback flow.
 jl_txn_backup_existing() {
-    local source backup
+    local source container
     source="$1"
     if [ ! -e "$source" ] && [ ! -L "$source" ]; then
         printf '\n'
         return 0
     fi
 
-    backup="$(jl_txn_backup_path_near "$source")" || return $?
-    mv "$source" "$backup" || {
+    container="$(jl_txn_backup_container_near "$source")" || return $?
+    mv "$source" "$container/original" || {
+        rmdir "$container" 2>/dev/null || true
         jl_error "Unable to back up transaction target: $source"
         return "$JL_EXIT_GENERAL"
     }
-    printf '%s\n' "$backup"
+    printf '%s\n' "$container"
+}
+
+# Copy an existing regular file into a backup container while leaving the
+# authoritative path in place until the staged file atomically replaces it.
+# This avoids a transient missing-manifest window during file-only and
+# coordinated directory/file transactions.
+jl_txn_backup_existing_file() {
+    local source container
+    source="$1"
+    if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+        printf '\n'
+        return 0
+    fi
+    jl_fs_is_regular_file_no_symlink "$source" || {
+        jl_error "Transaction file target is missing or unsafe: $source"
+        return "$JL_EXIT_UNSAFE"
+    }
+
+    container="$(jl_txn_backup_container_near "$source")" || return $?
+    cp -p "$source" "$container/original" || {
+        jl_fs_remove_entry_no_follow "$container" 2>/dev/null || true
+        jl_error "Unable to back up transaction file: $source"
+        return "$JL_EXIT_GENERAL"
+    }
+    printf '%s\n' "$container"
+}
+
+# Remove a completed backup container without following a symlink that might
+# have replaced it unexpectedly.
+jl_txn_discard_backup() {
+    local container
+    container="$1"
+    [ -n "$container" ] || return 0
+    if [ -L "$container" ] || [ ! -d "$container" ]; then
+        jl_error "Transaction backup container is missing or unsafe: $container"
+        return "$JL_EXIT_UNSAFE"
+    fi
+    jl_fs_remove_entry_no_follow "$container"
 }
 
 # Restore one backup, removing only the replacement entry created by the active
-# transaction. The backup path itself is never followed when it is a symlink.
+# transaction. The backup container itself is never followed when it is a
+# symlink.
 jl_txn_restore_backup() {
-    local backup destination
-    backup="$1"
+    local container destination original
+    container="$1"
     destination="$2"
 
     if [ -e "$destination" ] || [ -L "$destination" ]; then
         jl_fs_remove_entry_no_follow "$destination" || return $?
     fi
-    if [ -n "$backup" ] && { [ -e "$backup" ] || [ -L "$backup" ]; }; then
-        mv "$backup" "$destination" || {
+    if [ -n "$container" ]; then
+        if [ -L "$container" ] || [ ! -d "$container" ]; then
+            jl_error "Transaction backup container is missing or unsafe: $container"
+            return "$JL_EXIT_UNSAFE"
+        fi
+        original="$container/original"
+        if [ ! -e "$original" ] && [ ! -L "$original" ]; then
+            jl_error "Transaction backup entry is missing: $original"
+            return "$JL_EXIT_GENERAL"
+        fi
+        mv "$original" "$destination" || {
             jl_error "Unable to restore transaction backup: $destination"
+            return "$JL_EXIT_GENERAL"
+        }
+        rmdir "$container" || {
+            jl_error "Unable to remove restored backup container: $container"
             return "$JL_EXIT_GENERAL"
         }
     fi
@@ -174,7 +226,7 @@ jl_txn_replace_directory() {
     fi
 
     if [ "$status" -eq 0 ]; then
-        [ -z "$backup" ] || jl_fs_remove_entry_no_follow "$backup"
+        [ -z "$backup" ] || jl_txn_discard_backup "$backup"
         return 0
     fi
 
@@ -198,6 +250,7 @@ jl_txn_commit_directory_and_file() {
     destination_directory="$2"
     staged_file="$3"
     destination_file="$4"
+    shift 4
     directory_backup=""
     file_backup=""
 
@@ -219,7 +272,7 @@ jl_txn_commit_directory_and_file() {
     }
 
     directory_backup="$(jl_txn_backup_existing "$destination_directory")" || return $?
-    file_backup="$(jl_txn_backup_existing "$destination_file")" || {
+    file_backup="$(jl_txn_backup_existing_file "$destination_file")" || {
         jl_txn_restore_backup "$directory_backup" "$destination_directory" || true
         return "$JL_EXIT_GENERAL"
     }
@@ -238,10 +291,16 @@ jl_txn_commit_directory_and_file() {
     if [ "$status" -eq 0 ]; then
         jl_txn_fail_if_requested after-coordinated-file || status=$?
     fi
+    # Optional verifier commands run while both backups are still available.
+    # This lets callers validate committed cross-file state and still receive a
+    # complete rollback when verification fails.
+    if [ "$status" -eq 0 ] && [ "$#" -gt 0 ]; then
+        "$@" || status=$?
+    fi
 
     if [ "$status" -eq 0 ]; then
-        [ -z "$directory_backup" ] || jl_fs_remove_entry_no_follow "$directory_backup"
-        [ -z "$file_backup" ] || jl_fs_remove_entry_no_follow "$file_backup"
+        [ -z "$directory_backup" ] || jl_txn_discard_backup "$directory_backup"
+        [ -z "$file_backup" ] || jl_txn_discard_backup "$file_backup"
         return 0
     fi
 
@@ -250,6 +309,52 @@ jl_txn_commit_directory_and_file() {
     jl_txn_restore_backup "$directory_backup" "$destination_directory" || rollback_failed=1
     if [ "$rollback_failed" -ne 0 ]; then
         jl_error "Coordinated transaction failed and rollback was incomplete."
+        return "$JL_EXIT_GENERAL"
+    fi
+    return "$status"
+}
+
+# Atomically replace one staged file and retain the prior file until an optional
+# verifier succeeds. The staged file must be a sibling of the destination so
+# rename remains atomic.
+jl_txn_replace_file() {
+    local staged_file destination_file backup status rollback_status
+    staged_file="$1"
+    destination_file="$2"
+    shift 2
+    backup=""
+
+    jl_fs_is_regular_file_no_symlink "$staged_file" || {
+        jl_error "Staged file is missing or unsafe: $staged_file"
+        return "$JL_EXIT_VALIDATION"
+    }
+    jl_fs_same_filesystem "$staged_file" "$(dirname "$destination_file")" || {
+        jl_error "File staging is on a different filesystem."
+        return "$JL_EXIT_UNSAFE"
+    }
+
+    backup="$(jl_txn_backup_existing_file "$destination_file")" || return $?
+    status=0
+    jl_txn_fail_if_requested after-file-backup || status=$?
+    if [ "$status" -eq 0 ]; then
+        mv "$staged_file" "$destination_file" || status=$?
+    fi
+    if [ "$status" -eq 0 ]; then
+        jl_txn_fail_if_requested after-file-replacement || status=$?
+    fi
+    if [ "$status" -eq 0 ] && [ "$#" -gt 0 ]; then
+        "$@" || status=$?
+    fi
+
+    if [ "$status" -eq 0 ]; then
+        [ -z "$backup" ] || jl_txn_discard_backup "$backup"
+        return 0
+    fi
+
+    rollback_status=0
+    jl_txn_restore_backup "$backup" "$destination_file" || rollback_status=$?
+    if [ "$rollback_status" -ne 0 ]; then
+        jl_error "File replacement failed and rollback was incomplete: $destination_file"
         return "$JL_EXIT_GENERAL"
     fi
     return "$status"

--- a/tests/installation/test-installation.sh
+++ b/tests/installation/test-installation.sh
@@ -27,6 +27,7 @@ assert_file_exists "$prefix/bin/new-studio"
 assert_file_exists "$prefix/bin/new-client"
 assert_file_exists "$prefix/share/jl-mixing/tools/project-state.py"
 assert_file_exists "$prefix/share/jl-mixing/tools/import-project-source.py"
+assert_file_exists "$prefix/share/jl-mixing/tools/import-revision-source.py"
 assert_file_exists "$prefix/share/jl-mixing/schemas/client-profile-snapshot.schema.json"
 assert_file_exists "$prefix/share/jl-mixing/templates/Intake_Report.md"
 assert_file_exists "$prefix/share/jl-mixing/templates/Revision_Notes.md"
@@ -59,6 +60,15 @@ assert_json_eq "1.1.0" "$installed_manifest" '.metadata.schema_version' \
 assert_dir_exists "$installed_project/03_DAW_Project"
 assert_path_not_exists "$installed_project/03_DAW_Project/Project"
 assert_path_not_exists "$installed_project/05_Final_Delivery/delivery-manifest.json"
+
+PATH="$prefix/bin:$PATH" new-revision --project "$installed_project" \
+    --description "Installed revision" >/dev/null
+assert_file_exists "$installed_project/04_Revisions/Revision_01/Revision_Notes.md"
+assert_path_not_exists "$installed_project/04_Revisions/Revision_01/Prints"
+PATH="$prefix/bin:$PATH" approve-mix --project "$installed_project" \
+    --approved-by Client --date 2030-01-01T12:00:00Z >/dev/null
+assert_json_eq "1" "$installed_manifest" '.state.approved_revision' \
+    "installed approve-mix records v1.1 approval"
 
 # A sentinel in the application directory must disappear during upgrade, while
 # the independent studio workspace remains untouched.

--- a/tests/integration/integration-helper.sh
+++ b/tests/integration/integration-helper.sh
@@ -127,3 +127,48 @@ with wave.open(str(path), "wb") as output:
     output.writeframes(silent_frame * 480)
 PY_WAV
 }
+
+# Create a complete canonical v1.1 project in Setup state without invoking the
+# slower project-creation command. Revision-workflow tests use this fixture to
+# focus on the commands under test while still validating every governing JSON
+# document and standard directory boundary.
+fixture_v11_project() {
+    local studio_root client_root project_root manifest
+    studio_root="$1"
+    client_root="$studio_root/Clients/Acme Records"
+    project_root="$client_root/Projects/Blue Sky"
+
+    mkdir -p \
+        "$studio_root/Studio" \
+        "$client_root/Projects" \
+        "$project_root/00_Admin" \
+        "$project_root/01_Client_Files/Original_Delivery" \
+        "$project_root/01_Client_Files/References" \
+        "$project_root/01_Client_Files/Documentation" \
+        "$project_root/02_Audio_Preparation/Working_Audio" \
+        "$project_root/02_Audio_Preparation/Rejected_Files" \
+        "$project_root/03_DAW_Project" \
+        "$project_root/04_Revisions" \
+        "$project_root/05_Final_Delivery/Stems" \
+        "$project_root/06_Recall/External_Files" \
+        "$project_root/06_Recall/Screenshots"
+
+    jq --arg root "$studio_root" '.root_path=$root' \
+        "$ROOT/examples/studio.json" > "$studio_root/Studio/studio.json"
+    cp "$ROOT/examples/client.json" "$client_root/client.json"
+    cp "$ROOT/examples/client-profile-snapshot.json" \
+        "$project_root/00_Admin/client-profile-snapshot.json"
+    manifest="$project_root/00_Admin/project-manifest.json"
+    jq '.state={current_revision:0,approved_revision:null,delivered_revision:null} |
+        .revisions=[]' "$ROOT/examples/project-manifest.json" > "$manifest"
+
+    cp "$ROOT/templates/Intake_Report.md" "$project_root/00_Admin/Intake_Report.md"
+    cp "$ROOT/templates/Project_Notes.md" "$project_root/00_Admin/Project_Notes.md"
+    cp "$ROOT/templates/Preparation_Report.md" \
+        "$project_root/02_Audio_Preparation/Preparation_Report.md"
+    cp "$ROOT/templates/Delivery_Notes.md" \
+        "$project_root/05_Final_Delivery/Delivery_Notes.md"
+    cp "$ROOT/templates/Recall_Sheet.md" "$project_root/06_Recall/Recall_Sheet.md"
+
+    printf '%s\n' "$project_root"
+}

--- a/tests/integration/test-approve-mix.sh
+++ b/tests/integration/test-approve-mix.sh
@@ -1,23 +1,155 @@
 #!/usr/bin/env bash
 set -eu
 
-# Purpose: Exercise approval and automatic superseding of the prior approval.
+# Purpose: Exercise v1.1 approval, historical metadata, older revisions, and warnings.
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/tests/integration/integration-helper.sh"
 
-# Arrange: build an isolated temporary fixture.
+require_test_command jq
+require_test_command python3
+python3 -c 'import jsonschema' >/dev/null 2>&1 || {
+    if [ "${JL_TEST_STRICT:-0}" = "1" ]; then
+        fail "jsonschema is required for strict approve-mix tests"
+    fi
+    echo "[SKIP] approve-mix integration tests require jsonschema."
+    exit 0
+}
+
 tmp="$(new_test_dir)"
-trap 'rm -rf "$tmp"' EXIT
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 studio_root="$tmp/studio"
-fixture_studio "$studio_root"
-project_root="$(fixture_project "$studio_root" two-revisions)"
+project_root="$(fixture_v11_project "$studio_root")"
 manifest="$project_root/00_Admin/project-manifest.json"
+(cd "$project_root" && "$ROOT/bin/new-revision" --description 'Initial mix' >/dev/null)
+(cd "$project_root" && "$ROOT/bin/new-revision" --description 'Second mix' >/dev/null)
 
-(cd "$project_root/04_Revisions/Revision_02" && "$ROOT/bin/approve-mix" --approved-by Client)
-# Assert: verify observable behavior rather than internal implementation.
-assert_json_eq "2" "$manifest" '.state.approved_revision' "approved revision"
-assert_json_eq "superseded" "$manifest" '.revisions[] | select(.number==1) | .status' "prior approval superseded"
-assert_json_eq "approved" "$manifest" '.revisions[] | select(.number==2) | .status' "selected revision approved"
-assert_json_eq "Client" "$manifest" '.state.approved_by' "approver recorded"
+run_approve() {
+    (cd "$project_root/04_Revisions/Revision_02" && "$ROOT/bin/approve-mix" "$@")
+}
 
-printf '[OK] approve-mix (%s assertions)\n' "$TEST_COUNT"
+# Omitted revision defaults to current; approver defaults to Client.
+output="$(run_approve --date 2030-01-01T12:00:00Z)"
+assert_json_eq "2" "$manifest" '.state.approved_revision' "current revision approved"
+assert_json_eq "2" "$manifest" '.state.current_revision' "current pointer unchanged"
+assert_eq "null" "$(jq -c '.state.delivered_revision' "$manifest")" \
+    "delivered pointer unchanged"
+assert_json_eq "Client" "$manifest" '.revisions[1].approval.approved_by' \
+    "default approver stored"
+assert_json_eq "2030-01-01T12:00:00Z" "$manifest" \
+    '.revisions[1].approval.approved_at' "approval timestamp stored"
+assert_eq "null" "$(jq -c '.revisions[0].approval.approved_at' "$manifest")" \
+    "unselected revision remains unapproved"
+assert_contains "$output" 'Project state:               Approved' "approved state output"
+assert_contains "$output" 'create-delivery' "delivery next step"
+
+# New work preserves the prior approval and returns the project to In progress.
+(cd "$project_root" && "$ROOT/bin/new-revision" --description 'Third mix' >/dev/null)
+assert_json_eq "3" "$manifest" '.state.current_revision' "new revision becomes current"
+assert_json_eq "2" "$manifest" '.state.approved_revision' "prior approval pointer preserved"
+assert_json_eq "Client" "$manifest" '.revisions[1].approval.approved_by' \
+    "historical approval retained after new revision"
+assert_eq "In progress" "$(python3 "$ROOT/tools/project-state.py" derive "$project_root")" \
+    "new work derives In progress"
+
+# Build a structurally valid current delivery for Revision 2 so approval output
+# can verify the explicit replacement warning without relying on create-delivery.
+printf 'mix' > "$project_root/05_Final_Delivery/Blue Sky Main.wav"
+project_document_id="$(jq -r '.metadata.document_id' "$manifest")"
+project_id="$(jq -r '.project_id' "$manifest")"
+project_name="$(jq -r '.project_name' "$manifest")"
+client_document_id="$(jq -r '.client.client_document_id' "$manifest")"
+client_id="$(jq -r '.client.client_id' "$manifest")"
+revision_two_id="$(jq -r '.revisions[1].revision_id' "$manifest")"
+revision_two_description="$(jq -r '.revisions[1].description' "$manifest")"
+revision_two_approval="$(jq -c '.revisions[1].approval' "$manifest")"
+delivery_method="$(jq -r '.delivery.method' "$manifest")"
+jq -n \
+    --arg project_document_id "$project_document_id" \
+    --arg project_id "$project_id" \
+    --arg project_name "$project_name" \
+    --arg client_document_id "$client_document_id" \
+    --arg client_id "$client_id" \
+    --arg revision_id "$revision_two_id" \
+    --arg description "$revision_two_description" \
+    --argjson approval "$revision_two_approval" \
+    --arg method "$delivery_method" \
+    '{
+      metadata:{schema:"mixing-delivery",schema_version:"1.1.0",
+        document_id:"77777777-7777-4777-8777-777777777777",
+        created_with:"jl-mixing 1.1.0",created_at:"2030-01-01T13:00:00Z"},
+      project:{project_document_id:$project_document_id,project_id:$project_id,project_name:$project_name},
+      client:{client_document_id:$client_document_id,client_id:$client_id},
+      revision:{number:2,revision_id:$revision_id,description:$description,approval:$approval},
+      delivery:{method:$method},
+      files:[{path:"Blue Sky Main.wav",deliverable_type:"main_mix",size_bytes:3,
+        sha256:"1111111111111111111111111111111111111111111111111111111111111111"}]
+    }' > "$project_root/05_Final_Delivery/delivery-manifest.json"
+jq '.state.delivered_revision=2' "$manifest" > "$manifest.tmp"
+mv "$manifest.tmp" "$manifest"
+
+# Approving an older revision is valid, retains Revision 2 history, and warns
+# that final delivery still represents another revision.
+output="$(run_approve --revision 1 --approved-by Producer --date 2030-01-02T12:00:00Z)"
+assert_json_eq "1" "$manifest" '.state.approved_revision' "approval moved backward"
+assert_json_eq "Producer" "$manifest" '.revisions[0].approval.approved_by' \
+    "older revision approval stored"
+assert_json_eq "Client" "$manifest" '.revisions[1].approval.approved_by' \
+    "prior revision approval retained historically"
+assert_json_eq "2" "$manifest" '.state.delivered_revision' "delivery pointer preserved"
+assert_contains "$output" 'older than the current working revision' "older-revision notice"
+assert_contains "$output" 'Current final delivery represents Revision 2.' \
+    "delivery replacement warning"
+assert_contains "$output" 'Project state:               In progress' "older approval state"
+
+# Reapproving a previously approved but currently unapproved revision replaces
+# only that revision's approval metadata.
+output="$(run_approve --revision 2 --approved-by Label --date 2030-01-03T12:00:00Z)"
+assert_json_eq "2" "$manifest" '.state.approved_revision' "approval returned to revision two"
+assert_json_eq "Label" "$manifest" '.revisions[1].approval.approved_by' \
+    "revision two approval metadata replaced"
+assert_json_eq "Producer" "$manifest" '.revisions[0].approval.approved_by' \
+    "revision one historical metadata retained"
+case "$output" in
+    *'Current final delivery represents Revision'*) fail "matching delivered revision warned unexpectedly" ;;
+    *) pass "matching delivered revision produces no replacement warning" ;;
+esac
+
+# Already-approved is a no-op error and leaves the manifest byte-identical.
+cp "$manifest" "$tmp/no-op-before.json"
+set +e
+no_op_output="$(run_approve --revision 2 --approved-by SomeoneElse 2>&1)"
+no_op_status=$?
+set -e
+[ "$no_op_status" -ne 0 ] || fail "already-approved revision unexpectedly succeeded"
+pass "already-approved revision rejected"
+assert_contains "$no_op_output" 'already the approved revision' "no-op diagnostic"
+assert_contains "$no_op_output" 'create-delivery' "no-op next guidance"
+assert_same_bytes "$tmp/no-op-before.json" "$manifest"
+
+# Dry-run previews approval without generating or persisting a timestamp.
+dry_output="$(run_approve --revision 3 --dry-run)"
+assert_contains "$dry_output" 'current time at execution' "dry-run timestamp description"
+assert_contains "$dry_output" 'state.approved_revision: 2 → 3' "dry-run pointer change"
+assert_json_eq "2" "$manifest" '.state.approved_revision' "dry-run leaves approval unchanged"
+
+# Validation and removed-option failures make no changes.
+assert_failure "approval date before revision creation rejected" \
+    run_approve --revision 3 --date 2000-01-01T00:00:00Z
+assert_failure "timezone-free approval date rejected" \
+    run_approve --revision 3 --date 2030-01-04T12:00:00
+assert_failure "empty approver rejected" run_approve --revision 3 --approved-by ''
+assert_failure "missing revision rejected" run_approve --revision 99
+assert_failure "removed notes option rejected" run_approve --notes 'Approved'
+assert_failure "removed non-interactive option rejected" run_approve --non-interactive
+assert_json_eq "2" "$manifest" '.state.approved_revision' "validation failures preserve approval"
+
+# Failure after file replacement is rolled back to the exact prior manifest.
+cp "$manifest" "$tmp/rollback-before.json"
+assert_failure "approval transaction failure rolls back" \
+    env JL_MIXING_FAIL_AT=after-file-replacement \
+        JL_MIXING_HOME="$ROOT" JL_MIXING_ROOT="$studio_root" \
+        "$ROOT/bin/approve-mix" --project "$project_root" --revision 3 \
+        --approved-by Client --date 2030-01-05T12:00:00Z
+assert_same_bytes "$tmp/rollback-before.json" "$manifest"
+
+echo "[OK] approve-mix ($TEST_COUNT assertions)"

--- a/tests/integration/test-new-revision.sh
+++ b/tests/integration/test-new-revision.sh
@@ -1,24 +1,141 @@
 #!/usr/bin/env bash
 set -eu
 
-# Purpose: Exercise revision folder/template creation and manifest state.
+# Purpose: Exercise the complete v1.1 revision-creation contract.
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/tests/integration/integration-helper.sh"
+. "$ROOT/lib/project-state.sh"
 
-# Arrange: build an isolated temporary fixture.
+require_test_command jq
+require_test_command python3
+python3 -c 'import jsonschema' >/dev/null 2>&1 || {
+    if [ "${JL_TEST_STRICT:-0}" = "1" ]; then
+        fail "jsonschema is required for strict new-revision tests"
+    fi
+    echo "[SKIP] new-revision integration tests require jsonschema."
+    exit 0
+}
+
 tmp="$(new_test_dir)"
-trap 'rm -rf "$tmp"' EXIT
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 studio_root="$tmp/studio"
-fixture_studio "$studio_root"
-project_root="$(fixture_project "$studio_root" fresh)"
+project_root="$(fixture_v11_project "$studio_root")"
 manifest="$project_root/00_Admin/project-manifest.json"
 
-(cd "$project_root" && "$ROOT/bin/new-revision" --description "Initial mix")
-# Assert: verify observable behavior rather than internal implementation.
-assert_dir_exists "$project_root/04_Revisions/Revision_01/Prints"
-assert_file_exists "$project_root/04_Revisions/Revision_01/Revision_Notes.md"
-assert_json_eq "1" "$manifest" '.state.current_revision' "current revision"
-assert_json_eq "open" "$manifest" '.revisions[0].status' "new revision status"
-assert_json_eq "Initial mix" "$manifest" '.revisions[0].description' "revision description"
+run_revision() {
+    (cd "$project_root" && "$ROOT/bin/new-revision" "$@")
+}
 
-printf '[OK] new-revision (%s assertions)\n' "$TEST_COUNT"
+# Revision 1 uses the initial-mix default and creates no Prints subdirectory.
+output="$(run_revision)"
+revision_one="$project_root/04_Revisions/Revision_01"
+assert_dir_exists "$revision_one"
+assert_file_exists "$revision_one/Revision_Notes.md"
+assert_path_not_exists "$revision_one/Prints"
+assert_contains "$(cat "$revision_one/Revision_Notes.md")" '# Revision 1 Notes' \
+    "revision heading rendered"
+assert_contains "$(cat "$revision_one/Revision_Notes.md")" 'Description: Initial mix' \
+    "initial description rendered"
+assert_json_eq "1" "$manifest" '.state.current_revision' "current revision advanced"
+assert_eq "null" "$(jq -c '.state.approved_revision' "$manifest")" "approved pointer preserved"
+assert_eq "null" "$(jq -c '.state.delivered_revision' "$manifest")" "delivered pointer preserved"
+assert_json_eq "Initial mix" "$manifest" '.revisions[0].description' "default description stored"
+assert_eq "null" "$(jq -c '.revisions[0].approval.approved_at' "$manifest")" \
+    "new revision unapproved"
+assert_eq "false" "$(jq -r '.revisions[0] | has("status") or has("folder") or has("created_by")' "$manifest")" \
+    "legacy revision fields absent"
+assert_contains "$output" 'Revision created successfully.' "success heading"
+assert_contains "$output" 'approve-mix' "next approval command"
+assert_contains "$output" "cd '$revision_one'" "copy-and-paste revision cd"
+assert_eq "In progress" "$(python3 "$ROOT/tools/project-state.py" derive "$project_root")" \
+    "revision creates In progress state"
+
+# Dry-run validates and lists immediate source files without changing state.
+source_dir="$tmp/revision-two-source"
+mkdir "$source_dir"
+printf 'main\n' > "$source_dir/Blue Sky Main.wav"
+printf 'instrumental\n' > "$source_dir/Blue Sky Instrumental.wav"
+dry_output="$(run_revision --description 'Client notes addressed' --source "$source_dir" --dry-run)"
+assert_contains "$dry_output" 'Dry run — no changes made.' "dry-run heading"
+assert_contains "$dry_output" 'Revision_02/Blue Sky Main.wav' "dry-run source file"
+assert_contains "$dry_output" 'state.current_revision: 1 → 2' "dry-run state mutation"
+assert_path_not_exists "$project_root/04_Revisions/Revision_02"
+assert_json_eq "1" "$manifest" '.state.current_revision' "dry-run leaves manifest unchanged"
+
+# Actual source copying preserves basenames directly in the flattened revision.
+cd_result="$tmp/cd-result"
+: > "$cd_result"
+output="$(JL_MIXING_CD_RESULT_FILE="$cd_result" \
+    run_revision --description 'Client notes addressed' --source "$source_dir" --cd)"
+revision_two="$project_root/04_Revisions/Revision_02"
+assert_file_exists "$revision_two/Blue Sky Main.wav"
+assert_file_exists "$revision_two/Blue Sky Instrumental.wav"
+assert_file_exists "$revision_two/Revision_Notes.md"
+assert_path_not_exists "$revision_two/Prints"
+assert_same_bytes "$source_dir/Blue Sky Main.wav" "$revision_two/Blue Sky Main.wav"
+assert_eq "$revision_two" "$(cat "$cd_result")" "private directory result written"
+assert_json_eq "2" "$manifest" '.state.current_revision' "second revision current"
+assert_json_eq "Client notes addressed" "$manifest" '.revisions[1].description' \
+    "explicit description stored"
+assert_eq "superseded" "$(jl_project_revision_status "$manifest" 1)" \
+    "older open revision derived superseded"
+assert_eq "open" "$(jl_project_revision_status "$manifest" 2)" \
+    "new current revision derived open"
+case "$output" in
+    *"cd '$revision_two'"*) fail "result-channel success printed redundant cd command" ;;
+    *) pass "result-channel success omits redundant cd command" ;;
+esac
+
+# Later revisions receive a numbered default description and --no-cd overrides
+# a studio-level automatic-directory preference.
+jq '.cli.change_directory_after_create=true' "$studio_root/Studio/studio.json" \
+    > "$studio_root/Studio/studio.json.tmp"
+mv "$studio_root/Studio/studio.json.tmp" "$studio_root/Studio/studio.json"
+output="$(run_revision --no-cd)"
+revision_three="$project_root/04_Revisions/Revision_03"
+assert_file_exists "$revision_three/Revision_Notes.md"
+assert_json_eq "Revision 3" "$manifest" '.revisions[2].description' \
+    "later default description"
+assert_contains "$output" "cd '$revision_three'" "no-cd prints manual cd"
+
+# Explicit validation failures occur before manifest or filesystem mutation.
+revision_count_before="$(jq -r '.revisions | length' "$manifest")"
+assert_failure "empty explicit description rejected" run_revision --description ''
+assert_failure "explicit cd rejected with dry-run" run_revision --cd --dry-run
+assert_failure "mutually exclusive cd options rejected" run_revision --cd --no-cd
+assert_failure "removed non-interactive option rejected" run_revision --non-interactive
+assert_eq "$revision_count_before" "$(jq -r '.revisions | length' "$manifest")" \
+    "argument failures preserve revision history"
+
+nested_source="$tmp/nested-source"
+mkdir -p "$nested_source/Nested"
+printf nested > "$nested_source/Nested/file.wav"
+assert_failure "nested source directory rejected" run_revision --source "$nested_source"
+
+symlink_source="$tmp/symlink-source"
+mkdir "$symlink_source"
+ln -s "$source_dir/Blue Sky Main.wav" "$symlink_source/linked.wav"
+assert_failure "source symlink rejected" run_revision --source "$symlink_source"
+
+reserved_source="$tmp/reserved-source"
+mkdir "$reserved_source"
+printf notes > "$reserved_source/Revision_Notes.md"
+assert_failure "reserved notes source rejected" run_revision --source "$reserved_source"
+
+# Unexpected canonical revision paths invalidate state rather than being adopted.
+mkdir "$project_root/04_Revisions/Revision_04"
+assert_failure "unrecorded revision directory rejected" run_revision
+rmdir "$project_root/04_Revisions/Revision_04"
+
+# Injected failure after the coordinated directory commit restores both the
+# prior manifest and the absence of the proposed revision directory.
+manifest_before="$tmp/manifest-before.json"
+cp "$manifest" "$manifest_before"
+assert_failure "coordinated commit failure rolls back revision" \
+    env JL_MIXING_FAIL_AT=after-coordinated-directory \
+        JL_MIXING_HOME="$ROOT" JL_MIXING_ROOT="$studio_root" \
+        "$ROOT/bin/new-revision" --project "$project_root" --description 'Rollback revision'
+assert_same_bytes "$manifest_before" "$manifest"
+assert_path_not_exists "$project_root/04_Revisions/Revision_04"
+
+echo "[OK] new-revision ($TEST_COUNT assertions)"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -71,6 +71,7 @@ bin/complete-project
 tools/build-intake-report.py
 tools/project-state.py
 tools/import-project-source.py
+tools/import-revision-source.py
 tools/build-release
 tools/verify-release-archive'
 

--- a/tests/unit/test-import-revision-source.sh
+++ b/tests/unit/test-import-revision-source.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -eu
+
+# Purpose: Verify safe immediate-file planning and copying for new-revision.
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/tests/test-helper.sh"
+require_test_command python3
+
+tmp="$(new_test_dir)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+tool="$ROOT/tools/import-revision-source.py"
+source_dir="$tmp/source"
+destination="$tmp/destination"
+plan="$tmp/plan.json"
+mkdir -p "$source_dir" "$destination"
+printf 'main\n' > "$source_dir/Blue Sky Main.wav"
+printf 'instrumental\n' > "$source_dir/Blue Sky Instrumental.wav"
+
+python3 "$tool" scan "$source_dir" "$plan"
+assert_eq '["Blue Sky Instrumental.wav","Blue Sky Main.wav"]' \
+    "$(jq -c '.files' "$plan")" "deterministic immediate-file plan"
+python3 "$tool" copy "$source_dir" "$destination" "$plan"
+assert_file_exists "$destination/Blue Sky Main.wav"
+assert_file_exists "$destination/Blue Sky Instrumental.wav"
+assert_same_bytes "$source_dir/Blue Sky Main.wav" "$destination/Blue Sky Main.wav"
+
+single_plan="$tmp/single.json"
+single_destination="$tmp/single-destination"
+mkdir "$single_destination"
+python3 "$tool" scan "$source_dir/Blue Sky Main.wav" "$single_plan"
+python3 "$tool" copy "$source_dir/Blue Sky Main.wav" "$single_destination" "$single_plan"
+assert_file_exists "$single_destination/Blue Sky Main.wav"
+
+mkdir "$source_dir/Nested"
+assert_failure "nested source directories rejected" python3 "$tool" scan "$source_dir" "$plan"
+rmdir "$source_dir/Nested"
+ln -s "$source_dir/Blue Sky Main.wav" "$source_dir/link.wav"
+assert_failure "source symlinks rejected" python3 "$tool" scan "$source_dir" "$plan"
+rm "$source_dir/link.wav"
+printf 'reserved\n' > "$source_dir/Revision_Notes.md"
+assert_failure "reserved notes filename rejected" python3 "$tool" scan "$source_dir" "$plan"
+rm "$source_dir/Revision_Notes.md"
+
+case_dir="$tmp/case-source"
+mkdir "$case_dir"
+printf A > "$case_dir/Print.wav"
+printf B > "$case_dir/print.wav" 2>/dev/null || true
+if [ -f "$case_dir/Print.wav" ] && [ -f "$case_dir/print.wav" ] && \
+   [ "$(cat "$case_dir/Print.wav")" != "$(cat "$case_dir/print.wav")" ]; then
+    assert_failure "case-insensitive file collisions rejected" \
+        python3 "$tool" scan "$case_dir" "$tmp/case-plan.json"
+else
+    pass "case-insensitive fixture unavailable on this filesystem"
+fi
+
+# A changed source plan is rejected before any copy occurs.
+change_source="$tmp/change-source"
+change_destination="$tmp/change-destination"
+mkdir "$change_source" "$change_destination"
+printf first > "$change_source/First.wav"
+python3 "$tool" scan "$change_source" "$tmp/change-plan.json"
+printf second > "$change_source/Second.wav"
+assert_failure "changed source rejected during copy" \
+    python3 "$tool" copy "$change_source" "$change_destination" "$tmp/change-plan.json"
+if find "$change_destination" -mindepth 1 -print -quit | grep -q .; then
+    fail "changed-source copy left destination content"
+fi
+pass "changed-source copy leaves destination empty"
+
+echo "[OK] import-revision-source.py ($TEST_COUNT assertions)"

--- a/tests/unit/test-project-state.sh
+++ b/tests/unit/test-project-state.sh
@@ -141,6 +141,16 @@ assert_eq "In progress" "$(jl_project_state_derive "$project")" "newer work retu
 assert_eq "approved" "$(jl_project_revision_status "$manifest" 1)" "older approved revision remains approved"
 assert_eq "open" "$(jl_project_revision_status "$manifest" 2)" "new current revision is open"
 
+# Delivery approval is an immutable package-time snapshot. Reapproving the same
+# delivered revision may replace the project record without rewriting the
+# existing delivery manifest.
+jq '.revisions[0].approval = {approved_at:"2026-07-17T12:00:00Z", approved_by:"Label"}' \
+    "$manifest" > "$tmp/reapproved.json"
+mv "$tmp/reapproved.json" "$manifest"
+assert_eq "In progress" "$(jl_project_state_derive "$project")" \
+    "delivery approval snapshot may differ after reapproval"
+write_manifest "$revision_two" 2 1 1
+
 # Invalid state fixtures fail without silently repairing records or directories.
 jq '.revisions[1].number = 3' "$manifest" > "$tmp/noncontiguous.json"
 assert_failure "noncontiguous revisions rejected" \

--- a/tests/unit/test-revision.sh
+++ b/tests/unit/test-revision.sh
@@ -1,27 +1,56 @@
 #!/usr/bin/env bash
 set -eu
 
-# Purpose: Verify revision numbering, append behavior, approval, and superseding.
+# Purpose: Verify canonical v1.1 revision records and pointer mutations.
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/tests/test-helper.sh"
 require_test_command jq
 . "$ROOT/lib/revision.sh"
 
-# Arrange: build an isolated temporary fixture.
+# Arrange: build a canonical v1.1 manifest with one unapproved revision.
 tmp="$(new_test_dir)"
-trap 'rm -rf "$tmp"' EXIT
-cp "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" "$tmp/project.json"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+manifest="$tmp/project.json"
+jq '.state={current_revision:1,approved_revision:null,delivered_revision:null} |
+    .revisions=[.revisions[0] | .approval={approved_at:null,approved_by:null}]' \
+    "$ROOT/examples/project-manifest.json" > "$manifest"
 
-# Assert: verify observable behavior rather than internal implementation.
-assert_eq "2" "$(jl_revision_next_number "$tmp/project.json")" "next revision number"
-record="$(jl_revision_create_record 2 'Vocal changes' 66666666-6666-4666-8666-666666666666 2026-07-19T12:00:00Z)"
-assert_eq "open" "$(printf '%s' "$record" | jq -r '.status')" "new record status"
-assert_eq "04_Revisions/Revision_02" "$(printf '%s' "$record" | jq -r '.folder')" "new record folder"
-jl_revision_append "$tmp/project.json" 'Vocal changes' 2 2026-07-19T12:00:00Z 66666666-6666-4666-8666-666666666666
-assert_eq "2" "$(jl_revision_current "$tmp/project.json")" "append updates current revision"
-assert_eq "open" "$(jl_revision_status "$tmp/project.json" 2)" "appended revision is open"
-jl_revision_approve "$tmp/project.json" 2 Client 2026-07-20T12:00:00Z
-assert_eq "approved" "$(jl_revision_status "$tmp/project.json" 2)" "selected revision approved"
-assert_eq "superseded" "$(jl_revision_status "$tmp/project.json" 1)" "prior approval superseded"
-assert_eq "2" "$(jl_json_get "$tmp/project.json" '.state.approved_revision')" "approved revision state"
+assert_eq "2" "$(jl_revision_next_number "$manifest")" "next revision follows current pointer"
+record="$(jl_revision_create_record \
+    2 'Vocal changes' 66666666-6666-4666-8666-666666666666 2026-07-19T12:00:00Z)"
+assert_eq "2" "$(printf '%s' "$record" | jq -r '.number')" "record number"
+assert_eq "Vocal changes" "$(printf '%s' "$record" | jq -r '.description')" "record description"
+assert_eq "null" "$(printf '%s' "$record" | jq -c '.approval.approved_at')" "new approval timestamp null"
+assert_eq "null" "$(printf '%s' "$record" | jq -c '.approval.approved_by')" "new approver null"
+assert_eq "false" "$(printf '%s' "$record" | jq -r 'has("status") or has("folder") or has("created_by")')" \
+    "legacy revision fields absent"
+
+jl_revision_append "$manifest" 'Vocal changes' 2 \
+    2026-07-19T12:00:00Z 66666666-6666-4666-8666-666666666666
+assert_eq "2" "$(jl_revision_current "$manifest")" "append updates current revision"
+assert_eq "null" "$(jq -c '.state.approved_revision' "$manifest")" "append preserves approved pointer"
+assert_eq "null" "$(jq -c '.state.delivered_revision' "$manifest")" "append preserves delivered pointer"
+assert_eq "open" "$(jl_revision_status "$manifest" 2)" "appended revision is open"
+assert_eq "superseded" "$(jl_revision_status "$manifest" 1)" "older unapproved revision is superseded"
+
+jl_revision_approve "$manifest" 2 Client 2026-07-20T12:00:00Z
+assert_eq "approved" "$(jl_revision_status "$manifest" 2)" "selected revision approved"
+assert_eq "2" "$(jl_json_get "$manifest" '.state.approved_revision')" "approved pointer"
+assert_eq "Client" "$(jq -r '.revisions[1].approval.approved_by' "$manifest")" "approver stored on revision"
+assert_eq "null" "$(jq -c '.state.delivered_revision' "$manifest")" "approval preserves delivery pointer"
+
+# Moving approval retains historical metadata on the previously approved record.
+jl_revision_approve "$manifest" 1 Producer 2026-07-21T12:00:00Z
+assert_eq "1" "$(jl_json_get "$manifest" '.state.approved_revision')" "approval pointer moved backward"
+assert_eq "Producer" "$(jq -r '.revisions[0].approval.approved_by' "$manifest")" "older revision approved"
+assert_eq "Client" "$(jq -r '.revisions[1].approval.approved_by' "$manifest")" \
+    "historical approval retained"
+assert_failure "approving current approved revision is rejected" \
+    jl_revision_approve "$manifest" 1 Client 2026-07-22T12:00:00Z
+
+# Temporary legacy read compatibility remains until create-delivery is migrated.
+legacy="$tmp/legacy.json"
+cp "$ROOT/tests/fixtures/legacy-v1.0.4/project-manifest.json" "$legacy"
+assert_eq "approved" "$(jl_revision_status "$legacy" 1)" "legacy stored status remains readable"
+
 echo "[OK] revision.sh ($TEST_COUNT assertions)"

--- a/tests/unit/test-transaction.sh
+++ b/tests/unit/test-transaction.sh
@@ -70,4 +70,35 @@ assert_file_exists "$tmp/project/05_Final_Delivery/stable.txt"
 assert_contains "$(cat "$tmp/project/00_Admin/project-manifest.json")" '"stable":true' \
     "coordinated rollback restored manifest"
 
+
+# Optional committed-state verification runs before backups are discarded.
+printf 'verified-old delivery' > "$tmp/project/05_Final_Delivery/value.txt"
+printf '{"verified_old":true}
+' > "$tmp/project/00_Admin/project-manifest.json"
+stage_dir="$(jl_txn_stage_directory_near "$tmp/project/05_Final_Delivery")"
+printf 'verified-new delivery' > "$stage_dir/value.txt"
+stage_file="$(jl_mktemp_file_near "$tmp/project/00_Admin/project-manifest.json")"
+printf '{"verified_new":true}
+' > "$stage_file"
+assert_failure "coordinated verifier failure rolls back both targets"     jl_txn_commit_directory_and_file         "$stage_dir" "$tmp/project/05_Final_Delivery"         "$stage_file" "$tmp/project/00_Admin/project-manifest.json" false
+assert_eq "verified-old delivery"     "$(cat "$tmp/project/05_Final_Delivery/value.txt")"     "verifier rollback restored directory"
+assert_contains "$(cat "$tmp/project/00_Admin/project-manifest.json")"     '"verified_old":true' "verifier rollback restored file"
+
+# File-only replacement supports the same rollback-capable verification flow.
+printf 'old file
+' > "$tmp/project/00_Admin/file-only.json"
+stage_file="$(jl_mktemp_file_near "$tmp/project/00_Admin/file-only.json")"
+printf 'new file
+' > "$stage_file"
+jl_txn_replace_file "$stage_file" "$tmp/project/00_Admin/file-only.json" true
+assert_eq "new file" "$(cat "$tmp/project/00_Admin/file-only.json")"     "file-only transaction committed"
+
+printf 'stable file
+' > "$tmp/project/00_Admin/file-only.json"
+stage_file="$(jl_mktemp_file_near "$tmp/project/00_Admin/file-only.json")"
+printf 'bad file
+' > "$stage_file"
+assert_failure "file verifier failure rolls back replacement"     jl_txn_replace_file "$stage_file" "$tmp/project/00_Admin/file-only.json" false
+assert_eq "stable file" "$(cat "$tmp/project/00_Admin/file-only.json")"     "file-only rollback restored prior content"
+
 echo "[OK] transaction.sh ($TEST_COUNT assertions)"

--- a/tools/build-release
+++ b/tools/build-release
@@ -80,13 +80,14 @@ cp -R "$ROOT/bin" "$ROOT/lib" "$ROOT/schemas" "$ROOT/templates" "$ROOT/docs" "$p
 mkdir -p "$package_root/tools" "$package_root/packaging"
 cp "$ROOT/tools/validate-json.py" "$ROOT/tools/build-intake-report.py" \
     "$ROOT/tools/project-state.py" "$ROOT/tools/import-project-source.py" \
-    "$package_root/tools/"
+    "$ROOT/tools/import-revision-source.py" "$package_root/tools/"
 cp "$ROOT/packaging/requirements.txt" "$package_root/packaging/"
 
 chmod +x "$package_root/install.sh" "$package_root/uninstall.sh" "$package_root/bin/"* \
     "$package_root/tools/validate-json.py" "$package_root/tools/build-intake-report.py" \
     "$package_root/tools/project-state.py" \
-    "$package_root/tools/import-project-source.py"
+    "$package_root/tools/import-project-source.py" \
+    "$package_root/tools/import-revision-source.py"
 
 # Record the exact release contents for human review and archive verification.
 (

--- a/tools/import-revision-source.py
+++ b/tools/import-revision-source.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Safely plan and copy immediate files into a new revision directory.
+
+The helper never follows symbolic links. A directory source may contain only
+immediate regular files; nested directories and special filesystem objects are
+rejected. The exact planned filenames are rescanned before copying so a changed
+source cannot silently alter the committed revision.
+"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser, Namespace
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+from typing import Any
+
+VALIDATION_ERROR = 5
+RESERVED_NAME = "revision_notes.md"
+
+
+def parser() -> ArgumentParser:
+    result = ArgumentParser(description=__doc__)
+    subcommands = result.add_subparsers(dest="command", required=True)
+
+    scan = subcommands.add_parser("scan", help="validate a source and write a plan")
+    scan.add_argument("source", type=Path)
+    scan.add_argument("plan", type=Path)
+
+    copy = subcommands.add_parser("copy", help="copy a previously scanned source")
+    copy.add_argument("source", type=Path)
+    copy.add_argument("destination", type=Path)
+    copy.add_argument("plan", type=Path)
+    return result
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(VALIDATION_ERROR)
+
+
+def classify(path: Path) -> str:
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        fail(f"Unable to inspect revision source {path}: {error}")
+    if stat.S_ISLNK(mode):
+        fail(f"Symbolic links are not allowed in revision sources: {path}")
+    if stat.S_ISREG(mode):
+        return "file"
+    if stat.S_ISDIR(mode):
+        return "directory"
+    fail(f"Unsupported revision source filesystem object: {path}")
+    raise AssertionError("unreachable")
+
+
+def validate_name(name: str, path: Path) -> None:
+    if not name or name in {".", ".."}:
+        fail(f"Unsafe revision source name: {path}")
+    if any(ord(character) < 32 or ord(character) == 127 for character in name):
+        fail(f"Control characters are not allowed in revision source names: {path}")
+    if name.casefold() == RESERVED_NAME:
+        fail(f"Revision source may not replace Revision_Notes.md: {path}")
+
+
+def build_plan(source: Path) -> dict[str, Any]:
+    source_type = classify(source)
+    names: list[str] = []
+    seen: dict[str, str] = {RESERVED_NAME: "Revision_Notes.md"}
+
+    def add_file(path: Path) -> None:
+        validate_name(path.name, path)
+        key = path.name.casefold()
+        if key in seen:
+            fail(
+                "Case-insensitive revision destination collision: "
+                f"{seen[key]!r} and {path.name!r}"
+            )
+        seen[key] = path.name
+        names.append(path.name)
+
+    if source_type == "file":
+        add_file(source)
+    else:
+        try:
+            children = sorted(
+                os.scandir(source), key=lambda item: (item.name.casefold(), item.name)
+            )
+        except OSError as error:
+            fail(f"Unable to read revision source directory {source}: {error}")
+        for child in children:
+            child_path = Path(child.path)
+            entry_type = classify(child_path)
+            if entry_type == "directory":
+                fail(f"Nested directories are not allowed in revision sources: {child_path}")
+            add_file(child_path)
+
+    names.sort(key=lambda value: (value.casefold(), value))
+    return {"source_type": source_type, "source": str(source), "files": names}
+
+
+def write_plan(source: Path, plan_path: Path) -> None:
+    plan_path.write_text(
+        json.dumps(build_plan(source), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def copy_from_plan(source: Path, destination: Path, plan_path: Path) -> None:
+    try:
+        expected = json.loads(plan_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        fail(f"Unable to read revision source plan {plan_path}: {error}")
+    current = build_plan(source)
+    if current.get("source_type") != expected.get("source_type") or current.get(
+        "files"
+    ) != expected.get("files"):
+        fail("Revision source changed after preflight; no revision was created.")
+
+    if destination.is_symlink() or not destination.is_dir():
+        fail(f"Revision destination is missing or unsafe: {destination}")
+    if any(destination.iterdir()):
+        fail(f"Revision destination must be empty before source copying: {destination}")
+
+    for name in current["files"]:
+        source_file = source if current["source_type"] == "file" else source / name
+        destination_file = destination / name
+        shutil.copy2(source_file, destination_file, follow_symlinks=False)
+
+
+def main(args: Namespace) -> int:
+    if args.command == "scan":
+        write_plan(args.source, args.plan)
+    else:
+        copy_from_plan(args.source, args.destination, args.plan)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(parser().parse_args()))

--- a/tools/project-state.py
+++ b/tools/project-state.py
@@ -184,7 +184,10 @@ def validate_delivery(project_root: Path, project: dict[str, Any]) -> None:
         (delivery.get("revision", {}).get("number"), delivered, "delivered revision number"),
         (delivery.get("revision", {}).get("revision_id"), revision.get("revision_id"), "revision ID"),
         (delivery.get("revision", {}).get("description"), revision.get("description"), "revision description"),
-        (delivery.get("revision", {}).get("approval"), revision.get("approval"), "revision approval"),
+        # Approval is an immutable package-time snapshot. A later reapproval of
+        # the same revision replaces the project record but must not rewrite or
+        # invalidate an existing delivery manifest. Its non-null structure is
+        # enforced by the delivery schema.
         (delivery.get("delivery", {}).get("method"), project.get("delivery", {}).get("method"), "delivery method"),
     ]
     for actual, expected, label in checks:

--- a/tools/validate-json.py
+++ b/tools/validate-json.py
@@ -19,8 +19,8 @@ def parser() -> ArgumentParser:
     result = ArgumentParser(
         description="Validate JL Mixing JSON examples or one explicit document."
     )
-    result.add_argument("--schema", type=Path)
-    result.add_argument("--document", type=Path)
+    result.add_argument("--schema", type=Path, action="append")
+    result.add_argument("--document", type=Path, action="append")
     result.add_argument(
         "--strict",
         action="store_true",
@@ -142,8 +142,10 @@ def validate_rejections(pairs: Iterable[ValidationPair]) -> bool:
 def main() -> int:
     args = parser().parse_args()
     root = Path(__file__).resolve().parent.parent
-    if bool(args.schema) != bool(args.document):
-        print("--schema and --document must be supplied together.", file=sys.stderr)
+    schemas = args.schema or []
+    documents = args.document or []
+    if len(schemas) != len(documents):
+        print("--schema and --document must be supplied in matching pairs.", file=sys.stderr)
         return 2
 
     try:
@@ -160,8 +162,8 @@ def main() -> int:
         )
         return 0
 
-    if args.schema and args.document:
-        return 0 if validate_pairs([(args.schema, args.document)]) else 1
+    if schemas:
+        return 0 if validate_pairs(zip(schemas, documents)) else 1
 
     positive_ok = validate_pairs(default_pairs(root))
     negative_ok = validate_rejections(negative_pairs(root))

--- a/tools/verify-release-archive
+++ b/tools/verify-release-archive
@@ -29,7 +29,7 @@ done
 
 for required in install.sh uninstall.sh VERSION LICENSE README.md RELEASE_MANIFEST.txt \
     bin lib schemas templates docs tools/validate-json.py tools/build-intake-report.py tools/project-state.py \
-    tools/import-project-source.py packaging/requirements.txt; do
+    tools/import-project-source.py tools/import-revision-source.py packaging/requirements.txt; do
     [ -e "$package_root/$required" ] || {
         echo "Missing release content: $required" >&2
         exit 5


### PR DESCRIPTION
Migrates new-revision to the v1.1 project model
Migrates approve-mix to the v1.1 approval model
Contiguous revision numbering and flattened revision directories
User-owned revision notes with resolved number and description
Safe optional source-file copying
Approval of current or older revisions
Historical approval preservation and reapproval handling
Immutable delivery-manifest approval snapshots
Transactional directory and manifest commits with rollback
--cd and --no-cd support for new-revision
Dry-run and workflow Next: guidance
Installed-runtime and release-package integration