### PR TITLE
Define Automation API and roadmap

### DIFF
--- a/docs/AUTOMATION_API.md
+++ b/docs/AUTOMATION_API.md
@@ -86,6 +86,26 @@ Errors use stable machine codes and human-readable messages:
 
 Clients must branch on `code`, not message text.
 
+## Exit-code contract
+
+Automation API 1.0 preserves the existing JL Mixing Automation exit-code contract:
+
+| Exit code | Meaning | JSON status |
+|---:|---|---|
+| `0` | Successful operation or valid dry-run preview | `success` or `planned` |
+| `1` | General or internal failure | `error` |
+| `2` | Invalid arguments or request | `error` |
+| `3` | Configuration or required-tool problem | `error` |
+| `4` | Workspace, client, project, or execution-context problem | `error` |
+| `5` | Validation completed with blocking findings | `blocked` |
+| `6` | Unsafe operation rejected | `blocked` |
+
+The JSON `status` describes the broad outcome, while stable machine error codes describe the specific reason. Clients should branch primarily on JSON status and machine codes and use the process exit code as a secondary integrity check and for shell compatibility.
+
+A valid dry run returns `status: planned` with exit `0`. Intake validation that completes and writes a valid report but finds blocking issues returns `status: blocked` with exit `5`. Safety guardrail rejections return `status: blocked` with exit `6`.
+
+Failures outside the running API contract retain operating-system conventions. A missing executable may produce shell exit `127`, and signal termination may produce `128 + signal`. Missing or malformed JSON is always treated by clients as an Automation transport or protocol failure regardless of process exit code.
+
 ## Compatibility rules
 
 Within API major version 1:
@@ -123,7 +143,7 @@ Mutating operations that support preview return `status: planned` and a structur
 - Human diagnostics and progress may use standard error only when documented.
 - Commands remain non-interactive in JSON mode.
 - Paths are returned as explicit fields, never embedded only in prose.
-- Exit codes remain documented per operation and must agree with the JSON status.
+- Exit codes must agree with the JSON status and the approved mapping.
 - Secrets and unrestricted command strings are never returned.
 
 ## Contract testing
@@ -140,12 +160,12 @@ API releases shall include:
 ## Approved design decisions
 
 1. `jl-mixing` is the canonical machine-facing API dispatcher. Existing human-facing commands remain supported and share the same underlying implementation.
+2. API 1.0 preserves existing exit codes `0` through `6`: exit `0` maps to `success` or `planned`; exits `1` through `4` map to `error`; exits `5` and `6` map to `blocked`. Stable JSON machine codes provide the specific reason.
 
 ## Open design decisions
 
 Before implementation, approve:
 
-1. exact exit-code mapping;
-2. progress-event behavior for long operations;
-3. whether read-only query operations ship in API 1.0 or a later 1.x addition;
-4. JSON Schema publication and location.
+1. progress-event behavior for long operations;
+2. whether read-only query operations ship in API 1.0 or a later 1.x addition;
+3. JSON Schema publication and location.

--- a/docs/AUTOMATION_API.md
+++ b/docs/AUTOMATION_API.md
@@ -137,10 +137,47 @@ Capability names use stable dotted identifiers. Initial candidates include:
 
 Mutating operations that support preview return `status: planned` and a structured plan. The confirmed operation must identify the same logical request. Clients must still re-read authoritative workspace state after success; JSON output does not replace post-operation reconciliation.
 
