### PR TITLE
feat: migrate validate-intake to v1.1

### DIFF
--- a/bin/validate-intake
+++ b/bin/validate-intake
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# Inventory and validate the immutable client-delivery source.
+# Inventory and validate the immutable client-delivery source for a v1.1 project.
 #
-# A Python helper builds the machine-managed Markdown section. This wrapper
-# preserves engineer notes and never modifies files in Original_Delivery.
+# This command preserves the v1.0.4 inspection boundary. It adapts context,
+# report organization, dry-run/output, and compatibility diagnostics without
+# adding broader audio QC.
 set -eu
 
-# Resolve the installation root from this launcher. Installed wrappers may
-# override it with JL_MIXING_HOME.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="${JL_MIXING_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-# Load shared services; command files intentionally keep reusable logic in lib/.
+# shellcheck source=lib/common.sh
 . "$APP_ROOT/lib/common.sh"
+# shellcheck source=lib/context.sh
 . "$APP_ROOT/lib/context.sh"
+# shellcheck source=lib/filesystem.sh
 . "$APP_ROOT/lib/filesystem.sh"
+# shellcheck source=lib/json.sh
 . "$APP_ROOT/lib/json.sh"
+# shellcheck source=lib/platform.sh
 . "$APP_ROOT/lib/platform.sh"
+# shellcheck source=lib/templates.sh
 . "$APP_ROOT/lib/templates.sh"
+# shellcheck source=lib/validation.sh
 . "$APP_ROOT/lib/validation.sh"
 
-# Print command syntax and supported options, then return to the caller.
 usage() {
     cat <<'USAGE'
 Usage: validate-intake [options]
@@ -26,14 +30,26 @@ Usage: validate-intake [options]
 Options:
   --project PATH             Explicit project path
   --source PATH              Intake source directory
-  --report-only              Validate and report without other actions
   --expected-sample-rate HZ  Override expected sample rate
   --expected-bit-depth BITS  Override expected bit depth
   --no-duplicate-check       Skip duplicate-basename detection
-  --non-interactive          Accepted for command consistency
-  --dry-run                  Build a temporary report without updating the project
+  --dry-run                  Build and print a temporary report
   -h, --help                 Show this help
 USAGE
+}
+
+removed_option_error() {
+    case "$1" in
+        --report-only)
+            jl_error "--report-only was removed in JL Mixing 1.1."
+            jl_error "validate-intake is always report-only and never modifies intake source files."
+            ;;
+        --non-interactive)
+            jl_error "--non-interactive was removed in JL Mixing 1.1."
+            jl_error "validate-intake does not prompt for input."
+            ;;
+    esac
+    return "$JL_EXIT_ARGUMENTS"
 }
 
 project_ref=""
@@ -43,72 +59,142 @@ expected_bit_depth=""
 no_duplicate_check=0
 dry_run=0
 
-# Parse options explicitly so unknown or missing arguments fail predictably.
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --project) [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS"; project_ref="$2"; shift 2 ;;
-        --source) [ "$#" -ge 2 ] || jl_die "--source requires a value." "$JL_EXIT_ARGUMENTS"; source_path="$2"; shift 2 ;;
-        --report-only|--non-interactive) shift ;;
-        --expected-sample-rate) [ "$#" -ge 2 ] || jl_die "--expected-sample-rate requires a value." "$JL_EXIT_ARGUMENTS"; expected_sample_rate="$2"; shift 2 ;;
-        --expected-bit-depth) [ "$#" -ge 2 ] || jl_die "--expected-bit-depth requires a value." "$JL_EXIT_ARGUMENTS"; expected_bit_depth="$2"; shift 2 ;;
+        --project)
+            [ "$#" -ge 2 ] || jl_die "--project requires a value." "$JL_EXIT_ARGUMENTS"
+            project_ref="$2"; shift 2
+            ;;
+        --source)
+            [ "$#" -ge 2 ] || jl_die "--source requires a value." "$JL_EXIT_ARGUMENTS"
+            source_path="$2"; shift 2
+            ;;
+        --expected-sample-rate)
+            [ "$#" -ge 2 ] || jl_die "--expected-sample-rate requires a value." "$JL_EXIT_ARGUMENTS"
+            expected_sample_rate="$2"; shift 2
+            ;;
+        --expected-bit-depth)
+            [ "$#" -ge 2 ] || jl_die "--expected-bit-depth requires a value." "$JL_EXIT_ARGUMENTS"
+            expected_bit_depth="$2"; shift 2
+            ;;
         --no-duplicate-check) no_duplicate_check=1; shift ;;
         --dry-run) dry_run=1; shift ;;
+        --report-only|--non-interactive) removed_option_error "$1"; exit $? ;;
         -h|--help) usage; exit 0 ;;
-        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS"; exit $? ;;
+        *) jl_die "Unknown option: $1" "$JL_EXIT_ARGUMENTS" ;;
     esac
 done
 
-# Resolve the project and expected format before scanning the source tree.
-project_root="$(jl_context_resolve_project "$project_ref" "$PWD")" || exit $?
+# Require a complete, internally consistent v1.1 project before scanning.
+project_root="$(jl_context_resolve_project_v11 "$project_ref" "$PWD")" || exit $?
+jl_context_validate_project_v11 "$project_root" || exit $?
 manifest="$project_root/00_Admin/project-manifest.json"
 report="$project_root/00_Admin/Intake_Report.md"
