### PR TITLE
Port client.create service to v1.5 Python runtime

### DIFF
--- a/src/jl_mixing/client.py
+++ b/src/jl_mixing/client.py
@@ -1,0 +1,160 @@
+"""Authoritative cross-platform client creation service."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .errors import ContextError, UnsafeOperationError, ValidationError
+from .metadata import create_v11
+from .naming import sanitize_folder_name, title_from_slug
+from .paths import assert_no_case_insensitive_child_collision, assert_no_symlink_components
+from .validation import (
+    require_bit_depth,
+    require_deliverables,
+    require_file_format,
+    require_sample_rate,
+    require_slug,
+)
+
+
+@dataclass(frozen=True)
+class ClientCreateRequest:
+    studio_root: Path
+    client_id: str
+    client_name: str | None = None
+    artist: str = ""
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    file_format: str | None = None
+    delivery_method: str | None = None
+    deliverables: list[str] | None = None
+    change_directory: bool | None = None
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class ClientCreateResult:
+    client_root: Path
+    client_document: dict[str, Any]
+    effective_cd: bool
+    created: bool
+
+
+def _load_studio(studio_root: Path) -> dict[str, Any]:
+    studio_file = studio_root / "Studio" / "studio.json"
+    if studio_root.is_symlink() or studio_file.is_symlink() or not studio_file.is_file():
+        raise ContextError(f"Studio configuration not found or unsafe: {studio_file}")
+    try:
+        document = json.loads(studio_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Invalid studio configuration: {studio_file}") from exc
+    metadata = document.get("metadata")
+    if not isinstance(metadata, dict) or metadata.get("schema") != "mixing-studio" or metadata.get("schema_version") != "1.1.0":
+        raise ValidationError(f"Unexpected studio schema identity: {studio_file}")
+    return document
+
+
+def _client_id_available(clients_root: Path, candidate: str) -> None:
+    wanted = candidate.casefold()
+    for client_file in clients_root.glob("*/client.json"):
+        if client_file.is_symlink() or not client_file.is_file():
+            continue
+        try:
+            existing = json.loads(client_file.read_text(encoding="utf-8")).get("client_id")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(existing, str) and existing.casefold() == wanted:
+            raise ValidationError(f"Client ID already exists: {candidate}")
+
+
+def _require_nonempty(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must not be empty.")
+    return value.strip()
+
+
+def _build_document(request: ClientCreateRequest, studio: dict[str, Any]) -> tuple[dict[str, Any], str, bool]:
+    client_id = require_slug(request.client_id, label="Client ID")
+    client_name = (request.client_name if request.client_name is not None else title_from_slug(client_id)).strip()
+    client_name = _require_nonempty(client_name, "client name")
+    artist = request.artist.strip()
+
+    defaults = studio.get("defaults") if isinstance(studio.get("defaults"), dict) else {}
+    audio_defaults = defaults.get("audio") if isinstance(defaults.get("audio"), dict) else {}
+    delivery_defaults = defaults.get("delivery") if isinstance(defaults.get("delivery"), dict) else {}
+
+    sample_rate = require_sample_rate(request.sample_rate if request.sample_rate is not None else audio_defaults.get("sample_rate"))
+    bit_depth = require_bit_depth(request.bit_depth if request.bit_depth is not None else audio_defaults.get("bit_depth"))
+    file_format = require_file_format(request.file_format if request.file_format is not None else audio_defaults.get("file_format"))
+    delivery_method = _require_nonempty(
+        request.delivery_method if request.delivery_method is not None else delivery_defaults.get("method"),
+        "delivery method",
+    )
+    deliverables_source = request.deliverables if request.deliverables is not None else delivery_defaults.get("requested_deliverables")
+    deliverables = require_deliverables(deliverables_source)
+
+    cli = studio.get("cli") if isinstance(studio.get("cli"), dict) else {}
+    inherited_cd = cli.get("change_directory_after_create") is True
+    effective_cd = request.change_directory if request.change_directory is not None else inherited_cd
+
+    document: dict[str, Any] = {
+        "metadata": create_v11("mixing-client", mutability="mutable"),
+        "client_id": client_id,
+        "client_name": client_name,
+        "defaults": {
+            "artist": artist,
+            "audio": {
+                "sample_rate": sample_rate,
+                "bit_depth": bit_depth,
+                "file_format": file_format,
+            },
+            "delivery": {
+                "method": delivery_method,
+                "requested_deliverables": deliverables,
+            },
+        },
+    }
+    return document, sanitize_folder_name(client_name), effective_cd
+
+
+def create_client(request: ClientCreateRequest) -> ClientCreateResult:
+    studio_root = request.studio_root.expanduser().resolve()
+    studio = _load_studio(studio_root)
+    clients_root = studio_root / "Clients"
+    if clients_root.is_symlink() or not clients_root.is_dir():
+        raise ContextError(f"Clients directory is missing or unsafe: {clients_root}")
+    assert_no_symlink_components(studio_root, clients_root)
+
+    document, folder_name, effective_cd = _build_document(request, studio)
+    _client_id_available(clients_root, request.client_id)
+    assert_no_case_insensitive_child_collision(clients_root, folder_name)
+    destination = clients_root / folder_name
+    if destination.exists() or destination.is_symlink():
+        raise UnsafeOperationError(f"Client destination already exists: {destination}")
+
+    if request.dry_run:
+        return ClientCreateResult(destination, document, effective_cd, False)
+
+    stage = Path(tempfile.mkdtemp(prefix=f".{folder_name}.jl-stage-", dir=clients_root))
+    try:
+        (stage / "Projects").mkdir()
+        (stage / "client.json").write_text(
+            json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        if destination.exists() or destination.is_symlink():
+            raise UnsafeOperationError(f"Client destination already exists: {destination}")
+        os.replace(stage, destination)
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+    return ClientCreateResult(destination, document, effective_cd, True)

--- a/src/jl_mixing/naming.py
+++ b/src/jl_mixing/naming.py
@@ -1,0 +1,38 @@
+"""Cross-platform naming helpers used by creation workflows."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from .errors import ValidationError
+
+_RESERVED = {"CON", "PRN", "AUX", "NUL", "CLOCK$"}
+_RESERVED.update({f"COM{i}" for i in range(1, 10)})
+_RESERVED.update({f"LPT{i}" for i in range(1, 10)})
+
+
+def title_from_slug(slug: str) -> str:
+    return " ".join(part[:1].upper() + part[1:] for part in slug.split("-"))
+
+
+def sanitize_folder_name(value: str) -> str:
+    value = unicodedata.normalize("NFC", value)
+    characters: list[str] = []
+    for character in value:
+        if ord(character) < 32 or ord(character) == 127:
+            characters.append(" ")
+        elif character in '/\\:*?"<>|':
+            characters.append(" - ")
+        else:
+            characters.append(character)
+    result = "".join(characters)
+    result = re.sub(r"\s+", " ", result).strip()
+    result = re.sub(r"(?:\s*-\s*)+", " - ", result).strip()
+    result = result.strip(" .-")
+    if not result:
+        raise ValidationError("Display name does not produce a usable folder name.")
+    base = result.split(".", 1)[0].upper()
+    if result in {".", ".."} or base in _RESERVED:
+        raise ValidationError(f"Reserved folder name is not allowed: {result}")
+    return result