+## Progress-event contract
+
+Long-running API operations may support opt-in machine-readable progress through:
+
+```bash
+jl-mixing intake validate --json --progress=json
+```
+
+The streams have separate contracts:
+
+- standard output contains exactly one final Automation API response;
+- standard error contains zero or more newline-delimited JSON progress-event objects.
+
+When `--progress=json` is enabled, every non-empty standard-error line must be a valid progress event. Human-formatted diagnostics must not be mixed into that stream.
+
+Example progress event:
+
+```json
+{
+  "api_version": "1.0",
+  "event": "progress",
+  "operation": "intake.validate",
+  "phase": "inspection",
+  "completed": 3,
+  "total": 12,
+  "unit": "files",
+  "message": "Inspecting audio files."
+}
+```
+
+Progress is advisory. Events do not prove that a mutation committed, a report was written, or authoritative state matches the request. The final response, exit code, and client reconciliation remain authoritative.
+
+Operations report `completed`, `total`, and `unit` only when the total is known reliably. Clients use indeterminate progress when these values are absent. Published phase identifiers become stable API values; initial candidates include `discovery`, `validation`, `inspection`, `copy`, `verification`, `archive`, `report`, and `commit`.
+
+Progress support is optional by capability and operation. Cancellation semantics are not part of API 1.0 and require a separate design.
+
 ## Output and process rules
 
 - JSON mode writes only the response object to standard output.
-- Human diagnostics and progress may use standard error only when documented.
+- Human diagnostics may use standard error when progress JSON mode is not enabled and the behavior is documented.
+- When `--progress=json` is enabled, standard error contains only newline-delimited JSON progress events.
 - Commands remain non-interactive in JSON mode.
 - Paths are returned as explicit fields, never embedded only in prose.
 - Exit codes must agree with the JSON status and the approved mapping.
@@ -155,17 +192,18 @@ API releases shall include:
 - compatibility tests proving older API 1.x clients can ignore newly added optional fields;
 - tests for paths containing spaces and non-destructive dry-run behavior;
 - exact tests for operation identifiers, machine error codes, and exit-code mapping;
+- progress tests proving stdout remains a single final object and progress-mode stderr contains only valid newline-delimited event objects;
 - parity tests proving dispatcher operations and corresponding human-facing commands use the same workflow rules and produce equivalent authoritative state.
 
 ## Approved design decisions
 
 1. `jl-mixing` is the canonical machine-facing API dispatcher. Existing human-facing commands remain supported and share the same underlying implementation.
 2. API 1.0 preserves existing exit codes `0` through `6`: exit `0` maps to `success` or `planned`; exits `1` through `4` map to `error`; exits `5` and `6` map to `blocked`. Stable JSON machine codes provide the specific reason.
+3. API 1.0 supports opt-in progress events through `--progress=json`. Events are newline-delimited JSON on standard error, while standard output remains one final response. Progress is advisory and does not replace final-response or authoritative-state reconciliation.
 
 ## Open design decisions
 
 Before implementation, approve:
 
-1. progress-event behavior for long operations;
-2. whether read-only query operations ship in API 1.0 or a later 1.x addition;
-3. JSON Schema publication and location.
+1. whether read-only query operations ship in API 1.0 or a later 1.x addition;
+2. JSON Schema publication and location.

--- a/docs/AUTOMATION_API.md
+++ b/docs/AUTOMATION_API.md
@@ -11,9 +11,13 @@ The Automation API is the stable machine contract used by JL Mixing Studio and f
 
 JL Mixing Studio 1.0 depends on the exact JL Mixing Automation 1.3.0 command contract. API 1.0 will be introduced explicitly; no current command output should be described as API 1.0 until implementation and contract tests are released.
 
-## Version discovery
+## Dispatcher and version discovery
 