-[ -n "$source_path" ] || source_path="$project_root/01_Client_Files/Original_Delivery"
-source_path="$(jl_abspath_allow_missing "$source_path")"
+project_name="$(jl_json_get "$manifest" '.project_name')" || exit $?
 
-[ -d "$source_path" ] || { jl_error "Intake source directory not found: $source_path"; exit "$JL_EXIT_VALIDATION"; }
+[ -n "$source_path" ] || source_path="$project_root/01_Client_Files/Original_Delivery"
+source_path="$(jl_abspath_allow_missing "$source_path")" || exit $?
+if ! jl_fs_is_directory_no_symlink "$source_path"; then
+    jl_error "Intake source directory not found or unsafe: $source_path"
+    exit "$JL_EXIT_VALIDATION"
+fi
+
 [ -n "$expected_sample_rate" ] || expected_sample_rate="$(jl_json_get "$manifest" '.audio.sample_rate')"
 [ -n "$expected_bit_depth" ] || expected_bit_depth="$(jl_json_get "$manifest" '.audio.bit_depth')"
-jl_validate_sample_rate "$expected_sample_rate" || { jl_error "Unsupported expected sample rate: $expected_sample_rate"; exit "$JL_EXIT_VALIDATION"; }
-jl_validate_bit_depth "$expected_bit_depth" || { jl_error "Unsupported expected bit depth: $expected_bit_depth"; exit "$JL_EXIT_VALIDATION"; }
+jl_validate_sample_rate "$expected_sample_rate" || {
+    jl_error "Unsupported expected sample rate: $expected_sample_rate"
+    exit "$JL_EXIT_VALIDATION"
+}
+jl_validate_bit_depth "$expected_bit_depth" || {
+    jl_error "Unsupported expected bit depth: $expected_bit_depth"
+    exit "$JL_EXIT_VALIDATION"
+}
 
-# Generate the automated section in a temporary sibling file for safe replacement.
-replacement="$(jl_mktemp_file_near "$report")"
-cleanup_report() { rm -f "$replacement"; }
+# Normal mode must be able to replace exactly one managed region. Dry-run needs
+# only the report file because it never attempts replacement or marker repair.
+if ! jl_fs_is_regular_file_no_symlink "$report"; then
+    jl_error "Intake report not found or unsafe: $report"
+    exit "$JL_EXIT_VALIDATION"
+fi
+if [ "$dry_run" -eq 0 ]; then
+    jl_markdown_validate_managed_section \
+        "$report" \
+        '<!-- BEGIN AUTOMATED SECTION -->' \
+        '<!-- END AUTOMATED SECTION -->' || exit $?
+fi
+
+replacement="$(jl_mktemp_file_near "$report")" || exit $?
+summary="$(jl_mktemp_file_near "$report")" || {
+    rm -f "$replacement"
+    exit $?
+}
+cleanup_report() { rm -f "$replacement" "$summary"; }
 trap cleanup_report EXIT HUP INT TERM
 
-# Build the Python helper argument vector without eval or string re-parsing.
 set -- \
     --source "$source_path" \
     --output "$replacement" \
+    --summary-output "$summary" \
     --expected-sample-rate "$expected_sample_rate" \
     --expected-bit-depth "$expected_bit_depth"
 if [ "$no_duplicate_check" -eq 1 ]; then
     set -- "$@" --no-duplicate-check
 fi
 
-# Use the same private/runtime Python selected for JSON Schema validation so
-# installed users never need to activate or configure the application venv.
 python_command="$(jl_json_validator_python)" || {
     jl_error "Python 3 is required for intake reporting."
     exit "$JL_EXIT_CONFIG"
 }
 
-# Preserve the validator result while still updating the report with discovered issues.
 validation_status=0
 "$python_command" "$APP_ROOT/tools/build-intake-report.py" "$@" || validation_status=$?
+case "$validation_status" in
+    0|"$JL_EXIT_VALIDATION") ;;
+    *)
+        jl_error "Intake report generation failed."
+        exit "$validation_status"
+        ;;
+esac
 
-# Dry-run prints generated Markdown; normal mode replaces only the marked section.
-if [ "$dry_run" -eq 1 ]; then
-    cat "$replacement"
-else
-    jl_markdown_replace_managed_section \
-        "$report" \
-        '<!-- BEGIN AUTOMATED SECTION -->' \
-        '<!-- END AUTOMATED SECTION -->' \
-        "$replacement"
-    printf 'Updated intake report: %s\n' "$report"
+if [ ! -s "$replacement" ] || [ ! -s "$summary" ]; then
+    jl_error "Intake report generation did not produce complete output."
+    exit "$JL_EXIT_GENERAL"
 fi
 
