### PR TITLE
Fix template rendering on Monterey Python

### DIFF
--- a/lib/templates.sh
+++ b/lib/templates.sh
@@ -60,7 +60,8 @@ if unresolved and not allow_unresolved:
 
 if not text.endswith("\n"):
     text += "\n"
-output_path.write_text(text, encoding="utf-8", newline="\n")
+with output_path.open("w", encoding="utf-8", newline="\n") as output_file:
+    output_file.write(text)
 PY_TEMPLATE
     then
         rm -f "$temp_file"
@@ -254,7 +255,8 @@ if unresolved and not allow_unresolved:
 json.loads(text)
 if not text.endswith("\n"):
     text += "\n"
-output_path.write_text(text, encoding="utf-8", newline="\n")
+with output_path.open("w", encoding="utf-8", newline="\n") as output_file:
+    output_file.write(text)
 PY_JSON_TEMPLATE
     then
         rm -f "$temp_file"

--- a/tests/unit/test-templates.sh
+++ b/tests/unit/test-templates.sh
@@ -15,6 +15,11 @@ jl_template_render "$tmp/template.txt" "$tmp/output.txt" NAME Jake PLACE Studio
 assert_eq "Hello Jake from Studio" "$(cat "$tmp/output.txt")" "render literal tokens"
 assert_failure "unresolved token rejected" jl_template_render "$tmp/template.txt" "$tmp/bad.txt" NAME Jake
 
+# Monterey ships a Python version where Path.write_text() does not accept the
+# newline keyword. Keep template rendering on the older-compatible Path.open API.
+assert_failure "unsupported Path.write_text newline API is absent" \
+    grep -F 'write_text(text, encoding="utf-8", newline=' "$ROOT/lib/templates.sh"
+
 printf '{"name":"{{NAME}}","pattern":"{{PROJECT_NAME}}"}\n' > "$tmp/template.json"
 JL_TEMPLATE_ALLOW_UNRESOLVED=1 jl_template_render_json \
     "$tmp/template.json" "$tmp/output.json" NAME 'Jake "Mix"'


### PR DESCRIPTION
## Summary

Fix JL Mixing Automation template rendering on the Python version included with macOS Monterey.

## Root cause

`Path.write_text(..., newline="\n")` relies on a keyword added after Monterey's system Python. Every text and JSON template render therefore failed when JL Mixing Studio launched Automation on the minimum supported macOS version.

## Changes

- Write rendered templates through `Path.open(..., newline="\n")` and `write()`.
- Preserve UTF-8 encoding and forced LF newline behavior.
- Cover both text and JSON template renderers.
- Add regression coverage preventing the unsupported API from returning.

## Validation

The branch is based directly on current `main` and changes only `lib/templates.sh` and its focused unit test. Full shell, strict, and release checks are delegated to CI.

Fixes JLAudio/jl-mixing-studio#67
Relates to JLAudio/jl-mixing-studio#51 and JLAudio/jl-mixing-studio#61.