### PR TITLE
Implement v1.5 Python intake.validate API adapter

### DIFF
--- a/src/jl_mixing/api/__init__.py
+++ b/src/jl_mixing/api/__init__.py
@@ -1,0 +1,1 @@
+"""Automation API 1.0 adapters for the cross-platform runtime."""

--- a/src/jl_mixing/api/intake_validate.py
+++ b/src/jl_mixing/api/intake_validate.py
@@ -1,0 +1,175 @@
+"""Automation API 1.0 adapter for intake.validate."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..context import resolve_project
+from ..errors import ArgumentError, ContextError, JLMixingError, ValidationError
+from ..intake import validate_intake
+from ..markdown import replace_managed_section
+from ..versions import api_version
+
+_BEGIN = "<!-- BEGIN AUTOMATED SECTION -->"
+_END = "<!-- END AUTOMATED SECTION -->"
+
+
+@dataclass(frozen=True)
+class IntakeRequest:
+    project: Path
+    source: Path | None = None
+    expected_sample_rate: int | None = None
+    expected_bit_depth: int | None = None
+    duplicate_check: bool = True
+    dry_run: bool = False
+
+
+def _manifest(project: Path) -> dict[str, Any]:
+    path = project / "00_Admin" / "project-manifest.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Project manifest is unreadable: {path}") from exc
+
+
+def _workspace_path(project: Path) -> Path:
+    current = project
+    for _ in range(4):
+        current = current.parent
+    return current
+
+
+def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "intake.validate",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [{
+            "code": code,
+            "message": message,
+            "details": {"exit_code": exit_code},
+            "retryable": False,
+        }],
+    }
+
+
+def execute(request: IntakeRequest) -> tuple[dict[str, Any], int]:
+    try:
+        project = resolve_project(request.project, Path.cwd())
+        manifest = _manifest(project)
+        project_id = manifest.get("project_id", "")
+        audio = manifest.get("audio") if isinstance(manifest.get("audio"), dict) else {}
+        sample_rate = request.expected_sample_rate or audio.get("sample_rate")
+        bit_depth = request.expected_bit_depth or audio.get("bit_depth")
+        if not isinstance(sample_rate, int) or sample_rate <= 0:
+            raise ValidationError(f"Unsupported expected sample rate: {sample_rate}")
+        if not isinstance(bit_depth, int) or bit_depth <= 0:
+            raise ValidationError(f"Unsupported expected bit depth: {bit_depth}")
+
+        source = (request.source or (project / "01_Client_Files" / "Original_Delivery")).resolve()
+        result = validate_intake(
+            source,
+            expected_sample_rate=sample_rate,
+            expected_bit_depth=bit_depth,
+            duplicate_check=request.duplicate_check,
+        )
+        report_path = project / "00_Admin" / "Intake_Report.md"
+        if not request.dry_run:
+            replace_managed_section(report_path, _BEGIN, _END, result.report_markdown)
+
+        status = "planned" if request.dry_run and not result.blocked else "blocked" if result.blocked else "success"
+        exit_code = 5 if result.blocked else 0
+        data: dict[str, Any] = {
+            "project": {"id": project_id, "path": str(project)},
+            "manifest_path": str(project / "00_Admin" / "project-manifest.json"),
+            "intake_report_path": str(report_path),
+            "workspace_path": str(_workspace_path(project)),
+            "source_path": str(source),
+            "report_markdown": result.report_markdown,
+            "summary": {
+                "files_discovered": result.files_discovered,
+                "blocking_errors": result.blocking_errors,
+                "warnings": result.warnings,
+                "ffprobe_available": result.ffprobe_available,
+            },
+        }
+        if request.dry_run:
+            data["would_update"] = [str(report_path)]
+        errors: list[dict[str, Any]] = []
+        if result.blocked:
+            errors.append({
+                "code": "INTAKE_BLOCKING_FINDINGS",
+                "message": "Intake validation completed with blocking findings.",
+                "details": {"exit_code": 5, "blocking_errors": result.blocking_errors},
+                "retryable": False,
+            })
+        return {
+            "api_version": api_version(),
+            "operation": "intake.validate",
+            "status": status,
+            "data": data,
+            "warnings": [],
+            "errors": errors,
+        }, exit_code
+    except ContextError as exc:
+        return _error_envelope("PROJECT_NOT_FOUND", str(exc), exc.exit_code), exc.exit_code
+    except ValidationError as exc:
+        code = "SOURCE_NOT_FOUND" if "Source directory" in str(exc) else "VALIDATION_FAILED"
+        return _error_envelope(code, str(exc), exc.exit_code, status="blocked"), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+
+
+def parse_args(args: list[str]) -> IntakeRequest:
+    project: str | None = None
+    source: str | None = None
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    duplicate_check = True
+    dry_run = False
+    json_seen = 0
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg in {"--project", "--source", "--expected-sample-rate", "--expected-bit-depth"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                if project is not None:
+                    raise ArgumentError("intake validate JSON mode requires exactly one --project PATH option.")
+                project = value
+            elif arg == "--source": source = value
+            elif arg == "--expected-sample-rate":
+                try: sample_rate = int(value)
+                except ValueError as exc: raise ArgumentError(f"Invalid sample rate: {value}") from exc
+            else:
+                try: bit_depth = int(value)
+                except ValueError as exc: raise ArgumentError(f"Invalid bit depth: {value}") from exc
+        elif arg == "--no-duplicate-check": duplicate_check = False
+        elif arg == "--dry-run": dry_run = True
+        elif arg.startswith("--progress="):
+            raise ArgumentError("intake validate does not yet support JSON progress events.")
+        else:
+            raise ArgumentError(f"Unknown option: {arg}")
+        index += 1
+    if json_seen != 1:
+        raise ArgumentError("intake validate requires exactly one --json option.")
+    if not project:
+        raise ArgumentError("intake validate JSON mode requires exactly one --project PATH option.")
+    return IntakeRequest(
+        project=Path(project),
+        source=Path(source) if source else None,
+        expected_sample_rate=sample_rate,
+        expected_bit_depth=bit_depth,
+        duplicate_check=duplicate_check,
+        dry_run=dry_run,
+    )

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -6,10 +6,16 @@ import json
 import sys
 from collections.abc import Sequence
 
+from .api.intake_validate import _error_envelope, execute as intake_execute, parse_args as parse_intake_args
+from .errors import ArgumentError
 from .system_info import document as system_info_document
 
 EXIT_ARGUMENTS = 2
 EXIT_CONFIG = 3
+
+
+def _emit_json(payload: dict[str, object]) -> None:
+    print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -21,8 +27,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return EXIT_CONFIG
-        print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+        _emit_json(payload)
         return 0
+
+    if len(args) >= 2 and args[0:2] == ["intake", "validate"]:
+        try:
+            request = parse_intake_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            return exc.exit_code
+        payload, status = intake_execute(request)
+        _emit_json(payload)
+        return status
 
     print("Error: command has not yet been migrated to the v1.5 Python runtime.", file=sys.stderr)
     return EXIT_ARGUMENTS

--- a/src/jl_mixing/markdown.py
+++ b/src/jl_mixing/markdown.py
@@ -1,0 +1,22 @@
+"""Managed Markdown section helpers shared by report workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .errors import ValidationError
+from .transactions import atomic_write_text
+
+
+def replace_managed_section(path: Path, begin: str, end: str, replacement: str) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise ValidationError(f"Markdown file not found or unsafe: {path}")
+    text = path.read_text(encoding="utf-8")
+    if text.count(begin) != 1 or text.count(end) != 1:
+        raise ValidationError(f"Managed Markdown markers are missing or duplicated: {path}")
+    before, remainder = text.split(begin, 1)
+    managed, after = remainder.split(end, 1)
+    del managed
+    content = replacement.rstrip("\n")
+    updated = f"{before}{begin}\n{content}\n{end}{after}"
+    atomic_write_text(path, updated)