-rm -f "$replacement"
-trap - EXIT HUP INT TERM
+if [ "$dry_run" -eq 1 ]; then
+    cat "$replacement"
+    exit "$validation_status"
+fi
+
+# A completed scan always updates the report, even when blocking findings cause
+# the command to return validation status 5.
+jl_markdown_replace_managed_section \
+    "$report" \
+    '<!-- BEGIN AUTOMATED SECTION -->' \
+    '<!-- END AUTOMATED SECTION -->' \
+    "$replacement" || exit $?
+
+files_discovered="$(jq -er '.files_discovered' "$summary")" || exit "$JL_EXIT_GENERAL"
+blocking_errors="$(jq -er '.blocking_errors' "$summary")" || exit "$JL_EXIT_GENERAL"
+warning_count="$(jq -er '.warnings' "$summary")" || exit "$JL_EXIT_GENERAL"
+
+if [ "$validation_status" -eq 0 ]; then
+    printf 'Intake validation completed.\n\n'
+else
+    printf 'Intake validation completed with blocking errors.\n\n'
+fi
+printf 'Project:         %s\n' "$project_name"
+printf 'Source:          %s\n' "$source_path"
+printf 'Files inspected: %s\n' "$files_discovered"
+printf 'Blocking errors: %s\n' "$blocking_errors"
+printf 'Warnings:        %s\n' "$warning_count"
+printf 'Report:          %s\n' "$report"
+printf '\nNext:\n'
+if [ "$validation_status" -eq 0 ]; then
+    printf '  Review 00_Admin/Intake_Report.md\n'
+    printf '  Prepare accepted audio in 02_Audio_Preparation/Working_Audio/\n'
+else
+    printf '  Review and resolve the critical errors in 00_Admin/Intake_Report.md\n'
+fi
+
 exit "$validation_status"

--- a/tests/installation/test-installation.sh
+++ b/tests/installation/test-installation.sh
@@ -61,6 +61,12 @@ assert_dir_exists "$installed_project/03_DAW_Project"
 assert_path_not_exists "$installed_project/03_DAW_Project/Project"
 assert_path_not_exists "$installed_project/05_Final_Delivery/delivery-manifest.json"
 
+printf 'installed notes\n' > "$installed_project/01_Client_Files/Original_Delivery/Notes.txt"
+PATH="$prefix/bin:$PATH" validate-intake --project "$installed_project" >/dev/null
+assert_contains "$(cat "$installed_project/00_Admin/Intake_Report.md")" \
+    "## Unsupported or Non-Audio Files" \
+    "installed validate-intake updates the v1.1 managed report"
+
 PATH="$prefix/bin:$PATH" new-revision --project "$installed_project" \
     --description "Installed revision" >/dev/null
 assert_file_exists "$installed_project/04_Revisions/Revision_01/Revision_Notes.md"

--- a/tests/integration/test-validate-intake-errors.sh
+++ b/tests/integration/test-validate-intake-errors.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -eu
+
+# Purpose: Verify blocking intake findings still update the managed report.
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/tests/integration/integration-helper.sh"
+
+tmp="$(new_test_dir)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+fake_bin="$tmp/fake-bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/ffprobe" <<'FFPROBE'
+#!/usr/bin/env bash
+printf 'invalid data found when processing input\n' >&2
+exit 1
+FFPROBE
+chmod +x "$fake_bin/ffprobe"
+
+project_root="$(fixture_v11_project "$tmp/studio")"
+report="$project_root/00_Admin/Intake_Report.md"
+printf 'bad\n' > "$project_root/01_Client_Files/Original_Delivery/Bad.wav"
+
+set +e
+PATH="$fake_bin:$PATH" "$ROOT/bin/validate-intake" --project "$project_root" \
+    >"$tmp/output" 2>&1
+status=$?
+set -e
+assert_eq "5" "$status" "unreadable candidate audio remains blocking"
+report_text="$(cat "$report")"
+command_text="$(cat "$tmp/output")"
+assert_contains "$report_text" 'Unreadable audio file `Bad.wav`' "blocking error is written to report"
+assert_contains "$report_text" "not readable" "unreadable inventory status is clear"
+assert_contains "$command_text" "completed with blocking errors" "blocking summary is truthful"
+assert_contains "$command_text" "Review and resolve the critical errors" "blocking next step is printed"
+
+printf '[OK] validate-intake blocking findings (%s assertions)\n' "$TEST_COUNT"

--- a/tests/integration/test-validate-intake.sh
+++ b/tests/integration/test-validate-intake.sh
@@ -1,31 +1,140 @@
 #!/usr/bin/env bash
 set -eu
 
-# Purpose: Exercise source inventory generation while preserving engineer notes.
+# Purpose: Verify the v1.1 command contract while preserving v1.0.4 intake QC.
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/tests/integration/integration-helper.sh"
 
-# Arrange: build an isolated temporary fixture.
+make_fake_ffprobe() {
+    local bin_dir
+    bin_dir="$1"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/ffprobe" <<'FFPROBE'
+#!/usr/bin/env bash
+set -eu
+path=""
+for argument in "$@"; do path="$argument"; done
+case "$path" in
+    *Bad.wav)
+        printf 'invalid data found when processing input\n' >&2
+        exit 1
+        ;;
+    *Lead\ Vocal.wav)
+        printf '%s\n' '{"streams":[{"sample_rate":"44100","bits_per_raw_sample":"16","channels":2}],"format":{"duration":"123.45"}}'
+        ;;
+    *)
+        printf '%s\n' '{"streams":[{"sample_rate":"48000","bits_per_raw_sample":"24","channels":2}],"format":{"duration":"2.00"}}'
+        ;;
+esac
+FFPROBE
+    chmod +x "$bin_dir/ffprobe"
+}
+
+run_capture() {
+    local output_file status_file
+    output_file="$1"
+    status_file="$2"
+    shift 2
+    set +e
+    "$@" >"$output_file" 2>&1
+    printf '%s\n' "$?" >"$status_file"
+    set -e
+}
+
 tmp="$(new_test_dir)"