--- a/src/jl_mixing/validation.py
+++ b/src/jl_mixing/validation.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
+import re
+
 from .errors import ValidationError
 
 SUPPORTED_SAMPLE_RATES = frozenset({44100, 48000, 88200, 96000, 176400, 192000})
 SUPPORTED_BIT_DEPTHS = frozenset({16, 24, 32})
+SUPPORTED_FILE_FORMATS = frozenset({"WAV", "AIFF"})
+SUPPORTED_DELIVERABLES = frozenset({
+    "main_mix",
+    "instrumental",
+    "acapella",
+    "tv_mix",
+    "performance_mix",
+    "stems",
+    "master",
+})
+_SLUG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
 def require_sample_rate(value: object) -> int:
@@ -18,3 +31,33 @@ def require_bit_depth(value: object) -> int:
     if not isinstance(value, int) or isinstance(value, bool) or value not in SUPPORTED_BIT_DEPTHS:
         raise ValidationError(f"Unsupported expected bit depth: {value}")
     return value
+
+
+def require_file_format(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"Unsupported file format: {value}")
+    normalized = value.upper()
+    if normalized not in SUPPORTED_FILE_FORMATS:
+        raise ValidationError(f"Unsupported file format: {normalized}")
+    return normalized
+
+
+def require_slug(value: object, *, label: str = "ID") -> str:
+    if not isinstance(value, str) or not _SLUG.fullmatch(value):
+        raise ValidationError(f"{label} must be a lowercase slug using single hyphens: {value}")
+    return value
+
+
+def require_deliverables(values: object) -> list[str]:
+    if not isinstance(values, list) or not values:
+        raise ValidationError("At least one requested deliverable is required.")
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str) or value not in SUPPORTED_DELIVERABLES:
+            raise ValidationError(f"Unsupported deliverable type: {value}")
+        if value in seen:
+            raise ValidationError("Requested deliverables must be unique.")
+        seen.add(value)
+        result.append(value)
+    return result