--- a/tests/python/test_intake_api.py
+++ b/tests/python/test_intake_api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_project(root: Path) -> Path:
+    project = root / "Clients" / "API Client" / "Projects" / "Intake Project"
+    admin = project / "00_Admin"
+    source = project / "01_Client_Files" / "Original_Delivery"
+    admin.mkdir(parents=True)
+    source.mkdir(parents=True)
+    manifest = {
+        "metadata": {
+            "schema": "mixing-project",
+            "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "project_id": "intake-project",
+        "project_name": "Intake Project",
+        "audio": {"sample_rate": 48000, "bit_depth": 24},
+    }
+    (admin / "project-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (admin / "Intake_Report.md").write_text(
+        "# Intake Report\n\n<!-- BEGIN AUTOMATED SECTION -->\nold\n<!-- END AUTOMATED SECTION -->\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class IntakeApiTests(unittest.TestCase):
+    def test_dry_run_is_structured_and_non_mutating(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            source = project / "01_Client_Files" / "Original_Delivery"
+            (source / "Notes.txt").write_text("notes\n", encoding="utf-8")
+            report = project / "00_Admin" / "Intake_Report.md"
+            before = report.read_bytes()
+            proc = run_cli("intake", "validate", "--json", "--project", str(project), "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "intake.validate")
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["data"]["project"]["id"], "intake-project")
+            self.assertEqual(payload["data"]["summary"]["files_discovered"], 1)
+            self.assertIn("Notes.txt", payload["data"]["report_markdown"])
+            self.assertEqual(payload["data"]["would_update"], [str(report)])
+            self.assertEqual(report.read_bytes(), before)
+
+    def test_success_updates_only_managed_report_region(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            source = project / "01_Client_Files" / "Original_Delivery"
+            (source / "Notes.txt").write_text("notes\n", encoding="utf-8")
+            report = project / "00_Admin" / "Intake_Report.md"
+            proc = run_cli("intake", "validate", "--json", "--project", str(project))
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "success")
+            persisted = report.read_text(encoding="utf-8")
+            self.assertTrue(persisted.startswith("# Intake Report\n"))
+            self.assertIn(payload["data"]["report_markdown"].rstrip(), persisted)
+            self.assertEqual(payload["errors"], [])
+
+    def test_empty_source_returns_blocked_contract_and_updates_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            report = project / "00_Admin" / "Intake_Report.md"
+            proc = run_cli("intake", "validate", "--json", "--project", str(project))
+            self.assertEqual(proc.returncode, 5)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["errors"][0]["code"], "INTAKE_BLOCKING_FINDINGS")
+            self.assertIn("No files were found", report.read_text(encoding="utf-8"))
+
+    def test_invalid_request_is_machine_json_with_argument_exit_code(self) -> None:
+        proc = run_cli("intake", "validate", "--project", "/missing")
+        self.assertEqual(proc.returncode, 2)
+        self.assertEqual(proc.stderr, "")
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["errors"][0]["code"], "INVALID_REQUEST")
+        self.assertEqual(payload["errors"][0]["details"]["exit_code"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_intake_api.py
+++ b/tests/python/test_intake_api.py
@@ -69,7 +69,7 @@ class IntakeApiTests(unittest.TestCase):
             self.assertEqual(payload["data"]["project"]["id"], "intake-project")
             self.assertEqual(payload["data"]["summary"]["files_discovered"], 1)
             self.assertIn("Notes.txt", payload["data"]["report_markdown"])
-            self.assertEqual(payload["data"]["would_update"], [str(report)])
+            self.assertEqual(payload["data"]["would_update"], [str(report.resolve())])
             self.assertEqual(report.read_bytes(), before)
 
     def test_success_updates_only_managed_report_region(self) -> None:


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by wiring Automation API 1.0 `intake.validate` directly to the new cross-platform Python intake service.

## Changes

- add managed Markdown replacement primitive
- add Python `intake.validate` request parser and API 1.0 response adapter
- route `jl_mixing.cli intake validate --json` through the Python service
- preserve structured planned/success/blocked/error envelopes
- preserve explicit `--project` requirement, dry-run behavior, report persistence, blocking exit code 5, and `INTAKE_BLOCKING_FINDINGS`
- preserve `report_markdown`, summary counts, source/report/manifest/workspace paths, and `would_update`
- keep JSON-mode failures on stdout with empty stderr
- add dry-run, success, blocked, and invalid-request tests

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- existing Bash dispatcher remains active for the installed command until the later launcher cutover
- API adapter calls the Python service directly and does not parse human CLI output

Part of #71.