-Automation shall provide a machine-readable discovery operation. The final command name is an implementation decision; the preferred shape is:
+`jl-mixing` is the canonical machine-facing Automation API dispatcher. JL Mixing Studio and future supported API clients invoke only this executable with allowlisted subcommands and arguments.
+
+Existing human-facing commands such as `new-client`, `new-mix`, `validate-intake`, `new-revision`, `approve-mix`, and `create-delivery` remain supported. The dispatcher and existing commands share the same underlying implementation; the dispatcher must not invoke the existing commands as subprocesses or create a competing implementation of workflow rules.
+
+Machine-readable discovery uses:
 
 ```bash
 jl-mixing system-info --json
@@ -130,14 +134,18 @@ API releases shall include:
 - golden success, planned, blocked, and error examples;
 - compatibility tests proving older API 1.x clients can ignore newly added optional fields;
 - tests for paths containing spaces and non-destructive dry-run behavior;
-- exact tests for operation identifiers, machine error codes, and exit-code mapping.
+- exact tests for operation identifiers, machine error codes, and exit-code mapping;
+- parity tests proving dispatcher operations and corresponding human-facing commands use the same workflow rules and produce equivalent authoritative state.
+
+## Approved design decisions
+
+1. `jl-mixing` is the canonical machine-facing API dispatcher. Existing human-facing commands remain supported and share the same underlying implementation.
 
 ## Open design decisions
 
 Before implementation, approve:
 
-1. whether `jl-mixing` becomes a dispatcher executable or discovery remains a dedicated command;
-2. exact exit-code mapping;
-3. progress-event behavior for long operations;
-4. whether read-only query operations ship in API 1.0 or a later 1.x addition;
-5. JSON Schema publication and location.
+1. exact exit-code mapping;
+2. progress-event behavior for long operations;
+3. whether read-only query operations ship in API 1.0 or a later 1.x addition;
+4. JSON Schema publication and location.

--- a/docs/AUTOMATION_API.md
+++ b/docs/AUTOMATION_API.md
@@ -1,0 +1,143 @@
+# JL Mixing Automation API
+
+**Status:** Proposed design; not yet implemented  
+**Initial target:** API 1.0
+
+## Purpose
+
+The Automation API is the stable machine contract used by JL Mixing Studio and future supported clients. It does not replace the human-oriented CLI. Existing commands remain usable interactively while supported machine operations gain documented JSON behavior.
+
+## Transition baseline
+
+JL Mixing Studio 1.0 depends on the exact JL Mixing Automation 1.3.0 command contract. API 1.0 will be introduced explicitly; no current command output should be described as API 1.0 until implementation and contract tests are released.
+
+## Version discovery
+
+Automation shall provide a machine-readable discovery operation. The final command name is an implementation decision; the preferred shape is:
+
+```bash
+jl-mixing system-info --json
+```
+
+Example response:
+
+```json
+{
+  "api_version": "1.0",
+  "application": {
+    "name": "jl-mixing",
+    "version": "1.4.0"
+  },
+  "metadata": {
+    "readable_schema_versions": ["1.1.0"],
+    "writable_schema_version": "1.1.0"
+  },
+  "capabilities": [
+    "client.create",
+    "project.create",
+    "intake.validate",
+    "revision.create",
+    "revision.approve",
+    "delivery.create"
+  ]
+}
+```
+
+## Response envelope
+
+Every API operation returns one JSON object on standard output:
+
+```json
+{
+  "api_version": "1.0",
+  "operation": "project.create",
+  "status": "success",
+  "data": {},
+  "warnings": [],
+  "errors": []
+}
+```
+
+Required top-level fields are `api_version`, `operation`, `status`, `data`, `warnings`, and `errors`.
+
+Allowed status values for API 1.0 are:
+
+- `success` — operation completed and authoritative state was committed;
+- `planned` — dry-run completed without mutation;
+- `blocked` — request was understood but governing state or findings prevented completion;
+- `error` — request could not be completed because of invalid input, environment, transport, or internal failure.
+
+## Error objects
+
+Errors use stable machine codes and human-readable messages:
+
+```json
+{
+  "code": "PROJECT_NOT_FOUND",
+  "message": "The requested project could not be resolved.",
+  "details": {},
+  "retryable": false
+}
+```
+
+Clients must branch on `code`, not message text.
+
+## Compatibility rules
+
+Within API major version 1:
+
+- new optional fields and capabilities may be added;
+- existing required fields and field meanings must not change;
+- operation identifiers and documented status meanings must remain stable;
+- clients must ignore unknown optional fields;
+- removed or incompatible behavior requires API 2.0.
+
+The Automation application version may change without changing the API version.
+
+## Capability discovery
+
+Studio shall use capability identifiers for optional features. A missing optional capability disables only that feature. Missing required capabilities make the installed Automation version incompatible with that Studio release.
+
+Capability names use stable dotted identifiers. Initial candidates include:
+
+- `system.info`
+- `studio.create`
+- `client.create`
+- `project.create`
+- `intake.validate`
+- `revision.create`
+- `revision.approve`
+- `delivery.create`
+
+## Dry-run contract
+
+Mutating operations that support preview return `status: planned` and a structured plan. The confirmed operation must identify the same logical request. Clients must still re-read authoritative workspace state after success; JSON output does not replace post-operation reconciliation.
+
+## Output and process rules
+
+- JSON mode writes only the response object to standard output.
+- Human diagnostics and progress may use standard error only when documented.
+- Commands remain non-interactive in JSON mode.
+- Paths are returned as explicit fields, never embedded only in prose.
+- Exit codes remain documented per operation and must agree with the JSON status.
+- Secrets and unrestricted command strings are never returned.
+
+## Contract testing
+
+API releases shall include:
+
+- JSON Schema or equivalent fixtures for every response type;
+- golden success, planned, blocked, and error examples;
+- compatibility tests proving older API 1.x clients can ignore newly added optional fields;
+- tests for paths containing spaces and non-destructive dry-run behavior;
+- exact tests for operation identifiers, machine error codes, and exit-code mapping.
+
+## Open design decisions
+
+Before implementation, approve:
+
+1. whether `jl-mixing` becomes a dispatcher executable or discovery remains a dedicated command;
+2. exact exit-code mapping;
+3. progress-event behavior for long operations;
+4. whether read-only query operations ship in API 1.0 or a later 1.x addition;
+5. JSON Schema publication and location.

--- a/docs/AUTOMATION_API.md
+++ b/docs/AUTOMATION_API.md
@@ -1,6 +1,6 @@
 # JL Mixing Automation API
 
-**Status:** Proposed design; not yet implemented  
+**Status:** Approved design; not yet implemented  
 **Initial target:** API 1.0
 
 ## Purpose
@@ -181,6 +181,44 @@ Operations report `completed`, `total`, and `unit` only when the total is known 
 
 Progress support is optional by capability and operation. Cancellation semantics are not part of API 1.0 and require a separate design.
 
+## JSON Schema publication
+
+Automation API schemas use JSON Schema Draft 2020-12 and remain distinct from persisted workspace metadata schemas.
+
+The authoritative development layout is:
+
+```text
+api/
+├── schemas/
+│   └── v1.0/
+│       ├── response-envelope.schema.json
+│       ├── error.schema.json
+│       ├── warning.schema.json
+│       ├── progress-event.schema.json
+│       ├── system-info.schema.json
+│       └── operations/
+└── examples/
+    └── v1.0/
+        ├── success/
+        ├── planned/
+        ├── blocked/
+        └── error/
+```
+
+Schemas and golden examples in the JL Mixing Automation repository are the reviewed source of truth. Every Automation release supporting API 1.0 bundles the applicable schemas and examples for offline use under its installed shared-data directory. `system-info` reports the installed schema location explicitly.
+
+Released schemas are also published at immutable API-versioned GitHub Pages URLs such as:
+
+```text
+https://jlaudio.github.io/jl-mixing/api/v1.0/schemas/response-envelope.schema.json
+```
+
+Those public URLs are the canonical `$id` values. They contain the Automation API version, not the Automation application release version.
+
+Published API-version directories must not be replaced with incompatible content. New backward-compatible capabilities may add schema files within API 1.x; incompatible contract changes require a new API major version.
+
+JL Mixing Studio vendors or pins the supported schemas at build time and must not depend on downloading them at runtime.
+
 ## Output and process rules
 
 - JSON mode writes only the response object to standard output.
@@ -195,12 +233,14 @@ Progress support is optional by capability and operation. Cancellation semantics
 
 API releases shall include:
 
-- JSON Schema or equivalent fixtures for every response type;
+- JSON Schema validation for every response and progress-event type;
 - golden success, planned, blocked, and error examples;
 - compatibility tests proving older API 1.x clients can ignore newly added optional fields;
 - tests for paths containing spaces and non-destructive dry-run behavior;
 - exact tests for operation identifiers, machine error codes, and exit-code mapping;
 - progress tests proving stdout remains a single final object and progress-mode stderr contains only valid newline-delimited event objects;
+- packaging tests proving the released schemas and examples are installed with Automation;
+- publication checks proving each released schema `$id` matches its immutable API-versioned public URL;
 - parity tests proving dispatcher operations and corresponding human-facing commands use the same workflow rules and produce equivalent authoritative state.
 
 ## Approved design decisions
@@ -209,9 +249,6 @@ API releases shall include:
 2. API 1.0 preserves existing exit codes `0` through `6`: exit `0` maps to `success` or `planned`; exits `1` through `4` map to `error`; exits `5` and `6` map to `blocked`. Stable JSON machine codes provide the specific reason.
 3. API 1.0 supports opt-in progress events through `--progress=json`. Events are newline-delimited JSON on standard error, while standard output remains one final response. Progress is advisory and does not replace final-response or authoritative-state reconciliation.
 4. API 1.0 does not include general read-only queries beyond system and capability discovery. General workspace and domain queries are targeted for a backward-compatible API 1.1 addition after their contracts and Studio migration plan are designed.
+5. API schemas use JSON Schema Draft 2020-12, live under `api/schemas/<api-version>/`, ship with Automation releases for offline use, and are published at immutable API-versioned GitHub Pages URLs used as canonical `$id` values. Studio vendors or pins schemas at build time and does not download them at runtime.
 
-## Open design decisions
-
-Before implementation, approve:
-
-1. JSON Schema publication and location.
+All API 1.0 design decisions required by this document are approved. Implementation scope still requires a separate release plan and approved implementation issues.

--- a/docs/AUTOMATION_API.md
+++ b/docs/AUTOMATION_API.md
@@ -137,6 +137,14 @@ Capability names use stable dotted identifiers. Initial candidates include:
 
 Mutating operations that support preview return `status: planned` and a structured plan. The confirmed operation must identify the same logical request. Clients must still re-read authoritative workspace state after success; JSON output does not replace post-operation reconciliation.
 
+## Read-only query scope
+
+Automation API 1.0 includes system and capability discovery but does not include general read-only workspace, client, project, revision, report, or delivery query operations.
+
+General read-only queries are targeted for a backward-compatible API 1.1 addition after their normalized response models, partial-failure behavior, filtering and ordering rules, path-exposure policy, and Studio migration plan are designed. The first design should evaluate a normalized workspace snapshot operation before introducing many small query commands.
+
+Until Studio adopts those future capabilities, it may continue reading and validating authoritative workspace files directly.
+
 ## Progress-event contract
 
 Long-running API operations may support opt-in machine-readable progress through:
@@ -200,10 +208,10 @@ API releases shall include:
 1. `jl-mixing` is the canonical machine-facing API dispatcher. Existing human-facing commands remain supported and share the same underlying implementation.
 2. API 1.0 preserves existing exit codes `0` through `6`: exit `0` maps to `success` or `planned`; exits `1` through `4` map to `error`; exits `5` and `6` map to `blocked`. Stable JSON machine codes provide the specific reason.
 3. API 1.0 supports opt-in progress events through `--progress=json`. Events are newline-delimited JSON on standard error, while standard output remains one final response. Progress is advisory and does not replace final-response or authoritative-state reconciliation.
+4. API 1.0 does not include general read-only queries beyond system and capability discovery. General workspace and domain queries are targeted for a backward-compatible API 1.1 addition after their contracts and Studio migration plan are designed.
 
 ## Open design decisions
 
 Before implementation, approve:
 
-1. whether read-only query operations ship in API 1.0 or a later 1.x addition;
-2. JSON Schema publication and location.
+1. JSON Schema publication and location.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,43 @@
+# JL Mixing Automation Roadmap
+
+**Status:** Proposed for review
+
+## Product role
+
+JL Mixing Automation is the stable workflow engine and CLI for the JL Mixing ecosystem. It owns project structure, metadata validation, lifecycle rules, filesystem mutation, delivery behavior, and the public machine-readable Automation API.
+
+## Versioning
+
+The Automation application version, Automation API version, and metadata schema version are independent. Application releases may retain the same API and schema versions when their contracts do not change.
+
+## Near-term priorities
+
+1. Preserve the released v1.3.0 CLI behavior and v1.1.0 metadata schemas.
+2. Define Automation API 1.0 without changing existing human-oriented CLI behavior.
+3. Add machine-readable compatibility discovery.
+4. Add consistent JSON envelopes, operation identifiers, errors, warnings, and result semantics for Studio-supported operations.
+5. Add contract fixtures and tests that Studio can validate against.
+
+## Candidate API 1.x capabilities
+
+These are candidates, not committed release scope:
+
+- system and capability discovery;
+- structured dry-run plans;
+- structured results for existing workflow commands;
+- project, client, revision, and delivery inspection;
+- structured validation findings;
+- project health checks;
+- batch operations where transaction and partial-failure semantics are explicitly designed.
+
+## Metadata policy
+
+Metadata changes are the slowest-moving track. Add persisted fields only when the information must travel with the workspace and be understood by Automation, Studio, or another supported client. UI preferences, recent items, favorites, search history, and rebuildable indexes do not belong in project schemas.
+
+## Release admission rule
+
+A feature is assigned to an Automation release only after its behavior, API impact, schema impact, compatibility requirements, tests, and Studio dependency are approved. Cross-repository features use linked issues rather than a single mixed implementation issue.
+
+## Non-goals
+
+Automation does not own desktop presentation, local UI preferences, general-purpose indexing, cloud collaboration, accounting, CRM, or DAW session processing.


### PR DESCRIPTION
## What changed

- Adds a product-specific Automation roadmap.
- Defines the approved Automation API 1.0 design.
- Establishes the `jl-mixing` machine-facing dispatcher while preserving existing human-facing commands.
- Defines response envelopes, capabilities, dry-run behavior, exit codes, progress events, query scope, schema publication, and contract testing.

## Why

JL Mixing Studio should depend on a stable Automation API version rather than an exact Automation application release.

## Transition note

This design does not claim the current CLI output is API 1.0. Studio 1.0 remains tied to the released Automation 1.3.0 command contract until API 1.0 is implemented, released, and adopted.

## Approved design decisions

1. `jl-mixing` is the canonical machine-facing dispatcher; existing commands remain supported and share the same implementation.
2. API 1.0 preserves exit codes `0–6`, with JSON status and stable machine codes providing structured meaning.
3. Long operations may emit opt-in newline-delimited JSON progress events on stderr while stdout remains one final response.
4. General read-only workspace queries are deferred to API 1.1; API 1.0 includes system and capability discovery.
5. API schemas use Draft 2020-12, live in the Automation repository, ship with releases, and are published at immutable API-versioned GitHub Pages URLs.

## Final review focus

- Confirm the complete API 1.0 design document reflects the approved decisions.
- Confirm the roadmap remains version-agnostic until implementation scope is separately approved.
- Confirm no current CLI or metadata behavior is changed by merging these documentation files.