--- a/tests/python/test_client_service.py
+++ b/tests/python/test_client_service.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.client import ClientCreateRequest, create_client
+from jl_mixing.errors import ValidationError
+
+
+def write_studio(root: Path, *, default_cd: bool = False) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio",
+            "schema_version": "1.1.0",
+            "document_id": "33333333-3333-3333-3333-333333333333",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "test-studio",
+        "studio_name": "Test Studio",
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {
+                "method": "Cloud transfer",
+                "requested_deliverables": ["main_mix", "instrumental"],
+            },
+        },
+        "cli": {"change_directory_after_create": default_cd},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    return root
+
+
+class ClientServiceTests(unittest.TestCase):
+    def test_dry_run_inherits_defaults_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp), default_cd=True)
+            result = create_client(ClientCreateRequest(studio, "blue-sky", dry_run=True))
+            self.assertFalse(result.created)
+            self.assertTrue(result.effective_cd)
+            self.assertEqual(result.client_root.name, "Blue Sky")
+            self.assertFalse(result.client_root.exists())
+            self.assertEqual(result.client_document["client_name"], "Blue Sky")
+            self.assertEqual(result.client_document["defaults"]["audio"], {
+                "sample_rate": 48000,
+                "bit_depth": 24,
+                "file_format": "WAV",
+            })
+            self.assertEqual(
+                result.client_document["defaults"]["delivery"]["requested_deliverables"],
+                ["main_mix", "instrumental"],
+            )
+
+    def test_create_commits_client_and_projects_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            result = create_client(ClientCreateRequest(
+                studio,
+                "artist-one",
+                client_name="Artist One LLC",
+                artist="Artist One",
+                sample_rate=96000,
+                bit_depth=32,
+                file_format="aiff",
+                delivery_method="Drive",
+                deliverables=["main_mix", "stems", "master"],
+            ))
+            self.assertTrue(result.created)
+            self.assertTrue((result.client_root / "Projects").is_dir())
+            client_file = result.client_root / "client.json"
+            persisted = json.loads(client_file.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["client_id"], "artist-one")
+            self.assertEqual(persisted["defaults"]["artist"], "Artist One")
+            self.assertEqual(persisted["defaults"]["audio"]["sample_rate"], 96000)
+            self.assertEqual(persisted["defaults"]["audio"]["file_format"], "AIFF")
+            self.assertEqual(persisted["defaults"]["delivery"]["requested_deliverables"], ["main_mix", "stems", "master"])
+            self.assertEqual(persisted["metadata"]["schema_version"], "1.1.0")
+            self.assertTrue(persisted["metadata"]["created_with"].startswith("jl-mixing "))
+
+    def test_duplicate_client_id_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            create_client(ClientCreateRequest(studio, "same-client"))
+            with self.assertRaisesRegex(ValidationError, "Client ID already exists"):
+                create_client(ClientCreateRequest(studio, "same-client", client_name="Different Folder"))
+
+    def test_case_insensitive_folder_collision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            existing = studio / "Clients" / "Case Name"
+            existing.mkdir()
+            with self.assertRaisesRegex(ValidationError, "Case-insensitive path collision"):
+                create_client(ClientCreateRequest(studio, "case-client", client_name="case name"))
+
+    def test_windows_reserved_folder_name_is_rejected_on_every_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            with self.assertRaisesRegex(ValidationError, "Reserved folder name"):
+                create_client(ClientCreateRequest(studio, "reserved-client", client_name="CON"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by porting the authoritative client-creation workflow into the cross-platform Python runtime.

## Changes

- add shared creation validators for slugs, file formats, and deliverables
- port cross-platform folder-name sanitization, including Windows-reserved names
- add transactional `create_client()` service using a staged sibling directory and atomic rename into place
- inherit studio audio/delivery/CLI defaults when request values are omitted
- preserve explicit overrides for artist, audio format, delivery method, requested deliverables, and change-directory preference
- preserve case-insensitive client-folder collision checks and stable client-ID uniqueness
- create canonical `client.json` metadata with schema 1.1.0 and application-version provenance
- create the canonical empty `Projects/` directory
- preserve dry-run non-mutation
- add native Python tests for defaults, overrides, transaction commit, duplicate IDs, case collisions, and Windows-reserved names

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no installed launcher is changed in this slice
- parent-shell `--cd` behavior remains launcher integration, not service logic

Part of #71.