### PR TITLE
fix: normalize macOS shell integration temp path

### DIFF
--- a/bin/jl-mixing-shell-integration
+++ b/bin/jl-mixing-shell-integration
@@ -23,8 +23,21 @@ unset _jl_mixing_is_sourced
 export JL_MIXING_SHELL_INTEGRATION=1
 
 _jl_mixing_secure_result_file() {
-    local result_file
-    result_file="$(umask 077 && mktemp "${TMPDIR:-/tmp}/jl-mixing-cd.XXXXXX")" || return 1
+    local result_file temp_dir template
+
+    # macOS commonly exports TMPDIR with a trailing slash. Normalize it before
+    # constructing the result-file template so the path contains no empty
+    # segments that the command-side safety validator would reject.
+    temp_dir="${TMPDIR:-/tmp}"
+    while [ "$temp_dir" != "/" ] && [ "${temp_dir%/}" != "$temp_dir" ]; do
+        temp_dir="${temp_dir%/}"
+    done
+    case "$temp_dir" in
+        /) template="/jl-mixing-cd.XXXXXX" ;;
+        *) template="$temp_dir/jl-mixing-cd.XXXXXX" ;;
+    esac
+
+    result_file="$(umask 077 && mktemp "$template")" || return 1
     chmod 600 "$result_file" 2>/dev/null || {
         rm -f -- "$result_file"
         return 1

--- a/tests/integration/test-shell-integration.sh
+++ b/tests/integration/test-shell-integration.sh
@@ -58,6 +58,15 @@ assert_eq "$destination" "$(printf '%s\n' "$output" | tail -n 1)" "wrapper chang
 assert_eq "0o600" "$(cat "$mode_file")" "result file uses user-only permissions"
 assert_eq "0" "$(find "$result_tmp" -type f | wc -l | tr -d ' ')" "result file cleaned after success"
 
+trailing_destination="$tmp/Trailing Slash TMPDIR Client"
+output="$(PATH="$fake_bin:$PATH" TMPDIR="$result_tmp/" \
+    JL_TEST_DESTINATION="$trailing_destination" JL_TEST_MODE_FILE="$mode_file" \
+    bash -c '. "$1"; new-client success; pwd' _ "$integration")"
+assert_eq "$trailing_destination" "$(printf '%s\n' "$output" | tail -n 1)" \
+    "trailing-slash TMPDIR supports automatic directory change"
+assert_eq "0" "$(find "$result_tmp" -type f | wc -l | tr -d ' ')" \
+    "trailing-slash TMPDIR result file cleaned"
+
 assert_success "no result leaves command successful" env PATH="$fake_bin:$PATH" TMPDIR="$result_tmp" \
     bash -c '. "$1"; before=$PWD; new-client no-result; test "$PWD" = "$before"' _ "$integration"
 


### PR DESCRIPTION
closes issue #32 

