### PR TITLE
Add v1.5 cross-platform filesystem and context primitives

### DIFF
--- a/src/jl_mixing/context.py
+++ b/src/jl_mixing/context.py
@@ -1,0 +1,94 @@
+"""Cross-platform studio, client, project, and revision context discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .errors import ArgumentError, ContextError, ValidationError
+from .paths import native_absolute_path
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Invalid JSON document: {path}") from exc
+
+
+def _require_identity(path: Path, schema: str, version: str = "1.1.0") -> None:
+    if path.is_symlink() or not path.is_file():
+        raise ContextError(f"Required context marker not found or unsafe: {path}")
+    document = _read_json(path)
+    metadata = document.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValidationError(f"Missing metadata in: {path}")
+    if metadata.get("schema") != schema or metadata.get("schema_version") != version:
+        raise ValidationError(f"Unexpected schema identity in: {path}")
+
+
+def find_up_safe(start: Path | str, relative_marker: str) -> Path:
+    current = native_absolute_path(start, base=Path.cwd())
+    if not current.is_dir():
+        current = current.parent
+    while True:
+        marker = current.joinpath(*relative_marker.split("/"))
+        if marker.is_file() and not marker.is_symlink():
+            return current
+        if current.parent == current:
+            break
+        current = current.parent
+    raise ContextError(f"No context marker '{relative_marker}' found from: {start}")
+
+
+def project_root(start: Path | str) -> Path:
+    root = find_up_safe(start, "00_Admin/project-manifest.json")
+    _require_identity(root / "00_Admin" / "project-manifest.json", "mixing-project")
+    return root
+
+
+def client_root(start: Path | str) -> Path:
+    root = find_up_safe(start, "client.json")
+    _require_identity(root / "client.json", "mixing-client")
+    return root
+
+
+def studio_root(start: Path | str) -> Path:
+    root = find_up_safe(start, "Studio/studio.json")
+    _require_identity(root / "Studio" / "studio.json", "mixing-studio")
+    return root
+
+
+def resolve_project(explicit: Path | str | None, start: Path | str) -> Path:
+    if explicit is None or str(explicit) == "":
+        return project_root(start)
+    candidate = native_absolute_path(explicit, base=native_absolute_path(start, base=Path.cwd()))
+    if candidate.is_file() and candidate.name == "project-manifest.json":
+        candidate = candidate.parent.parent
+    manifest = candidate / "00_Admin" / "project-manifest.json"
+    if candidate.is_symlink() or manifest.is_symlink() or not manifest.is_file():
+        raise ContextError(f"Project not found or unsafe at explicit path: {explicit}")
+    _require_identity(manifest, "mixing-project")
+    return candidate
+
+
+def resolve_client(explicit: Path | str | None, start: Path | str) -> Path:
+    if explicit is None or str(explicit) == "":
+        return client_root(start)
+    candidate = native_absolute_path(explicit, base=native_absolute_path(start, base=Path.cwd()))
+    if candidate.is_file() and candidate.name == "client.json":
+        candidate = candidate.parent
+    marker = candidate / "client.json"
+    if candidate.is_symlink() or marker.is_symlink() or not marker.is_file():
+        raise ContextError(f"Client not found or unsafe at explicit path: {explicit}")
+    _require_identity(marker, "mixing-client")
+    return candidate
+
+
+def revision_root_for_number(project: Path, number: int) -> Path:
+    if not isinstance(number, int) or number < 1:
+        raise ArgumentError(f"Invalid revision number: {number}")
+    root = project / "04_Revisions" / f"Revision_{number:02d}"
+    if root.is_symlink() or not root.is_dir():
+        raise ContextError(f"Revision directory not found or unsafe: {root}")
+    return root

--- a/src/jl_mixing/errors.py
+++ b/src/jl_mixing/errors.py
@@ -1,0 +1,36 @@
+"""Shared JL Mixing runtime errors and stable exit-code semantics."""
+
+from __future__ import annotations
+
+EXIT_GENERAL = 1
+EXIT_ARGUMENTS = 2
+EXIT_CONFIG = 3
+EXIT_CONTEXT = 4
+EXIT_VALIDATION = 5
+EXIT_UNSAFE = 6
+
+
+class JLMixingError(RuntimeError):
+    """Base exception carrying the existing CLI exit-code contract."""
+
+    exit_code = EXIT_GENERAL
+
+
+class ArgumentError(JLMixingError):
+    exit_code = EXIT_ARGUMENTS
+
+
+class ConfigurationError(JLMixingError):
+    exit_code = EXIT_CONFIG
+
+
+class ContextError(JLMixingError):
+    exit_code = EXIT_CONTEXT
+
+
+class ValidationError(JLMixingError):
+    exit_code = EXIT_VALIDATION
+
+
+class UnsafeOperationError(JLMixingError):
+    exit_code = EXIT_UNSAFE

--- a/src/jl_mixing/paths.py
+++ b/src/jl_mixing/paths.py
@@ -1,0 +1,144 @@
+"""Cross-platform path and filesystem safety primitives."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path, PurePosixPath
+
+from .errors import UnsafeOperationError, ValidationError
+
+_ORIGINAL_DELIVERY_PARTS = ("01_Client_Files", "Original_Delivery")
+_DAW_PROJECT_PART = "03_DAW_Project"
+
+
+def portable_relative_path(value: str) -> PurePosixPath:
+    """Validate a manifest-relative path using the v1.4 portable grammar."""
+
+    if not value or value.startswith("/") or "\\" in value:
+        raise ValidationError(f"Unsafe relative path: {value}")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValidationError(f"Unsafe relative path segments in: {value}")
+    return PurePosixPath(*parts)
+
+
+def native_absolute_path(value: str | os.PathLike[str], *, base: Path | None = None) -> Path:
+    """Resolve a native path without imposing POSIX lexical rules on Windows."""
+
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        if base is None:
+            raise ValidationError(f"Absolute path required: {value}")
+        path = Path(base) / path
+    return path.resolve(strict=False)
+
+
+def resolve_under_root(root: Path, relative: str) -> Path:
+    """Resolve a validated portable relative path beneath a native root."""
+
+    root = native_absolute_path(root)
+    rel = portable_relative_path(relative)
+    candidate = root.joinpath(*rel.parts).resolve(strict=False)
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise UnsafeOperationError(f"Resolved path escapes root '{root}': {relative}") from exc
+    return candidate
+
+
+def _contains_subsequence(parts: tuple[str, ...], needle: tuple[str, ...]) -> bool:
+    width = len(needle)
+    return any(parts[index : index + width] == needle for index in range(len(parts) - width + 1))
+
+
+def is_original_delivery_path(path: Path | str) -> bool:
+    parts = native_absolute_path(path, base=Path.cwd()).parts
+    return _contains_subsequence(parts, _ORIGINAL_DELIVERY_PARTS)
+
+
+def is_daw_project_path(path: Path | str) -> bool:
+    return _DAW_PROJECT_PART in native_absolute_path(path, base=Path.cwd()).parts
+
+
+def assert_mutable_path(path: Path | str) -> None:
+    if is_original_delivery_path(path):
+        raise UnsafeOperationError(
+            f"Unsafe operation prevented inside immutable Original_Delivery: {path}"
+        )
+
+
+def assert_automation_owned_path(path: Path | str) -> None:
+    assert_mutable_path(path)
+    if is_daw_project_path(path):
+        raise UnsafeOperationError(
+            f"Unsafe operation prevented inside opaque 03_DAW_Project: {path}"
+        )
+
+
+def find_case_insensitive_child_collision(parent: Path, proposed: str) -> Path | None:
+    if not parent.is_dir():
+        return None
+    wanted = proposed.casefold()
+    for child in parent.iterdir():
+        if child.name.casefold() == wanted:
+            return child
+    return None
+
+
+def assert_no_case_insensitive_child_collision(parent: Path, proposed: str) -> None:
+    collision = find_case_insensitive_child_collision(parent, proposed)
+    if collision is not None:
+        raise ValidationError(f"Case-insensitive path collision: {collision}")
+
+
+def assert_no_symlink_components(root: Path, destination: Path) -> None:
+    """Reject symlinks from root through the existing destination components."""
+
+    if root.is_symlink():
+        raise UnsafeOperationError(f"Symlink root is not allowed: {root}")
+    root = root.resolve(strict=True)
+    destination = native_absolute_path(destination)
+    try:
+        relative = destination.relative_to(root)
+    except ValueError as exc:
+        raise UnsafeOperationError(f"Path escapes root: {destination}") from exc
+
+    current = root
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            raise UnsafeOperationError(f"Symbolic-link path component is not allowed: {current}")
+        if not current.exists():
+            break
+
+
+def ensure_directory(path: Path) -> None:
+    if path.exists() and not path.is_dir():
+        raise UnsafeOperationError(f"Cannot create directory because a non-directory exists: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def create_directory(path: Path) -> None:
+    if path.exists() or path.is_symlink():
+        raise UnsafeOperationError(f"Refusing to overwrite existing path: {path}")
+    path.mkdir(parents=True)
+
+
+def copy_file_exact(source: Path, destination: Path) -> None:
+    if not source.is_file() or source.is_symlink():
+        raise ValidationError(f"Source file not found or unsafe: {source}")
+    assert_mutable_path(destination)
+    if destination.exists() or destination.is_symlink():
+        raise UnsafeOperationError(f"Refusing to overwrite existing destination: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+
+
+def remove_entry_no_follow(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+    elif path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        raise UnsafeOperationError(f"Unsupported filesystem entry cannot be removed safely: {path}")

--- a/src/jl_mixing/transactions.py
+++ b/src/jl_mixing/transactions.py
@@ -1,0 +1,48 @@
+"""Cross-platform staged file transaction primitives."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from .paths import assert_mutable_path
+
+
+def atomic_write_bytes(target: Path, data: bytes, *, mode: int | None = None) -> None:
+    """Atomically replace one file using a temporary sibling and os.replace()."""
+
+    assert_mutable_path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    existing_mode = None
+    if target.exists() and target.is_file():
+        existing_mode = target.stat().st_mode & 0o777
+
+    fd, temp_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        final_mode = mode if mode is not None else existing_mode
+        if final_mode is not None:
+            os.chmod(temp_path, final_mode)
+        os.replace(temp_path, target)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
+def atomic_write_text(
+    target: Path,
+    text: str,
+    *,
+    encoding: str = "utf-8",
+    newline: str = "\n",
+    mode: int | None = None,
+) -> None:
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    if newline != "\n":
+        normalized = normalized.replace("\n", newline)
+    atomic_write_bytes(target, normalized.encode(encoding), mode=mode)

--- a/tests/python/test_primitives.py
+++ b/tests/python/test_primitives.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.context import client_root, project_root, resolve_project, revision_root_for_number, studio_root
+from jl_mixing.errors import ContextError, UnsafeOperationError, ValidationError
+from jl_mixing.paths import (
+    assert_automation_owned_path,
+    assert_no_case_insensitive_child_collision,
+    assert_no_symlink_components,
+    portable_relative_path,
+    resolve_under_root,
+)
+from jl_mixing.transactions import atomic_write_text
+
+
+def write_record(path: Path, schema: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "schema": schema,
+                    "schema_version": "1.1.0",
+                    "created_with": "jl-mixing 1.4.0",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class PortablePathTests(unittest.TestCase):
+    def test_manifest_paths_remain_forward_slash_portable(self) -> None:
+        self.assertEqual(str(portable_relative_path("Stems/Drums.wav")), "Stems/Drums.wav")
+        for invalid in ("", "/absolute", "../escape", "a//b", "a/./b", r"a\b"):
+            with self.subTest(invalid=invalid), self.assertRaises(ValidationError):
+                portable_relative_path(invalid)
+
+    def test_resolve_under_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            self.assertEqual(resolve_under_root(root, "A/B.wav"), root / "A" / "B.wav")
+
+    def test_case_insensitive_collision_is_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Client").mkdir()
+            with self.assertRaises(ValidationError):
+                assert_no_case_insensitive_child_collision(root, "client")
+
+    def test_user_owned_boundaries_are_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "Project"
+            for path in (
+                project / "01_Client_Files" / "Original_Delivery" / "source.wav",
+                project / "03_DAW_Project" / "session.logicx",
+            ):
+                with self.subTest(path=path), self.assertRaises(UnsafeOperationError):
+                    assert_automation_owned_path(path)
+
+    @unittest.skipIf(os.name == "nt", "Windows symlink creation may require elevated developer settings")
+    def test_symlink_component_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "root"
+            outside = Path(tmp) / "outside"
+            root.mkdir(); outside.mkdir()
+            (root / "link").symlink_to(outside, target_is_directory=True)
+            with self.assertRaises(UnsafeOperationError):
+                assert_no_symlink_components(root, root / "link" / "file.txt")
+
+
+class ContextTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name) / "Studio Root"
+        self.client = self.root / "Clients" / "API Client"
+        self.project = self.client / "Projects" / "Blue Sky"
+        self.revision = self.project / "04_Revisions" / "Revision_01"
+        self.revision.mkdir(parents=True)
+        write_record(self.root / "Studio" / "studio.json", "mixing-studio")
+        write_record(self.client / "client.json", "mixing-client")
+        write_record(self.project / "00_Admin" / "project-manifest.json", "mixing-project")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_upward_discovery_matches_workspace_boundaries(self) -> None:
+        leaf = self.revision / "nested" / "file.wav"
+        self.assertEqual(project_root(leaf), self.project.resolve())
+        self.assertEqual(client_root(leaf), self.client.resolve())
+        self.assertEqual(studio_root(leaf), self.root.resolve())
+
+    def test_explicit_manifest_path_resolves_project(self) -> None:
+        manifest = self.project / "00_Admin" / "project-manifest.json"
+        self.assertEqual(resolve_project(manifest, self.root), self.project.resolve())
+
+    def test_revision_number_uses_flattened_canonical_layout(self) -> None:
+        self.assertEqual(revision_root_for_number(self.project, 1), self.revision)
+        with self.assertRaises(ContextError):
+            revision_root_for_number(self.project, 2)
+
+
+class TransactionTests(unittest.TestCase):
+    def test_atomic_write_replaces_content_without_temp_leak(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "state.json"
+            target.write_text("old\n", encoding="utf-8")
+            atomic_write_text(target, "new\r\n")
+            self.assertEqual(target.read_bytes(), b"new\n")
+            self.assertEqual([p.name for p in target.parent.iterdir()], ["state.json"])
+
+    def test_atomic_write_rejects_original_delivery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "01_Client_Files" / "Original_Delivery" / "state.txt"
+            with self.assertRaises(UnsafeOperationError):
+                atomic_write_text(target, "unsafe")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by porting the first shared safety/context primitives to the cross-platform Python runtime.

## Changes

- add shared Python exceptions carrying the existing exit-code contract
- distinguish portable manifest-relative paths from native OS absolute paths
- preserve immutable `Original_Delivery` and opaque `03_DAW_Project` boundaries
- add case-insensitive child-collision checks
- add no-symlink-component validation
- add safe directory/copy/remove primitives
- add studio/client/project upward context discovery with schema identity checks
- add explicit project/client resolution and canonical revision path resolution
- add sibling-temp + `os.replace()` atomic file writes
- add Python parity/safety tests for these primitives

## Compatibility

- Automation API remains 1.0
- workspace metadata schemas remain 1.1.0
- v1.4 Bash workflows remain authoritative while migration is staged
- manifest-relative paths retain their forward-slash portable grammar
- native paths use the host OS path rules so the same source can operate on Windows and macOS

## Follow-up

Metadata mutation/validation primitives and workflow service ports remain subsequent slices.

Part of #71.