### PR TITLE
Expose authoritative intake report content in intake.validate API

### DIFF
--- a/bin/jl-mixing
+++ b/bin/jl-mixing
@@ -64,7 +64,7 @@ elif [ "${1:-}" = "system-info" ] && [ "$#" -eq 2 ] && [ "$2" = "--json" ]; then
         exit 3
     }
     base_json="$(. "$APP_ROOT/lib/api-dispatcher-command.sh")"
-    printf '%s\n' "$base_json" | "$python" -c 'import json,sys; d=json.load(sys.stdin); d["capabilities"]=sorted(set(d.get("capabilities",[])+["delivery.create","intake.validate","project.create","project.create.artist","revision.approve","revision.create","revision.create.description"])); print(json.dumps(d,separators=(",",":"),sort_keys=True))'
+    printf '%s\n' "$base_json" | "$python" -c 'import json,sys; d=json.load(sys.stdin); d["capabilities"]=sorted(set(d.get("capabilities",[])+["delivery.create","intake.validate","intake.validate.report","project.create","project.create.artist","revision.approve","revision.create","revision.create.description"])); print(json.dumps(d,separators=(",",":"),sort_keys=True))'
 else
     # Preserve the existing system-info and client.create dispatcher behavior
     # byte-for-byte while newer workflow adapters are layered separately.

--- a/lib/intake-validate-api.sh
+++ b/lib/intake-validate-api.sh
@@ -50,7 +50,7 @@ PY_ERROR
 jl_intake_validate_response() {
     local api_version python json_seen dry_run project_ref project_seen arg previous
     local output_file error_file status project_path manifest_path report_path workspace_path project_id
-    local files_discovered blocking_errors warning_count source_path ffprobe_available
+    local files_discovered blocking_errors warning_count source_path ffprobe_available report_content_path
     local error_code response_status message completed_scan
     api_version="$(jl_intake_api_read_version)" || return $?
     python="$(jl_intake_api_python)" || return $?
@@ -151,19 +151,27 @@ PY_PROJECT
         else
             response_status=error
         fi
+        if [ "$dry_run" -eq 1 ]; then
+            report_content_path="$output_file"
+        else
+            report_content_path="$report_path"
+        fi
         "$python" - "$api_version" "$response_status" "$project_id" "$project_path" "$manifest_path" \
             "$report_path" "$workspace_path" "$source_path" "$files_discovered" "$blocking_errors" \
-            "$warning_count" "$ffprobe_available" "$dry_run" "$status" <<'PY_RESULT'
+            "$warning_count" "$ffprobe_available" "$dry_run" "$status" "$report_content_path" <<'PY_RESULT'
 import json, sys
+from pathlib import Path
 (api_version, status, project_id, project_path, manifest_path, report_path,
  workspace_path, source_path, files_discovered, blocking_errors, warnings,
- ffprobe_available, dry_run, exit_code) = sys.argv[1:]
+ ffprobe_available, dry_run, exit_code, report_content_path) = sys.argv[1:]
+report_markdown = Path(report_content_path).read_text(encoding="utf-8")
 data = {
     "project": {"id": project_id, "path": project_path},
     "manifest_path": manifest_path,
     "intake_report_path": report_path,
     "workspace_path": workspace_path,
     "source_path": source_path,
+    "report_markdown": report_markdown,
     "summary": {
         "files_discovered": int(files_discovered),
         "blocking_errors": int(blocking_errors),

--- a/tests/unit/test-api-project-create-effective-artist.sh
+++ b/tests/unit/test-api-project-create-effective-artist.sh
@@ -57,6 +57,35 @@ assert d["data"]["revision"]["description"] == "Revision 2"
 PY
 pass "revision.create exposes default effective description"
 
+(cd "$studio" && "$ROOT/bin/new-mix" "Intake Report Project" --client api-client --artist "Inherited Artist" --no-cd >/dev/null)
+intake_project="$studio/Clients/API Client/Projects/Intake Report Project"
+printf 'session notes\n' > "$intake_project/01_Client_Files/Original_Delivery/Notes.txt"
+intake_planned="$tmp/intake-planned.json"
+"$ROOT/bin/jl-mixing" intake validate --json --project "$intake_project" --dry-run >"$intake_planned"
+python3 - "$intake_planned" <<'PY'
+import json, sys
+from pathlib import Path
+d = json.loads(Path(sys.argv[1]).read_text())
+assert d["status"] == "planned"
+report = d["data"]["report_markdown"]
+assert "## Intake Summary" in report
+assert "Notes.txt" in report
+assert d["data"]["summary"]["files_discovered"] == 1
+PY
+pass "intake.validate dry-run exposes provider-authored report content"
+
+intake_success="$tmp/intake-success.json"
+"$ROOT/bin/jl-mixing" intake validate --json --project "$intake_project" >"$intake_success"
+python3 - "$intake_success" "$intake_project/00_Admin/Intake_Report.md" <<'PY'
+import json, sys
+from pathlib import Path
+d = json.loads(Path(sys.argv[1]).read_text())
+report_path = Path(sys.argv[2])
+assert d["status"] == "success"
+assert d["data"]["report_markdown"] == report_path.read_text(encoding="utf-8")
+PY
+pass "intake.validate success exposes persisted authoritative report content"
+
 info="$tmp/system-info.json"
 "$ROOT/bin/jl-mixing" system-info --json >"$info"
 python3 - "$info" <<'PY'
@@ -65,5 +94,6 @@ from pathlib import Path
 d = json.loads(Path(sys.argv[1]).read_text())
 assert "project.create.artist" in d["capabilities"]
 assert "revision.create.description" in d["capabilities"]
+assert "intake.validate.report" in d["capabilities"]
 PY
-pass "system-info advertises additive effective-value capabilities"
+pass "system-info advertises additive effective-value and report capabilities"

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -33,7 +33,7 @@ assert document["metadata"] == {
     "readable_schema_versions": ["1.1.0"],
     "writable_schema_version": "1.1.0",
 }
-assert document["capabilities"] == ["client.create", "delivery.create", "intake.validate", "project.create", "project.create.artist", "revision.approve", "revision.create", "revision.create.description", "system.info"]
+assert document["capabilities"] == ["client.create", "delivery.create", "intake.validate", "intake.validate.report", "project.create", "project.create.artist", "revision.approve", "revision.create", "revision.create.description", "system.info"]
 assert Path(document["schemas"]["installed_path"]).resolve() == (
     root / "api" / "schemas" / f"v{api_version}"
 ).resolve()


### PR DESCRIPTION
## Summary

Adds a backward-compatible Automation API 1.0 extension so `intake.validate` exposes the exact provider-authored intake report content needed by Studio.

## Changes

- adds `data.report_markdown` to completed `intake.validate` responses
- dry-run returns the generated non-mutating report Markdown
- normal validation returns the persisted authoritative `Intake_Report.md` content
- advertises `intake.validate.report` through `system-info --json`
- preserves existing summary fields, blocking/error semantics, and API version 1.0
- adds focused contract coverage for planned and successful validation responses

This unblocks the JL Mixing Studio v1.1 intake consumer migration without duplicating Automation report-generation rules in Studio.

Closes #64
Related consumer: JLAudio/jl-mixing-studio#75