### PR TITLE
Start v1.5 cross-platform Python runtime

### DIFF
--- a/docs/V1.5_ARCHITECTURE.md
+++ b/docs/V1.5_ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# JL Mixing Automation v1.5 Cross-Platform Architecture
+
+## Decision
+
+JL Mixing Automation v1.5 will move the authoritative runtime and workflow
+implementation to Python 3.
+
+The same Python implementation will run on macOS and Windows. End-user release
+packages will bundle the required runtime so a separately installed Python
+interpreter is not an end-user prerequisite.
+
+## Why Python
+
+The v1.4 codebase already depends on Python for Automation API JSON handling,
+JSON Schema validation tooling, and selected state-processing utilities. Moving
+the authoritative workflow logic to Python therefore minimizes semantic-port
+risk compared with a full rewrite in Rust or Go while still removing the Bash,
+`jq`, and POSIX-shell assumptions that prevent native Windows support.
+
+Rust and Go remain technically viable, but both would require a larger rewrite
+of stable v1.4 behavior with no required API or CLI change in v1.5.
+
+## Compatibility constraints
+
+v1.5 is a platform port, not a workflow redesign.
+
+- Automation API version remains `1.0`.
+- API operations, response envelopes, capability names, status behavior, and
+  exit-code semantics remain compatible with v1.4.
+- Human CLI command names, options, defaults, and observable behavior remain
+  compatible with v1.4.
+- Workspace metadata schema identities remain `1.1.0`.
+- Valid v1.1+ workspaces remain usable without migration.
+- macOS and Windows use the same authoritative service implementation.
+- Platform-specific code is limited to launch/install/package integration and
+  unavoidable OS behavior such as executable discovery.
+
+## Target runtime layout
+
+```text
+src/jl_mixing/
+  cli.py             cross-platform command dispatcher
+  versions.py        application/API/schema version discovery
+  system_info.py     API discovery document
+  paths.py           path normalization and workspace safety
+  metadata.py        JSON metadata read/write/validation
+  transactions.py    staged atomic filesystem mutations
+  context.py         studio/client/project resolution
+  services/          authoritative workflow services
+  api/               Automation API 1.0 adapters
+```
+
+Human-facing commands and Automation API operations must call the same service
+layer. API adapters must not parse human CLI output.
+
+## Migration sequence
+
+1. Establish the Python package and `system-info --json` parity.
+2. Port shared version/path/metadata/context/transaction primitives.
+3. Port non-mutating intake validation and parity tests.
+4. Port creation workflows: studio, client, project, revision.
+5. Port revision approval and delivery creation.
+6. Replace Bash command entry points with thin launchers to the Python runtime.
+7. Add Windows CI, installation, packaging, path, and filesystem safety tests.
+8. Build self-contained macOS and Windows release artifacts.
+9. Run the v1.4 CLI/API compatibility matrix on both platforms before RC.
+
+## Packaging direction
+
+Development uses normal Python execution. Release packaging will produce a
+self-contained application artifact for each supported OS using a free/open
+source Python bundling tool selected during the packaging workstream. The
+package must include the API schemas and templates and expose the existing
+command surface without requiring users to install Python, Bash, or `jq`.
+
+## Definition of done
+
+The port is complete when the same source implementation passes the preserved
+v1.4 behavioral/API compatibility suite on macOS and Windows, plus platform-
+specific install/package/path tests, with no metadata migration and no API 1.0
+contract regression.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=70"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jl-mixing"
+dynamic = ["version"]
+description = "Cross-platform JL Mixing Automation runtime"
+requires-python = ">=3.10"
+license = {text = "Apache-2.0"}
+
+[project.scripts]
+jl-mixing-python = "jl_mixing.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.dynamic]
+version = {file = ["VERSION"]}