-trap 'rm -rf "$tmp"' EXIT
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+fake_bin="$tmp/fake-bin"
+make_fake_ffprobe "$fake_bin"
+
+# Arrange a canonical v1.1 project with every preserved finding category.
 studio_root="$tmp/studio"
-fixture_studio "$studio_root"
-project_root="$(fixture_project "$studio_root" fresh)"
+project_root="$(fixture_v11_project "$studio_root")"
 report="$project_root/00_Admin/Intake_Report.md"
-fixture_wav "$project_root/01_Client_Files/Original_Delivery/Lead Vocal.wav"
-python3 - "$report" <<'PY'
+source_root="$project_root/01_Client_Files/Original_Delivery"
+mkdir -p "$source_root/Audio" "$source_root/Drums" "$source_root/Samples" "$source_root/Documentation"
+printf 'lead\n' > "$source_root/Audio/Lead Vocal.wav"
+printf 'kick one\n' > "$source_root/Drums/Kick.wav"
+printf 'kick two\n' > "$source_root/Samples/Kick.wav"
+printf 'notes\n' > "$source_root/Documentation/Track Notes.pdf"
+ln -s "$source_root/Audio/Lead Vocal.wav" "$source_root/Audio/Linked Vocal.wav"
+
+python3 - "$report" <<'PY_REPORT'
 from pathlib import Path
 import sys
-# Seed user-authored text outside the managed section to prove preservation.
 path = Path(sys.argv[1])
-path.write_text(path.read_text().replace("Add manual observations here.", "Keep this engineer note."))
-PY
+path.write_bytes(
+    b"# Intake Report\n\nEngineer prefix: preserve exactly.\n\n"
+    b"<!-- BEGIN AUTOMATED SECTION -->\nold managed content\n"
+    b"<!-- END AUTOMATED SECTION -->\n\nEngineer suffix: preserve exactly.\n"
+)
+PY_REPORT
+python3 - "$report" "$tmp/outside-before.bin" <<'PY_OUTSIDE'
+from pathlib import Path
+import sys
+text = Path(sys.argv[1]).read_bytes()
+begin = b"<!-- BEGIN AUTOMATED SECTION -->"
+end = b"<!-- END AUTOMATED SECTION -->"
+outside = text[: text.index(begin) + len(begin)] + text[text.index(end):]
+Path(sys.argv[2]).write_bytes(outside)
+PY_OUTSIDE
 
-(cd "$project_root/01_Client_Files" && "$ROOT/bin/validate-intake")
+output="$tmp/validate.out"
+status="$tmp/validate.status"
+run_capture "$output" "$status" env PATH="$fake_bin:$PATH" \
+    "$ROOT/bin/validate-intake" --project "$project_root"
+assert_eq "0" "$(cat "$status")" "warnings do not block intake validation"
 report_text="$(cat "$report")"
