### PR TITLE
Add v1.5 cross-platform metadata primitives

### DIFF
--- a/src/jl_mixing/metadata.py
+++ b/src/jl_mixing/metadata.py
@@ -1,0 +1,98 @@
+"""Cross-platform metadata creation, validation, and mutation."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from .errors import ArgumentError, ValidationError
+from .transactions import atomic_write_text
+from .versions import application_version
+
+_SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+
+
+def now_iso8601() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def created_with() -> str:
+    return f"jl-mixing {application_version()}"
+
+
+def validate_created_with(value: object) -> str:
+    if not isinstance(value, str) or not value.startswith("jl-mixing "):
+        raise ValidationError(f"Invalid created_with value: {value}")
+    version = value.removeprefix("jl-mixing ")
+    if not _SEMVER.fullmatch(version):
+        raise ValidationError(f"Invalid jl-mixing semantic version: {version}")
+    return value
+
+
+def create_v11(
+    schema: str,
+    *,
+    mutability: Literal["mutable", "immutable"],
+    schema_version: str = "1.1.0",
+    document_id: str | None = None,
+    timestamp: str | None = None,
+) -> dict[str, str]:
+    if mutability not in {"mutable", "immutable"}:
+        raise ArgumentError(f"Unknown metadata mutability: {mutability}")
+    timestamp = timestamp or now_iso8601()
+    metadata = {
+        "schema": schema,
+        "schema_version": schema_version,
+        "document_id": document_id or str(uuid.uuid4()),
+        "created_with": created_with(),
+        "created_at": timestamp,
+    }
+    if mutability == "mutable":
+        metadata["last_modified_at"] = timestamp
+    return metadata
+
+
+def validate_v11(
+    metadata: object,
+    expected_schema: str,
+    *,
+    mutability: Literal["mutable", "immutable"],
+) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        raise ValidationError("Missing metadata object")
+    if metadata.get("schema") != expected_schema or metadata.get("schema_version") != "1.1.0":
+        raise ValidationError(f"Unexpected metadata schema identity: {metadata.get('schema')} {metadata.get('schema_version')}")
+    for field in ("document_id", "created_with", "created_at"):
+        if not isinstance(metadata.get(field), str) or not metadata[field]:
+            raise ValidationError(f"Missing metadata field: {field}")
+    validate_created_with(metadata["created_with"])
+    if "created_by" in metadata:
+        raise ValidationError("v1.1 metadata must not contain created_by")
+    if mutability == "mutable":
+        if not isinstance(metadata.get("last_modified_at"), str) or not metadata["last_modified_at"]:
+            raise ValidationError("Missing metadata field: last_modified_at")
+    elif mutability == "immutable":
+        if "last_modified_at" in metadata:
+            raise ValidationError("Immutable metadata must not contain last_modified_at")
+    else:
+        raise ArgumentError(f"Unknown metadata mutability: {mutability}")
+    return metadata
+
+
+def touch_document(document: dict[str, Any], timestamp: str | None = None) -> dict[str, Any]:
+    updated = deepcopy(document)
+    metadata = updated.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValidationError("Missing metadata object")
+    metadata["last_modified_at"] = timestamp or now_iso8601()
+    return updated
+
+
+def write_json_document(path: Path, document: dict[str, Any]) -> None:
+    import json
+
+    atomic_write_text(path, json.dumps(document, indent=2, ensure_ascii=False) + "\n")

--- a/tests/python/test_metadata.py
+++ b/tests/python/test_metadata.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.errors import ValidationError
+from jl_mixing.metadata import create_v11, touch_document, validate_created_with, validate_v11, write_json_document
+
+
+class MetadataTests(unittest.TestCase):
+    def test_mutable_v11_shape_matches_contract(self) -> None:
+        metadata = create_v11(
+            "mixing-project",
+            mutability="mutable",
+            document_id="11111111-1111-1111-1111-111111111111",
+            timestamp="2030-01-01T12:00:00Z",
+        )
+        self.assertEqual(metadata["schema_version"], "1.1.0")
+        self.assertEqual(metadata["created_at"], "2030-01-01T12:00:00Z")
+        self.assertEqual(metadata["last_modified_at"], metadata["created_at"])
+        self.assertTrue(metadata["created_with"].startswith("jl-mixing "))
+        self.assertNotIn("created_by", metadata)
+        validate_v11(metadata, "mixing-project", mutability="mutable")
+
+    def test_immutable_v11_omits_last_modified(self) -> None:
+        metadata = create_v11(
+            "mixing-delivery",
+            mutability="immutable",
+            document_id="22222222-2222-2222-2222-222222222222",
+            timestamp="2030-01-01T12:00:00Z",
+        )
+        self.assertNotIn("last_modified_at", metadata)
+        validate_v11(metadata, "mixing-delivery", mutability="immutable")
+
+    def test_created_with_accepts_prerelease_and_build(self) -> None:
+        self.assertEqual(
+            validate_created_with("jl-mixing 1.5.0-rc.1+build.7"),
+            "jl-mixing 1.5.0-rc.1+build.7",
+        )
+        for invalid in ("1.5.0", "jl-mixing 1.5", "other 1.5.0"):
+            with self.subTest(invalid=invalid), self.assertRaises(ValidationError):
+                validate_created_with(invalid)
+
+    def test_touch_changes_only_last_modified_timestamp(self) -> None:
+        document = {
+            "metadata": create_v11(
+                "mixing-client",
+                mutability="mutable",
+                document_id="33333333-3333-3333-3333-333333333333",
+                timestamp="2030-01-01T12:00:00Z",
+            ),
+            "name": "Client",
+        }
+        updated = touch_document(document, "2030-01-02T12:00:00Z")
+        self.assertEqual(document["metadata"]["last_modified_at"], "2030-01-01T12:00:00Z")
+        self.assertEqual(updated["metadata"]["last_modified_at"], "2030-01-02T12:00:00Z")
+        for field in ("schema", "schema_version", "document_id", "created_with", "created_at"):
+            self.assertEqual(updated["metadata"][field], document["metadata"][field])
+
+    def test_atomic_json_write_is_utf8_and_newline_terminated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            document = {"metadata": {"schema": "test"}, "name": "Beyoncé"}
+            write_json_document(path, document)
+            raw = path.read_bytes()
+            self.assertTrue(raw.endswith(b"\n"))
+            self.assertEqual(json.loads(raw.decode("utf-8")), document)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by moving the shared v1.1 metadata contract into the cross-platform Python runtime.

## Changes

- add mutable/immutable v1.1 metadata creation
- preserve application provenance independent of schema version
- preserve SemVer prerelease/build support in `created_with`
- validate schema identity and required metadata fields
- preserve removal of legacy `created_by`
- preserve immutable-record omission of `last_modified_at`
- add metadata touch semantics that modify only `last_modified_at`
- add atomic UTF-8 JSON document writing through the shared transaction primitive
- add parity-focused Python tests

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- application version remains independently sourced from `VERSION`
- no migration or workspace format change is introduced

Part of #71.