### PR TITLE
Add native Windows CI for v1.5 Python runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   batch4:
-    # Catch BSD/GNU and default-shell portability differences.
+    # Preserve the v1.4 POSIX regression suite during the staged Python port.
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
@@ -31,3 +31,18 @@ jobs:
         env:
           JL_MIXING_PYTHON: ${{ env.pythonLocation }}/bin/python
         run: make strict-test
+
+  windows-python:
+    # Exercise the v1.5 authoritative Python runtime natively on Windows.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Python validation dependency
+        run: python -m pip install -r packaging/requirements.txt
+      - name: Run v1.5 Python runtime tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}\src
+        run: python -m unittest discover -s tests/python -p "test_*.py"


### PR DESCRIPTION
## Summary

Add native Windows CI for the staged JL Mixing Automation v1.5 Python port under #71.

## Changes

- preserve the existing macOS/Ubuntu strict v1.4 regression matrix
- add a separate `windows-latest` job for the v1.5 Python runtime
- install the existing Python validation dependency on Windows
- run the complete `tests/python` suite natively with Windows path/filesystem semantics

## Rationale

The existing strict suite is intentionally POSIX because v1.4 is Bash-based. During migration, Windows should test the new authoritative Python runtime directly rather than requiring Bash/jq compatibility layers. This gives subsequent workflow ports immediate native Windows coverage while retaining the established macOS/Ubuntu regression suite.

Part of #71.