-# Assert: verify observable behavior rather than internal implementation.
-assert_contains "$report_text" "Keep this engineer note." "engineer notes are preserved"
-assert_contains "$report_text" "Lead Vocal.wav" "source inventory is written"
-assert_contains "$report_text" "Files discovered: 1" "file count is reported"
+command_text="$(cat "$output")"
+assert_contains "$report_text" "## Intake Summary" "summary section is generated"
+assert_contains "$report_text" "## Critical Errors" "critical-error section is generated"
+assert_contains "$report_text" "## Duplicate Filenames" "duplicate section is generated"
+assert_contains "$report_text" '`Drums/Kick.wav`, `Samples/Kick.wav`' "duplicate basenames are reported"
+assert_contains "$report_text" "## Project-Format Mismatches" "format-mismatch section is generated"
+assert_contains "$report_text" '`Audio/Lead Vocal.wav`: 44100 Hz; expected 48000 Hz.' "sample-rate mismatch is preserved"
+assert_contains "$report_text" '`Audio/Lead Vocal.wav`: 16-bit; expected 24-bit.' "bit-depth mismatch is preserved"
+assert_contains "$report_text" "## Unsupported or Non-Audio Files" "unsupported section is generated"
+assert_contains "$report_text" '`Documentation/Track Notes.pdf`' "unsupported file is reported"
+assert_contains "$report_text" "Files discovered: 4" "symlink files are not followed"
+assert_contains "$report_text" "Warnings: 4" "warning count preserves v1.0.4 severities"
+assert_contains "$report_text" "48000 Hz, 24-bit, 2 ch, 2.00 s" "technical metadata remains in inventory"
+assert_contains "$command_text" "Intake validation completed." "success summary is printed"
+assert_contains "$command_text" "Review 00_Admin/Intake_Report.md" "success next step is printed"
+assert_contains "$command_text" "Prepare accepted audio in 02_Audio_Preparation/Working_Audio/" "preparation guidance is printed"
+
+python3 - "$report" "$tmp/outside-after.bin" <<'PY_OUTSIDE'
+from pathlib import Path
+import sys
+text = Path(sys.argv[1]).read_bytes()
+begin = b"<!-- BEGIN AUTOMATED SECTION -->"
+end = b"<!-- END AUTOMATED SECTION -->"
+outside = text[: text.index(begin) + len(begin)] + text[text.index(end):]
+Path(sys.argv[2]).write_bytes(outside)
+PY_OUTSIDE
+assert_same_bytes "$tmp/outside-before.bin" "$tmp/outside-after.bin"
+
+# Dry-run prints the proposed section, honors overrides/skips, and changes no file.
+override_source="$tmp/override-source"
+mkdir -p "$override_source"
+printf 'lead\n' > "$override_source/Lead Vocal.wav"
+cp "$report" "$tmp/report-before-dry-run.md"
+run_capture "$output" "$status" env PATH="$fake_bin:$PATH" \
+    "$ROOT/bin/validate-intake" --project "$project_root" --source "$override_source" --dry-run \
+    --no-duplicate-check --expected-sample-rate 44100 --expected-bit-depth 16
+assert_eq "0" "$(cat "$status")" "dry-run returns preserved validation status"
+dry_text="$(cat "$output")"
+assert_contains "$dry_text" "Duplicate-basename detection was skipped." "skipped duplicate check is explicit"
+assert_contains "$dry_text" "## Project-Format Mismatches" "dry-run prints managed report content"
+assert_contains "$dry_text" "## Project-Format Mismatches
+
+- None." "matching overrides remove format mismatches"
+assert_same_bytes "$report" "$tmp/report-before-dry-run.md"
+
+# Known removed options receive targeted migration diagnostics.
+run_capture "$output" "$status" "$ROOT/bin/validate-intake" --report-only
+assert_eq "2" "$(cat "$status")" "removed report-only option is an argument error"
+assert_contains "$(cat "$output")" "--report-only was removed in JL Mixing 1.1." "report-only diagnostic is targeted"
+run_capture "$output" "$status" "$ROOT/bin/validate-intake" --non-interactive
+assert_eq "2" "$(cat "$status")" "removed non-interactive option is an argument error"
+assert_contains "$(cat "$output")" "--non-interactive was removed in JL Mixing 1.1." "non-interactive diagnostic is targeted"
 
 printf '[OK] validate-intake (%s assertions)\n' "$TEST_COUNT"

--- a/tests/unit/test-intake-report.sh
+++ b/tests/unit/test-intake-report.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -eu
+
+# Purpose: Exercise the report helper when optional ffprobe is unavailable.
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/tests/test-helper.sh"
+
+require_test_command python3
+
+tmp="$(new_test_dir)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+source_root="$tmp/source"
+mkdir -p "$source_root/A" "$source_root/B" "$tmp/empty-path"
+printf 'one\n' > "$source_root/A/Same.wav"
+printf 'two\n' > "$source_root/B/Same.wav"
+printf 'notes\n' > "$source_root/Notes.txt"
+
+output="$tmp/report.md"
+summary="$tmp/summary.json"
+PATH="$tmp/empty-path" "$(command -v python3)" "$ROOT/tools/build-intake-report.py" \
+    --source "$source_root" --output "$output" --summary-output "$summary" \
+    --expected-sample-rate 48000 --expected-bit-depth 24
+
+text="$(cat "$output")"
+assert_contains "$text" "ffprobe is not installed; enhanced audio inspection was unavailable." "unavailable ffprobe is explicit"
+assert_contains "$text" "Warnings: 3" "unavailable ffprobe retains warning semantics"
+assert_contains "$text" '`A/Same.wav`, `B/Same.wav`' "duplicate basename is reported without ffprobe"
+assert_contains "$text" '`Notes.txt`' "unsupported file is reported without ffprobe"
+assert_json_eq "3" "$summary" '.files_discovered' "summary records file count"
+assert_json_eq "0" "$summary" '.blocking_errors' "summary records no blocking errors"
+assert_json_eq "3" "$summary" '.warnings' "summary records warning count"
+assert_json_eq "false" "$summary" '(.ffprobe_available | tostring)' "summary records unavailable ffprobe"
+
+
+# Empty sources preserve the v1.0.4 blocking result and inventory presentation.
+empty_source="$tmp/empty-source"
+mkdir -p "$empty_source"
+set +e
+PATH="$tmp/empty-path" "$(command -v python3)" "$ROOT/tools/build-intake-report.py" \
+    --source "$empty_source" --output "$tmp/empty-report.md" \
+    --summary-output "$tmp/empty-summary.json" --expected-sample-rate 48000 \
+    --expected-bit-depth 24
+empty_status=$?
+set -e
+assert_eq "5" "$empty_status" "empty source remains blocking"
+assert_contains "$(cat "$tmp/empty-report.md")" "No files were found in the intake source." "empty-source error is reported"
+assert_contains "$(cat "$tmp/empty-report.md")" "| _No files_ | 0 | — |" "empty inventory row is reported"
+
+printf '[OK] intake report helper (%s assertions)\n' "$TEST_COUNT"

--- a/tools/build-intake-report.py
+++ b/tools/build-intake-report.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Build the automation-managed section of ``Intake_Report.md``.
 