--- a/src/jl_mixing/__init__.py
+++ b/src/jl_mixing/__init__.py
@@ -1,0 +1,5 @@
+"""Cross-platform JL Mixing Automation runtime."""
+
+from .versions import application_version
+
+__all__ = ["application_version"]

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -1,0 +1,32 @@
+"""Cross-platform JL Mixing Automation command dispatcher."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+
+from .system_info import document as system_info_document
+
+EXIT_ARGUMENTS = 2
+EXIT_CONFIG = 3
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+
+    if args == ["system-info", "--json"]:
+        try:
+            payload = system_info_document()
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return EXIT_CONFIG
+        print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+        return 0
+
+    print("Error: command has not yet been migrated to the v1.5 Python runtime.", file=sys.stderr)
+    return EXIT_ARGUMENTS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -1,0 +1,35 @@
+"""Automation API 1.0 discovery document."""
+
+from __future__ import annotations
+
+from .versions import api_version, application_version, schema_root
+
+_CAPABILITIES = [
+    "client.create",
+    "delivery.create",
+    "intake.validate",
+    "intake.validate.report",
+    "project.create",
+    "project.create.artist",
+    "revision.approve",
+    "revision.create",
+    "revision.create.description",
+    "system.info",
+]
+
+
+def document() -> dict[str, object]:
+    version = api_version()
+    return {
+        "api_version": version,
+        "application": {"name": "jl-mixing", "version": application_version()},
+        "metadata": {
+            "readable_schema_versions": ["1.1.0"],
+            "writable_schema_version": "1.1.0",
+        },
+        "capabilities": list(_CAPABILITIES),
+        "schemas": {
+            "installed_path": str(schema_root().resolve()),
+            "public_base_url": f"https://jlaudio.github.io/jl-mixing/api/v{version}/schemas/",
+        },
+    }

--- a/src/jl_mixing/versions.py
+++ b/src/jl_mixing/versions.py
@@ -1,0 +1,51 @@
+"""Version and installed-resource discovery for JL Mixing Automation."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+_SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+_API_VERSION = re.compile(r"^[0-9]+\.[0-9]+$")
+
+
+def application_root() -> Path:
+    """Return the installed application root.
+
+    JL_MIXING_HOME remains supported for compatibility with the v1.4 launch and
+    test environment. Otherwise resolve from the source/package layout.
+    """
+
+    override = os.environ.get("JL_MIXING_HOME")
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path(__file__).resolve().parents[2]
+
+
+def _read_first_line(path: Path, label: str) -> str:
+    try:
+        value = path.read_text(encoding="utf-8").splitlines()[0].strip()
+    except (OSError, IndexError) as exc:
+        raise RuntimeError(f"Unable to read {label}: {path}") from exc
+    if not value:
+        raise RuntimeError(f"Empty {label}: {path}")
+    return value
+
+
+def application_version() -> str:
+    value = _read_first_line(application_root() / "VERSION", "application version")
+    if not _SEMVER.fullmatch(value):
+        raise RuntimeError(f"Invalid application version: {value}")
+    return value
+
+
+def api_version() -> str:
+    value = _read_first_line(application_root() / "API_VERSION", "Automation API version")
+    if not _API_VERSION.fullmatch(value):
+        raise RuntimeError(f"Invalid Automation API version: {value}")
+    return value
+
+
+def schema_root() -> Path:
+    return application_root() / "api" / "schemas" / f"v{api_version()}"

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))
+
+from jl_mixing.system_info import document
+
+
+class SystemInfoTests(unittest.TestCase):
+    def test_document_preserves_v14_contract(self) -> None:
+        info = document()
+        self.assertEqual(info["api_version"], "1.0")
+        self.assertEqual(info["application"]["name"], "jl-mixing")
+        self.assertEqual(info["application"]["version"], (ROOT / "VERSION").read_text().strip())
+        self.assertEqual(
+            info["metadata"],
+            {
+                "readable_schema_versions": ["1.1.0"],
+                "writable_schema_version": "1.1.0",
+            },
+        )
+        self.assertEqual(
+            info["capabilities"],
+            [
+                "client.create",
+                "delivery.create",
+                "intake.validate",
+                "intake.validate.report",
+                "project.create",
+                "project.create.artist",
+                "revision.approve",
+                "revision.create",
+                "revision.create.description",
+                "system.info",
+            ],
+        )
+        self.assertEqual(
+            Path(info["schemas"]["installed_path"]),
+            (ROOT / "api" / "schemas" / "v1.0").resolve(),
+        )
+
+    def test_cli_emits_machine_json(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(SRC)
+        proc = subprocess.run(
+            [sys.executable, "-m", "jl_mixing.cli", "system-info", "--json"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stderr, "")
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload, document())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -119,7 +119,7 @@ echo "[OK] Shell syntax"
 for test_file in tests/unit/test-*.sh; do
     echo
     echo "Running $test_file"
-    "$test_file"
+    bash "$test_file"
 done
 
 validator_python="${JL_MIXING_PYTHON:-}"
@@ -144,7 +144,7 @@ if [ "$runtime_available" -eq 1 ]; then
     for test_file in tests/integration/test-*.sh; do
         echo
         echo "Running $test_file"
-        "$test_file"
+        bash "$test_file"
     done
     echo
     "$validator_python" tools/validate-json.py --strict
@@ -157,7 +157,7 @@ if [ "$runtime_available" -eq 1 ]; then
         for test_file in tests/installation/test-*.sh; do
             echo
             echo "Running $test_file"
-            "$test_file"
+            bash "$test_file"
         done
     fi
 else

--- a/tests/unit/test-python-runtime.sh
+++ b/tests/unit/test-python-runtime.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+python="${JL_MIXING_PYTHON:-$(command -v python3 || true)}"
+[ -n "$python" ] || { echo "Missing Python 3" >&2; exit 1; }
+
+PYTHONPATH="$ROOT/src" "$python" -m unittest discover -s "$ROOT/tests/python" -p 'test_*.py'


### PR DESCRIPTION
## Summary

Begins JL Mixing Automation v1.5 Windows support under umbrella #71 by establishing the cross-platform Python runtime boundary without changing the active v1.4 command implementation yet.

## Changes

- documents the v1.5 Python architecture and migration sequence
- adds `src/jl_mixing` runtime package
- adds cross-platform application/API/schema version discovery
- adds Python `system-info --json` provider preserving the full v1.4 API 1.0 capability set
- adds an initial Python CLI entry point
- adds package metadata/entry point for development
- adds Python unit/CLI parity coverage and hooks it into the existing test runner

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- existing Bash command launchers remain authoritative in this first slice
- no v1.4 workflow behavior is intentionally changed

## Next slices after this PR is green

1. cross-platform path/context/metadata/transaction primitives
2. non-mutating intake validation port and parity
3. creation workflows
4. approval/delivery workflows
5. launcher cutover and Windows CI/package lifecycle

Closes no issue; part of #71.