### PR TITLE
Expose effective description in revision.create API

### DIFF
--- a/bin/jl-mixing
+++ b/bin/jl-mixing
@@ -64,7 +64,7 @@ elif [ "${1:-}" = "system-info" ] && [ "$#" -eq 2 ] && [ "$2" = "--json" ]; then
         exit 3
     }
     base_json="$(. "$APP_ROOT/lib/api-dispatcher-command.sh")"
-    printf '%s\n' "$base_json" | "$python" -c 'import json,sys; d=json.load(sys.stdin); d["capabilities"]=sorted(set(d.get("capabilities",[])+["delivery.create","intake.validate","project.create","project.create.artist","revision.approve","revision.create"])); print(json.dumps(d,separators=(",",":"),sort_keys=True))'
+    printf '%s\n' "$base_json" | "$python" -c 'import json,sys; d=json.load(sys.stdin); d["capabilities"]=sorted(set(d.get("capabilities",[])+["delivery.create","intake.validate","project.create","project.create.artist","revision.approve","revision.create","revision.create.description"])); print(json.dumps(d,separators=(",",":"),sort_keys=True))'
 else
     # Preserve the existing system-info and client.create dispatcher behavior
     # byte-for-byte while newer workflow adapters are layered separately.

--- a/lib/revision-create-api.sh
+++ b/lib/revision-create-api.sh
@@ -53,7 +53,7 @@ PY_ERROR
 
 jl_revision_create_response() {
     local api_version python json_seen dry_run arg output_file error_file status
-    local revision_path revision_number project_path manifest_path workspace_path project_id
+    local revision_path revision_number revision_description project_path manifest_path workspace_path project_id
     local error_code response_status message
     api_version="$(jl_revision_api_read_version)" || return $?
     python="$(jl_revision_api_python)" || return $?
@@ -99,6 +99,7 @@ jl_revision_create_response() {
 
     revision_path="$(sed -n 's/^Revision folder:[[:space:]]*//p' "$output_file" | head -1)"
     revision_number="$(sed -n -e 's/^Revision:[[:space:]]*//p' -e 's/^New revision:[[:space:]]*//p' "$output_file" | head -1)"
+    revision_description="$(sed -n 's/^Description:[[:space:]]*//p' "$output_file" | head -1)"
     project_path=""
     manifest_path=""
     workspace_path=""
@@ -120,14 +121,14 @@ PY_PROJECT_ID
     if [ "$status" -eq 0 ]; then
         if [ "$dry_run" -eq 1 ]; then response_status=planned; else response_status=success; fi
         "$python" - "$api_version" "$response_status" "$project_id" "$project_path" "$manifest_path" \
-            "$revision_number" "$revision_path" "$workspace_path" "$dry_run" <<'PY_SUCCESS'
+            "$revision_number" "$revision_path" "$revision_description" "$workspace_path" "$dry_run" <<'PY_SUCCESS'
 import json, sys
 (api_version, status, project_id, project_path, manifest_path,
- revision_number, revision_path, workspace_path, dry_run) = sys.argv[1:]
+ revision_number, revision_path, revision_description, workspace_path, dry_run) = sys.argv[1:]
 data = {
     "project": {"id": project_id, "path": project_path},
     "manifest_path": manifest_path,
-    "revision": {"number": int(revision_number), "path": revision_path},
+    "revision": {"number": int(revision_number), "path": revision_path, "description": revision_description},
     "revision_notes_path": f"{revision_path}/Revision_Notes.md",
     "workspace_path": workspace_path,
 }

--- a/tests/unit/test-api-project-create-effective-artist.sh
+++ b/tests/unit/test-api-project-create-effective-artist.sh
@@ -31,6 +31,32 @@ assert d["data"]["project"]["artist"] == "Explicit Artist"
 PY
 pass "project.create exposes explicit effective artist"
 
+(cd "$studio" && "$ROOT/bin/new-mix" "Revision Description Project" --client api-client --artist "Inherited Artist" --no-cd >/dev/null)
+project="$studio/Clients/API Client/Projects/Revision Description Project"
+revision_explicit="$tmp/revision-explicit.json"
+"$ROOT/bin/jl-mixing" revision create --json --project "$project" --description "Vocal lift" --dry-run >"$revision_explicit"
+python3 - "$revision_explicit" <<'PY'
+import json, sys
+from pathlib import Path
+d = json.loads(Path(sys.argv[1]).read_text())
+assert d["status"] == "planned"
+assert d["data"]["revision"]["number"] == 2
+assert d["data"]["revision"]["description"] == "Vocal lift"
+PY
+pass "revision.create exposes explicit effective description"
+
+revision_default="$tmp/revision-default.json"
+"$ROOT/bin/jl-mixing" revision create --json --project "$project" --dry-run >"$revision_default"
+python3 - "$revision_default" <<'PY'
+import json, sys
+from pathlib import Path
+d = json.loads(Path(sys.argv[1]).read_text())
+assert d["status"] == "planned"
+assert d["data"]["revision"]["number"] == 2
+assert d["data"]["revision"]["description"] == "Revision 2"
+PY
+pass "revision.create exposes default effective description"
+
 info="$tmp/system-info.json"
 "$ROOT/bin/jl-mixing" system-info --json >"$info"
 python3 - "$info" <<'PY'
@@ -38,5 +64,6 @@ import json, sys
 from pathlib import Path
 d = json.loads(Path(sys.argv[1]).read_text())
 assert "project.create.artist" in d["capabilities"]
+assert "revision.create.description" in d["capabilities"]
 PY
-pass "system-info advertises project artist capability"
+pass "system-info advertises additive effective-value capabilities"

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -33,7 +33,7 @@ assert document["metadata"] == {
     "readable_schema_versions": ["1.1.0"],
     "writable_schema_version": "1.1.0",
 }
-assert document["capabilities"] == ["client.create", "delivery.create", "intake.validate", "project.create", "project.create.artist", "revision.approve", "revision.create", "system.info"]
+assert document["capabilities"] == ["client.create", "delivery.create", "intake.validate", "project.create", "project.create.artist", "revision.approve", "revision.create", "revision.create.description", "system.info"]
 assert Path(document["schemas"]["installed_path"]).resolve() == (
     root / "api" / "schemas" / f"v{api_version}"
 ).resolve()


### PR DESCRIPTION
## Summary

Adds a backward-compatible Automation API 1.0 extension so `revision.create` exposes the effective description resolved by the existing revision-creation service.

## Changes

- adds `data.revision.description` to planned and success responses
- advertises `revision.create.description` through `system-info --json`
- covers both explicit descriptions and the existing provider-default `Revision N` behavior
- updates the discovery contract expectation
- preserves API version 1.0 and existing revision creation semantics

This unblocks the JL Mixing Studio v1.1 `revision.create` consumer migration without duplicating Automation defaulting rules in Studio.

Closes #62
Related consumer: JLAudio/jl-mixing-studio#75