### PR TITLE
Implement v1.5 Python client.create API adapter

### DIFF
--- a/src/jl_mixing/api/client_create.py
+++ b/src/jl_mixing/api/client_create.py
@@ -1,0 +1,162 @@
+"""Automation API 1.0 adapter for client.create."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..client import ClientCreateRequest, create_client
+from ..context import studio_root
+from ..errors import ArgumentError, ContextError, JLMixingError, UnsafeOperationError, ValidationError
+from ..versions import api_version
+
+
+@dataclass(frozen=True)
+class ClientApiRequest:
+    client_id: str
+    client_name: str | None = None
+    artist: str = ""
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    file_format: str | None = None
+    delivery_method: str | None = None
+    deliverables: list[str] | None = None
+    dry_run: bool = False
+
+
+def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "client.create",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [{
+            "code": code,
+            "message": message,
+            "details": {"exit_code": exit_code},
+            "retryable": False,
+        }],
+    }
+
+
+def execute(request: ClientApiRequest) -> tuple[dict[str, Any], int]:
+    try:
+        workspace = studio_root(Path.cwd())
+        result = create_client(ClientCreateRequest(
+            studio_root=workspace,
+            client_id=request.client_id,
+            client_name=request.client_name,
+            artist=request.artist,
+            sample_rate=request.sample_rate,
+            bit_depth=request.bit_depth,
+            file_format=request.file_format,
+            delivery_method=request.delivery_method,
+            deliverables=request.deliverables,
+            dry_run=request.dry_run,
+        ))
+        data: dict[str, Any] = {
+            "client": {"id": request.client_id, "path": str(result.client_root)},
+            "configuration_path": str(result.client_root / "client.json"),
+            "workspace_path": str(workspace),
+        }
+        if request.dry_run:
+            data["would_create"] = [
+                str(result.client_root / "client.json"),
+                str(result.client_root / "Projects"),
+            ]
+        return {
+            "api_version": api_version(),
+            "operation": "client.create",
+            "status": "planned" if request.dry_run else "success",
+            "data": data,
+            "warnings": [],
+            "errors": [],
+        }, 0
+    except ContextError as exc:
+        return _error_envelope("WORKSPACE_CONTEXT_ERROR", str(exc), exc.exit_code), exc.exit_code
+    except ValidationError as exc:
+        message = str(exc)
+        code = "CLIENT_ALREADY_EXISTS" if any(token in message.lower() for token in ("already exists", "collision")) else "VALIDATION_FAILED"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except UnsafeOperationError as exc:
+        message = str(exc)
+        code = "CLIENT_ALREADY_EXISTS" if "already exists" in message.lower() else "UNSAFE_OPERATION"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+
+
+def _parse_deliverables(value: str) -> list[str]:
+    raw = value.split(",")
+    if not raw or any(not item.strip() for item in raw):
+        raise ValidationError(f"Invalid --deliverables list: {value}")
+    return [item.strip() for item in raw]
+
+
+def parse_args(args: list[str]) -> ClientApiRequest:
+    if not args or args[0].startswith("-"):
+        raise ArgumentError("client create requires CLIENT_ID and --json.")
+    client_id = args[0]
+    client_name: str | None = None
+    artist = ""
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    file_format: str | None = None
+    delivery_method: str | None = None
+    deliverables: list[str] | None = None
+    dry_run = False
+    json_seen = 0
+    index = 1
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg in {"--cd", "--no-cd"}:
+            raise ArgumentError("client create JSON mode does not accept --cd or --no-cd.")
+        elif arg in {"--name", "--artist", "--sample-rate", "--bit-depth", "--file-format", "--delivery-method", "--deliverables"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--name":
+                client_name = value
+            elif arg == "--artist":
+                artist = value
+            elif arg == "--sample-rate":
+                try:
+                    sample_rate = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported sample rate: {value}") from exc
+            elif arg == "--bit-depth":
+                try:
+                    bit_depth = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported bit depth: {value}") from exc
+            elif arg == "--file-format":
+                file_format = value
+            elif arg == "--delivery-method":
+                delivery_method = value
+            else:
+                deliverables = _parse_deliverables(value)
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+    if json_seen != 1:
+        raise ArgumentError("client create requires exactly one --json option.")
+    return ClientApiRequest(
+        client_id=client_id,
+        client_name=client_name,
+        artist=artist,
+        sample_rate=sample_rate,
+        bit_depth=bit_depth,
+        file_format=file_format,
+        delivery_method=delivery_method,
+        deliverables=deliverables,
+        dry_run=dry_run,
+    )

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -6,8 +6,13 @@ import json
 import sys
 from collections.abc import Sequence
 
-from .api.intake_validate import _error_envelope, execute as intake_execute, parse_args as parse_intake_args
-from .errors import ArgumentError
+from .api.client_create import _error_envelope as client_error_envelope
+from .api.client_create import execute as client_execute
+from .api.client_create import parse_args as parse_client_args
+from .api.intake_validate import _error_envelope as intake_error_envelope
+from .api.intake_validate import execute as intake_execute
+from .api.intake_validate import parse_args as parse_intake_args
+from .errors import ArgumentError, ValidationError
 from .system_info import document as system_info_document
 
 EXIT_ARGUMENTS = 2
@@ -30,11 +35,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         _emit_json(payload)
         return 0
 
+    if len(args) >= 2 and args[0:2] == ["client", "create"]:
+        try:
+            request = parse_client_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(client_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            return exc.exit_code
+        except ValidationError as exc:
+            _emit_json(client_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
+            return exc.exit_code
+        payload, status = client_execute(request)
+        _emit_json(payload)
+        return status
+
     if len(args) >= 2 and args[0:2] == ["intake", "validate"]:
         try:
             request = parse_intake_args(args[2:])
         except ArgumentError as exc:
-            _emit_json(_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            _emit_json(intake_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
             return exc.exit_code
         payload, status = intake_execute(request)
         _emit_json(payload)

--- a/tests/python/test_client_api.py
+++ b/tests/python/test_client_api.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_studio(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio",
+            "schema_version": "1.1.0",
+            "document_id": "44444444-4444-4444-4444-444444444444",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "api-studio",
+        "studio_name": "API Studio",
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {
+                "method": "Cloud transfer",
+                "requested_deliverables": ["main_mix", "instrumental"],
+            },
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    return root
+
+
+def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class ClientApiTests(unittest.TestCase):
+    def test_dry_run_is_structured_and_non_mutating(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            proc = run_cli(studio, "client", "create", "api-client", "--json", "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "client.create")
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["data"]["client"]["id"], "api-client")
+            client_path = Path(payload["data"]["client"]["path"])
+            self.assertFalse(client_path.exists())
+            self.assertEqual(
+                [Path(item).name for item in payload["data"]["would_create"]],
+                ["client.json", "Projects"],
+            )
+
+    def test_success_commits_authoritative_client_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            proc = run_cli(
+                studio,
+                "client", "create", "api-client", "--json",
+                "--name", "API Client",
+                "--artist", "API Artist",
+                "--sample-rate", "96000",
+                "--bit-depth", "32",
+                "--file-format", "aiff",
+                "--deliverables", "main_mix,stems",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "success")
+            client_path = Path(payload["data"]["client"]["path"])
+            self.assertTrue((client_path / "Projects").is_dir())
+            document = json.loads((client_path / "client.json").read_text(encoding="utf-8"))
+            self.assertEqual(document["client_id"], "api-client")
+            self.assertEqual(document["defaults"]["artist"], "API Artist")
+            self.assertEqual(document["defaults"]["audio"]["sample_rate"], 96000)
+            self.assertEqual(document["defaults"]["audio"]["file_format"], "AIFF")
+            self.assertEqual(document["defaults"]["delivery"]["requested_deliverables"], ["main_mix", "stems"])
+
+    def test_duplicate_client_returns_stable_blocked_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            first = run_cli(studio, "client", "create", "same-client", "--json")
+            self.assertEqual(first.returncode, 0, first.stderr)
+            proc = run_cli(studio, "client", "create", "same-client", "--json", "--name", "Other Name")
+            self.assertEqual(proc.returncode, 5)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["errors"][0]["code"], "CLIENT_ALREADY_EXISTS")
+            self.assertEqual(payload["errors"][0]["details"]["exit_code"], 5)
+
+    def test_json_mode_rejects_parent_shell_cd_options(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            proc = run_cli(studio, "client", "create", "api-client", "--json", "--cd")
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "error")
+            self.assertEqual(payload["errors"][0]["code"], "INVALID_REQUEST")
+
+    def test_json_flag_is_required_exactly_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            proc = run_cli(studio, "client", "create", "api-client")
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["errors"][0]["code"], "INVALID_REQUEST")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by wiring Automation API 1.0 `client.create` directly to the cross-platform Python client service.

## Changes

- add Python `client.create` request parser and API 1.0 response adapter
- route `jl_mixing.cli client create CLIENT_ID --json` through the Python service
- preserve planned/success/blocked/error response envelopes
- preserve explicit rejection of `--cd` and `--no-cd` in JSON mode
- preserve dry-run `would_create`, workspace/client/configuration paths, and stable exit-code mapping
- preserve `CLIENT_ALREADY_EXISTS` classification for duplicate IDs and case-insensitive destination collisions
- keep machine failures on stdout with empty stderr
- add native Windows/macOS/Linux Python contract tests for dry-run, success, duplicate clients, JSON flag handling, and shell-cd rejection

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- the installed Bash dispatcher is unchanged until later launcher cutover
- the API adapter calls the Python service directly and does not parse human CLI output

Part of #71.