### PR TITLE
Port validate-intake human CLI to v1.5 Python runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {text = "Apache-2.0"}
 
 [project.scripts]
 jl-mixing-python = "jl_mixing.cli:main"
+validate-intake-python = "jl_mixing.validate_intake_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jl_mixing/api/intake_validate.py
+++ b/src/jl_mixing/api/intake_validate.py
@@ -11,6 +11,7 @@ from ..context import resolve_project
 from ..errors import ArgumentError, ContextError, JLMixingError, ValidationError
 from ..intake import validate_intake
 from ..markdown import replace_managed_section
+from ..validation import require_bit_depth, require_sample_rate
 from ..versions import api_version
 
 _BEGIN = "<!-- BEGIN AUTOMATED SECTION -->"
@@ -64,12 +65,12 @@ def execute(request: IntakeRequest) -> tuple[dict[str, Any], int]:
         manifest = _manifest(project)
         project_id = manifest.get("project_id", "")
         audio = manifest.get("audio") if isinstance(manifest.get("audio"), dict) else {}
-        sample_rate = request.expected_sample_rate or audio.get("sample_rate")
-        bit_depth = request.expected_bit_depth or audio.get("bit_depth")
-        if not isinstance(sample_rate, int) or sample_rate <= 0:
-            raise ValidationError(f"Unsupported expected sample rate: {sample_rate}")
-        if not isinstance(bit_depth, int) or bit_depth <= 0:
-            raise ValidationError(f"Unsupported expected bit depth: {bit_depth}")
+        sample_rate = require_sample_rate(
+            request.expected_sample_rate if request.expected_sample_rate is not None else audio.get("sample_rate")
+        )
+        bit_depth = require_bit_depth(
+            request.expected_bit_depth if request.expected_bit_depth is not None else audio.get("bit_depth")
+        )
 
         source = (request.source or (project / "01_Client_Files" / "Original_Delivery")).resolve()
         result = validate_intake(
@@ -147,15 +148,22 @@ def parse_args(args: list[str]) -> IntakeRequest:
                 if project is not None:
                     raise ArgumentError("intake validate JSON mode requires exactly one --project PATH option.")
                 project = value
-            elif arg == "--source": source = value
+            elif arg == "--source":
+                source = value
             elif arg == "--expected-sample-rate":
-                try: sample_rate = int(value)
-                except ValueError as exc: raise ArgumentError(f"Invalid sample rate: {value}") from exc
+                try:
+                    sample_rate = int(value)
+                except ValueError as exc:
+                    raise ArgumentError(f"Invalid sample rate: {value}") from exc
             else:
-                try: bit_depth = int(value)
-                except ValueError as exc: raise ArgumentError(f"Invalid bit depth: {value}") from exc
-        elif arg == "--no-duplicate-check": duplicate_check = False
-        elif arg == "--dry-run": dry_run = True
+                try:
+                    bit_depth = int(value)
+                except ValueError as exc:
+                    raise ArgumentError(f"Invalid bit depth: {value}") from exc
+        elif arg == "--no-duplicate-check":
+            duplicate_check = False
+        elif arg == "--dry-run":
+            dry_run = True
         elif arg.startswith("--progress="):
             raise ArgumentError("intake validate does not yet support JSON progress events.")
         else:

--- a/src/jl_mixing/validate_intake_cli.py
+++ b/src/jl_mixing/validate_intake_cli.py
@@ -1,0 +1,162 @@
+"""v1.4-compatible human validate-intake command on the Python runtime."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from .context import resolve_project
+from .errors import ArgumentError, JLMixingError, ValidationError
+from .intake import validate_intake
+from .markdown import replace_managed_section
+from .validation import require_bit_depth, require_sample_rate
+
+_BEGIN = "<!-- BEGIN AUTOMATED SECTION -->"
+_END = "<!-- END AUTOMATED SECTION -->"
+
+_USAGE = """Usage: validate-intake [options]
+
+Options:
+  --project PATH             Explicit project path
+  --source PATH              Intake source directory
+  --expected-sample-rate HZ  Override expected sample rate
+  --expected-bit-depth BITS  Override expected bit depth
+  --no-duplicate-check       Skip duplicate-basename detection
+  --dry-run                  Build and print a temporary report
+  -h, --help                 Show this help
+"""
+
+
+def _read_manifest(project: Path) -> dict[str, object]:
+    path = project / "00_Admin" / "project-manifest.json"
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Project manifest is unreadable: {path}") from exc
+    if not isinstance(document, dict):
+        raise ValidationError(f"Project manifest is invalid: {path}")
+    return document
+
+
+def _parse(args: list[str]) -> tuple[Path | None, Path | None, int | None, int | None, bool, bool]:
+    project: Path | None = None
+    source: Path | None = None
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    duplicate_check = True
+    dry_run = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in {"-h", "--help"}:
+            print(_USAGE, end="")
+            raise SystemExit(0)
+        if arg == "--report-only":
+            raise ArgumentError(
+                "--report-only was removed in JL Mixing 1.1.\n"
+                "validate-intake is always report-only and never modifies intake source files."
+            )
+        if arg == "--non-interactive":
+            raise ArgumentError(
+                "--non-interactive was removed in JL Mixing 1.1.\n"
+                "validate-intake does not prompt for input."
+            )
+        if arg in {"--project", "--source", "--expected-sample-rate", "--expected-bit-depth"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project = Path(value)
+            elif arg == "--source":
+                source = Path(value)
+            elif arg == "--expected-sample-rate":
+                try:
+                    sample_rate = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported expected sample rate: {value}") from exc
+            else:
+                try:
+                    bit_depth = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported expected bit depth: {value}") from exc
+        elif arg == "--no-duplicate-check":
+            duplicate_check = False
+        elif arg == "--dry-run":
+            dry_run = True
+        else:
+            raise ArgumentError(f"Unknown option: {arg}")
+        index += 1
+    return project, source, sample_rate, bit_depth, duplicate_check, dry_run
+
+
+def command(args: Sequence[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if args is None else args)
+    try:
+        project_ref, source_ref, sample_rate_override, bit_depth_override, duplicate_check, dry_run = _parse(argv)
+        project = resolve_project(project_ref, Path.cwd())
+        manifest = _read_manifest(project)
+        project_name = manifest.get("project_name")
+        if not isinstance(project_name, str) or not project_name:
+            raise ValidationError("Project manifest does not contain a valid project_name.")
+        audio = manifest.get("audio") if isinstance(manifest.get("audio"), dict) else {}
+        sample_rate = require_sample_rate(
+            sample_rate_override if sample_rate_override is not None else audio.get("sample_rate")
+        )
+        bit_depth = require_bit_depth(
+            bit_depth_override if bit_depth_override is not None else audio.get("bit_depth")
+        )
+        source = (source_ref or (project / "01_Client_Files" / "Original_Delivery")).expanduser()
+        if not source.is_absolute():
+            source = Path.cwd() / source
+        source = source.resolve()
+        if source.is_symlink() or not source.is_dir():
+            raise ValidationError(f"Intake source directory not found or unsafe: {source}")
+
+        report = project / "00_Admin" / "Intake_Report.md"
+        if report.is_symlink() or not report.is_file():
+            raise ValidationError(f"Intake report not found or unsafe: {report}")
+
+        result = validate_intake(
+            source,
+            expected_sample_rate=sample_rate,
+            expected_bit_depth=bit_depth,
+            duplicate_check=duplicate_check,
+        )
+        exit_code = 5 if result.blocked else 0
+        if dry_run:
+            print(result.report_markdown, end="")
+            return exit_code
+
+        replace_managed_section(report, _BEGIN, _END, result.report_markdown)
+        if result.blocked:
+            print("Intake validation completed with blocking errors.\n")
+        else:
+            print("Intake validation completed.\n")
+        print(f"Project:         {project_name}")
+        print(f"Source:          {source}")
+        print(f"Files inspected: {result.files_discovered}")
+        print(f"Blocking errors: {result.blocking_errors}")
+        print(f"Warnings:        {result.warnings}")
+        print(f"Report:          {report}")
+        print("\nNext:")
+        if result.blocked:
+            print("  Review and resolve the critical errors in 00_Admin/Intake_Report.md")
+        else:
+            print("  Review 00_Admin/Intake_Report.md")
+            print("  Prepare accepted audio in 02_Audio_Preparation/Working_Audio/")
+        return exit_code
+    except JLMixingError as exc:
+        for line in str(exc).splitlines() or [str(exc)]:
+            print(f"Error: {line}", file=sys.stderr)
+        return exc.exit_code
+
+
+def main() -> None:
+    raise SystemExit(command())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jl_mixing/validation.py
+++ b/src/jl_mixing/validation.py
@@ -1,0 +1,20 @@
+"""Shared v1.4-compatible validation rules."""
+
+from __future__ import annotations
+
+from .errors import ValidationError
+
+SUPPORTED_SAMPLE_RATES = frozenset({44100, 48000, 88200, 96000, 176400, 192000})
+SUPPORTED_BIT_DEPTHS = frozenset({16, 24, 32})
+
+
+def require_sample_rate(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value not in SUPPORTED_SAMPLE_RATES:
+        raise ValidationError(f"Unsupported expected sample rate: {value}")
+    return value
+
+
+def require_bit_depth(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value not in SUPPORTED_BIT_DEPTHS:
+        raise ValidationError(f"Unsupported expected bit depth: {value}")
+    return value

--- a/tests/python/test_validate_intake_cli.py
+++ b/tests/python/test_validate_intake_cli.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_project(root: Path) -> Path:
+    project = root / "Clients" / "Human Client" / "Projects" / "Human Project"
+    admin = project / "00_Admin"
+    source = project / "01_Client_Files" / "Original_Delivery"
+    work = project / "02_Audio_Preparation" / "Working_Audio"
+    admin.mkdir(parents=True)
+    source.mkdir(parents=True)
+    work.mkdir(parents=True)
+    manifest = {
+        "metadata": {
+            "schema": "mixing-project",
+            "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "project_id": "human-project",
+        "project_name": "Human Project",
+        "audio": {"sample_rate": 48000, "bit_depth": 24},
+    }
+    (admin / "project-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (admin / "Intake_Report.md").write_text(
+        "# Intake Report\n\n<!-- BEGIN AUTOMATED SECTION -->\nold\n<!-- END AUTOMATED SECTION -->\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.validate_intake_cli", *args],
+        cwd=cwd or ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class ValidateIntakeCliTests(unittest.TestCase):
+    def test_help_preserves_v14_surface(self) -> None:
+        proc = run_cli("--help")
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stderr, "")
+        self.assertTrue(proc.stdout.startswith("Usage: validate-intake [options]\n"))
+        self.assertIn("--no-duplicate-check", proc.stdout)
+        self.assertIn("--dry-run", proc.stdout)
+
+    def test_dry_run_discovers_project_and_does_not_mutate_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            source = project / "01_Client_Files" / "Original_Delivery"
+            (source / "Notes.txt").write_text("notes\n", encoding="utf-8")
+            report = project / "00_Admin" / "Intake_Report.md"
+            before = report.read_bytes()
+            cwd = project / "02_Audio_Preparation" / "Working_Audio"
+            proc = run_cli("--dry-run", cwd=cwd)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            self.assertIn("## Intake Summary", proc.stdout)
+            self.assertIn("Notes.txt", proc.stdout)
+            self.assertEqual(report.read_bytes(), before)
+
+    def test_success_updates_report_and_preserves_human_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            source = project / "01_Client_Files" / "Original_Delivery"
+            (source / "Notes.txt").write_text("notes\n", encoding="utf-8")
+            report = project / "00_Admin" / "Intake_Report.md"
+            proc = run_cli("--project", str(project))
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            self.assertTrue(proc.stdout.startswith("Intake validation completed.\n\n"))
+            self.assertIn("Project:         Human Project\n", proc.stdout)
+            self.assertIn("Files inspected: 1\n", proc.stdout)
+            self.assertIn("Next:\n  Review 00_Admin/Intake_Report.md\n", proc.stdout)
+            persisted = report.read_text(encoding="utf-8")
+            self.assertIn("## Intake Summary", persisted)
+            self.assertIn("Notes.txt", persisted)
+
+    def test_removed_option_retains_argument_exit_code_and_guidance(self) -> None:
+        proc = run_cli("--report-only")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("Error: --report-only was removed in JL Mixing 1.1.", proc.stderr)
+        self.assertIn("always report-only", proc.stderr)
+
+    def test_unsupported_sample_rate_retains_validation_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            proc = run_cli("--project", str(project), "--expected-sample-rate", "12345")
+            self.assertEqual(proc.returncode, 5)
+            self.assertIn("Unsupported expected sample rate: 12345", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by implementing the human `validate-intake` interface on the same Python intake service already used by Automation API 1.0.

## Changes

- add shared v1.4-compatible sample-rate and bit-depth validators
- tighten the Python API adapter to preserve the exact v1.4 supported audio-format sets
- add Python `validate-intake` human command implementation
- preserve project discovery when `--project` is omitted
- preserve `--source`, expected sample-rate/bit-depth overrides, duplicate-check control, dry-run behavior, help text, removed-option guidance, human summary text, Next guidance, and exit codes
- expose a transitional `validate-intake-python` entry point without changing the installed v1.4 launcher yet
- add command-level Python tests for help, context discovery, dry-run non-mutation, report replacement, removed options, and validation failures

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash `validate-intake` remains authoritative until launcher cutover
- human and machine Python paths now share the same intake service and validation rules

Part of #71.