-The shell command ``validate-intake`` owns project/context resolution and the
-managed-section replacement. This helper focuses only on inspecting one source
-directory and producing deterministic Markdown. It never writes into the source
-folder and treats ``ffprobe`` as an optional enhancement rather than a hard
-runtime dependency.
+The shell command ``validate-intake`` owns v1.1 project/context validation and
+managed-section replacement. This helper intentionally preserves the exact
+v1.0.4 intake checks: recursive regular-file inventory, duplicate-basename
+warnings, extension-based audio candidacy, opportunistic ``ffprobe`` metadata,
+project sample-rate/bit-depth comparisons, and unreadable candidate-audio
+errors. It does not add broader audio QC.
 """
 
 from __future__ import annotations
@@ -18,19 +19,20 @@ import subprocess
 import sys
 from typing import Any
 
-# Extensions considered audio candidates. A candidate is still reported as
-# unreadable if ffprobe exists but cannot parse it.
+# Preserve the v1.0.4 audio-candidate allowlist exactly. Files outside this set
+# remain visible in the inventory and are reported as unsupported/non-audio.
 AUDIO_EXTENSIONS = {".wav", ".wave", ".aif", ".aiff", ".flac", ".mp3", ".m4a"}
 
 
 def parse_args() -> argparse.Namespace:
-    """Parse the narrow interface used by the Bash wrapper and tests."""
+    """Parse the narrow private interface used by the Bash wrapper and tests."""
 
     parser = argparse.ArgumentParser(
         description="Generate the managed intake-validation Markdown section."
     )
     parser.add_argument("--source", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--summary-output", type=Path)
     parser.add_argument("--expected-sample-rate", type=int)
     parser.add_argument("--expected-bit-depth", type=int)
     parser.add_argument("--no-duplicate-check", action="store_true")
@@ -38,12 +40,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def ffprobe_metadata(path: Path) -> tuple[dict[str, Any] | None, str | None]:
-    """Inspect the first audio stream and return normalized metadata or an error.
-
-    ``check=False`` is intentional: invalid client audio is reportable intake
-    data, not a Python exception. The caller decides whether it is a warning or
-    blocking validation error.
-    """
+    """Inspect the first audio stream using the preserved v1.0.4 probe fields."""
 
     command = [
         "ffprobe",
@@ -68,9 +65,6 @@ def ffprobe_metadata(path: Path) -> tuple[dict[str, Any] | None, str | None]:
         payload = json.loads(result.stdout)
         stream = (payload.get("streams") or [{}])[0]
         fmt = payload.get("format") or {}
-
-        # Some formats expose only bits_per_raw_sample, while others expose
-        # bits_per_sample. Prefer the former but accept either.
         bits = stream.get("bits_per_raw_sample") or stream.get("bits_per_sample") or None
         return (
             {
@@ -82,16 +76,18 @@ def ffprobe_metadata(path: Path) -> tuple[dict[str, Any] | None, str | None]:
             None,
         )
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
-        # Malformed or incomplete ffprobe JSON is reported to the intake report
-        # instead of terminating the whole file inventory.
         return None, f"could not parse ffprobe output: {exc}"
 
 
-def format_technical(metadata: dict[str, Any] | None) -> str:
-    """Format available technical metadata for one Markdown table cell."""
+def format_technical(metadata: dict[str, Any] | None, inspection: str) -> str:
+    """Format the existing opportunistic metadata for one inventory row."""
 
-    if not metadata:
+    if inspection == "unreadable":
+        return "not readable"
+    if inspection == "not-inspected":
         return "not inspected"
+    if not metadata:
+        return "readable audio"
 
     values: list[str] = []
     if metadata.get("sample_rate"):
@@ -105,126 +101,161 @@ def format_technical(metadata: dict[str, Any] | None) -> str:
     return ", ".join(values) or "readable audio"
 
 
+def markdown_items(items: list[str]) -> list[str]:
+    """Render a stable bullet list, using an explicit empty-state entry."""
+
+    return [f"- {item}" for item in items] if items else ["- None."]
+
+
+def write_summary(
+    path: Path | None,
+    *,
+    file_count: int,
+    error_count: int,
+    warning_count: int,
+    ffprobe_available: bool,
+) -> None:
+    """Write the private command-summary JSON when requested."""
+
+    if path is None:
+        return
+    payload = {
+        "files_discovered": file_count,
+        "blocking_errors": error_count,
+        "warnings": warning_count,
+        "ffprobe_available": ffprobe_available,
+    }
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def main() -> int:
-    """Inventory the source, render Markdown, and return validation status."""
+    """Inventory the source, render clearer Markdown, and return v1.0.4 status."""
 
     args = parse_args()
     source = args.source.resolve()
-    if not source.is_dir():
-        print(f"Source directory not found: {source}", file=sys.stderr)
+    if not source.is_dir() or source.is_symlink():
+        print(f"Source directory not found or unsafe: {source}", file=sys.stderr)
         return 5
 
-    # A case-insensitive path sort keeps generated reports stable across runs
-    # and platforms, which makes both human review and automated tests clearer.
+    # Preserve recursive inventory while refusing to follow symbolic-link files.
     files = sorted(
-        (path for path in source.rglob("*") if path.is_file()),
-        key=lambda path: str(path).lower(),
+        (
+            path
+            for path in source.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        ),
+        key=lambda path: str(path.relative_to(source)).lower(),
     )
     ffprobe_available = shutil.which("ffprobe") is not None
-    warnings: list[str] = []
-    errors: list[str] = []
-    inventory: list[tuple[Path, dict[str, Any] | None]] = []
+
+    critical_errors: list[str] = []
+    duplicate_findings: list[str] = []
+    mismatch_findings: list[str] = []
+    unsupported_findings: list[str] = []
+    unavailable_findings: list[str] = []
+    inventory: list[tuple[Path, dict[str, Any] | None, str]] = []
 
     if not files:
-        errors.append("No files were found in the intake source.")
+        critical_errors.append("No files were found in the intake source.")
 
-    # Duplicate basenames can become ambiguous after a DAW import even when the
-    # original files live in separate client subdirectories.
-    if not args.no_duplicate_check:
+    # Preserve case-insensitive duplicate-basename detection exactly.
+    if args.no_duplicate_check:
+        unavailable_findings.append("Duplicate-basename detection was skipped.")
+    else:
         by_name: dict[str, list[Path]] = {}
         for path in files:
             by_name.setdefault(path.name.lower(), []).append(path)
         for duplicate_paths in by_name.values():
             if len(duplicate_paths) > 1:
                 display = ", ".join(
-                    str(path.relative_to(source)) for path in duplicate_paths
+                    f"`{path.relative_to(source)}`" for path in duplicate_paths
                 )
-                warnings.append(f"Duplicate filename detected: {display}")
+                duplicate_findings.append(display)
 
-    # Inspect each file independently so one corrupt item does not hide the rest
-    # of the delivery inventory.
+    # Inspect each file independently so one unreadable candidate does not hide
+    # the rest of the delivery inventory.
     for path in files:
+        relative = path.relative_to(source)
         extension = path.suffix.lower()
         metadata: dict[str, Any] | None = None
+        inspection = "not-inspected"
+
         if extension in AUDIO_EXTENSIONS:
             if ffprobe_available:
                 metadata, error = ffprobe_metadata(path)
                 if error:
-                    errors.append(
-                        f"Unreadable audio file `{path.relative_to(source)}`: {error}"
-                    )
-                elif metadata:
-                    actual_rate = metadata.get("sample_rate")
-                    actual_depth = metadata.get("bit_depth")
-                    if (
-                        args.expected_sample_rate
-                        and actual_rate
-                        and actual_rate != args.expected_sample_rate
-                    ):
-                        warnings.append(
-                            f"Sample-rate mismatch for `{path.relative_to(source)}`: "
-                            f"{actual_rate} Hz; expected {args.expected_sample_rate} Hz."
-                        )
-                    if (
-                        args.expected_bit_depth
-                        and actual_depth
-                        and actual_depth != args.expected_bit_depth
-                    ):
-                        warnings.append(
-                            f"Bit-depth mismatch for `{path.relative_to(source)}`: "
-                            f"{actual_depth}-bit; expected {args.expected_bit_depth}-bit."
-                        )
+                    critical_errors.append(f"Unreadable audio file `{relative}`: {error}")
+                    inspection = "unreadable"
+                else:
+                    inspection = "inspected"
+                    if metadata:
+                        actual_rate = metadata.get("sample_rate")
+                        actual_depth = metadata.get("bit_depth")
+                        if (
+                            args.expected_sample_rate
+                            and actual_rate
+                            and actual_rate != args.expected_sample_rate
+                        ):
+                            mismatch_findings.append(
+                                f"`{relative}`: {actual_rate} Hz; "
+                                f"expected {args.expected_sample_rate} Hz."
+                            )
+                        if (
+                            args.expected_bit_depth
+                            and actual_depth
+                            and actual_depth != args.expected_bit_depth
+                        ):
+                            mismatch_findings.append(
+                                f"`{relative}`: {actual_depth}-bit; "
+                                f"expected {args.expected_bit_depth}-bit."
+                            )
         else:
-            warnings.append(
-                f"Non-audio or unsupported extension: `{path.relative_to(source)}`"
-            )
-        inventory.append((path, metadata))
+            unsupported_findings.append(f"`{relative}`")
 
-    # Summarize capabilities separately from per-file findings so a report makes
-    # clear whether technical audio inspection actually occurred.
-    passed: list[str] = []
-    if files:
-        passed.append(f"Inventoried {len(files)} file(s).")
-    if not errors:
-        passed.append("No blocking intake errors were detected.")
-    if ffprobe_available:
-        passed.append("Enhanced audio inspection was available through ffprobe.")
-    else:
-        warnings.append("ffprobe is not installed; enhanced audio inspection was skipped.")
+        inventory.append((path, metadata, inspection))
 
-    # Build Markdown as a list of lines to avoid fragile multiline interpolation
-    # and to keep section ordering explicit.
+    if not ffprobe_available:
+        unavailable_findings.append(
+            "ffprobe is not installed; enhanced audio inspection was unavailable."
+        )
+
+    # Warning counts retain v1.0.4 semantics. An explicitly skipped duplicate
+    # check is documented but does not itself become a warning.
+    warning_count = (
+        len(duplicate_findings)
+        + len(mismatch_findings)
+        + len(unsupported_findings)
+        + (0 if ffprobe_available else 1)
+    )
+
+    enhanced = "available through ffprobe" if ffprobe_available else "unavailable"
     lines: list[str] = [
         "## Intake Summary",
         "",
         f"- Source: `{source}`",
         f"- Files discovered: {len(files)}",
-        f"- Blocking errors: {len(errors)}",
-        f"- Warnings: {len(warnings)}",
+        f"- Blocking errors: {len(critical_errors)}",
+        f"- Warnings: {warning_count}",
+        f"- Expected sample rate: {args.expected_sample_rate or 'not specified'}",
+        f"- Expected bit depth: {args.expected_bit_depth or 'not specified'}",
+        f"- Enhanced inspection: {enhanced}",
         "",
-        "## Expected Project Settings",
-        "",
-        f"- Sample rate: {args.expected_sample_rate or 'not specified'}",
-        f"- Bit depth: {args.expected_bit_depth or 'not specified'}",
-        "",
-        "## Validation Results",
-        "",
-        "### Passed",
+        "## Critical Errors",
         "",
     ]
-    lines.extend(f"- {item}" for item in passed)
-    if not passed:
-        lines.append("- None.")
+    lines.extend(markdown_items(critical_errors))
 
-    lines.extend(["", "### Warnings", ""])
-    lines.extend(f"- {item}" for item in warnings)
-    if not warnings:
-        lines.append("- None.")
+    lines.extend(["", "## Duplicate Filenames", ""])
+    lines.extend(markdown_items(duplicate_findings))
 
-    lines.extend(["", "### Errors", ""])
-    lines.extend(f"- {item}" for item in errors)
-    if not errors:
-        lines.append("- None.")
+    lines.extend(["", "## Project-Format Mismatches", ""])
+    lines.extend(markdown_items(mismatch_findings))
+
+    lines.extend(["", "## Unsupported or Non-Audio Files", ""])
+    lines.extend(markdown_items(unsupported_findings))
+
+    lines.extend(["", "## Skipped or Unavailable Checks", ""])
+    lines.extend(markdown_items(unavailable_findings))
 
     lines.extend(
         [
@@ -235,30 +266,53 @@ def main() -> int:
             "|---|---:|---|",
         ]
     )
-    for path, metadata in inventory:
-        # Escape table pipes in client filenames so the Markdown row remains valid.
+    for path, metadata, inspection in inventory:
         relative = str(path.relative_to(source)).replace("|", "\\|")
         lines.append(
-            f"| `{relative}` | {path.stat().st_size} | {format_technical(metadata)} |"
+            f"| `{relative}` | {path.stat().st_size} | "
+            f"{format_technical(metadata, inspection)} |"
         )
     if not inventory:
         lines.append("| _No files_ | 0 | — |")
 
-    lines.extend(["", "## Preparation Recommendations", ""])
-    if errors:
-        lines.append("- Resolve blocking errors before preparing `Working_Audio/`.")
-    if warnings:
-        lines.append(
-            "- Review warnings and document any accepted exceptions in "
-            "`Preparation_Report.md`."
+    recommendations: list[str] = []
+    if critical_errors:
+        recommendations.append(
+            "Resolve blocking errors before preparing `Working_Audio/`."
         )
-    if not errors and not warnings:
-        lines.append("- Intake is ready for manual audio preparation.")
+    if mismatch_findings:
+        recommendations.append(
+            "Review project-format mismatches before conversion or DAW import."
+        )
+    if duplicate_findings:
+        recommendations.append(
+            "Review duplicate filenames to avoid ambiguous DAW imports."
+        )
+    if unsupported_findings:
+        recommendations.append(
+            "Review unsupported or non-audio files and retain any required documentation."
+        )
+    if unavailable_findings:
+        recommendations.append(
+            "Document skipped or unavailable checks in `Preparation_Report.md`."
+        )
+    if not recommendations:
+        recommendations.append("Intake is ready for manual audio preparation.")
 
-    # The Bash wrapper writes this temporary output into the report's managed
-    # section. A trailing newline keeps the resulting Markdown POSIX-friendly.
-    args.output.write_text("\n".join(lines).rstrip() + "\n")
-    return 5 if errors else 0
+    lines.extend(["", "## Preparation Recommendations", ""])
+    lines.extend(f"- {item}" for item in recommendations)
+
+    args.output.write_text(
+        "\n".join(lines).rstrip() + "\n", encoding="utf-8", newline="\n"
+    )
+    write_summary(
+        args.summary_output,
+        file_count=len(files),
+        error_count=len(critical_errors),
+        warning_count=warning_count,
+        ffprobe_available=ffprobe_available,
+    )
+    return 5 if critical_errors else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Migrates project discovery and validation to the flattened v1.1 layout
Preserves the v1.0.4 intake checks and severities
Preserves the exact audio-candidate extensions
Preserves opportunistic ffprobe metadata reporting
Preserves duplicate-basename detection
Preserves sample-rate and bit-depth comparisons
Preserves unreadable candidate audio as a blocking error
Adds the approved reorganized managed report
Preserves all content outside the managed markers byte-for-byte
Adds non-mutating dry-run output
Adds command summaries and Next: guidance
Adds targeted errors for removed options
Does not add expanded audio QC