### PR TITLE
Port new-client human CLI to v1.5 Python runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {text = "Apache-2.0"}
 [project.scripts]
 jl-mixing-python = "jl_mixing.cli:main"
 validate-intake-python = "jl_mixing.validate_intake_cli:main"
+new-client-python = "jl_mixing.new_client_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jl_mixing/new_client_cli.py
+++ b/src/jl_mixing/new_client_cli.py
@@ -1,0 +1,205 @@
+"""Human-facing new-client command backed by the cross-platform client service."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from pathlib import Path
+
+from .client import ClientCreateRequest, create_client
+from .context import studio_root
+from .errors import ArgumentError, JLMixingError, ValidationError
+
+_USAGE = """Usage: new-client CLIENT_ID [options]\n\nOptions:\n  --name NAME             Display name (default: title-cased client ID)\n  --artist NAME           Default artist or program name\n  --sample-rate HZ        Default project sample rate\n  --bit-depth BITS        Default project bit depth\n  --file-format FORMAT    Default project format: WAV or AIFF\n  --delivery-method TEXT  Default delivery method\n  --deliverables LIST     Comma-separated requested deliverables\n  --cd                    Enter the new client directory after creation\n  --no-cd                 Remain in the current directory after creation\n  --dry-run               Show the planned client without creating it\n  -h, --help              Show this help\n"""
+
+
+def _removed_option(name: str) -> ArgumentError:
+    if name == "--revision-limit":
+        return ArgumentError(
+            "--revision-limit was removed in JL Mixing 1.1.\n"
+            "The v1.1 revision workflow has no included-revision limit."
+        )
+    return ArgumentError(
+        "--non-interactive was removed in JL Mixing 1.1.\n"
+        "new-client already uses supplied values and inherited defaults without prompting."
+    )
+
+
+def _parse_deliverables(value: str) -> list[str]:
+    raw = value.split(",")
+    if not raw or any(not item.strip() for item in raw):
+        raise ValidationError(f"Invalid --deliverables list: {value}")
+    values = [item.strip() for item in raw]
+    if len(set(values)) != len(values):
+        raise ValidationError("Requested deliverables must be unique.")
+    return values
+
+
+def _parse(args: list[str]) -> tuple[ClientCreateRequest | None, bool]:
+    if not args:
+        raise ArgumentError("client ID must not be empty.")
+    if args == ["-h"] or args == ["--help"]:
+        return None, True
+    if args[0].startswith("-"):
+        raise ArgumentError("client ID must not be empty.")
+
+    client_id = args[0]
+    values: dict[str, object] = {
+        "client_name": None,
+        "artist": "",
+        "sample_rate": None,
+        "bit_depth": None,
+        "file_format": None,
+        "delivery_method": None,
+        "deliverables": None,
+    }
+    cd_value: bool | None = None
+    cd_seen = False
+    no_cd_seen = False
+    dry_run = False
+    index = 1
+    while index < len(args):
+        arg = args[index]
+        if arg in {"--revision-limit", "--non-interactive"}:
+            raise _removed_option(arg)
+        if arg in {"-h", "--help"}:
+            return None, True
+        if arg == "--cd":
+            cd_seen = True
+            cd_value = True
+        elif arg == "--no-cd":
+            no_cd_seen = True
+            cd_value = False
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg in {"--name", "--artist", "--sample-rate", "--bit-depth", "--file-format", "--delivery-method", "--deliverables"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--name":
+                values["client_name"] = value
+            elif arg == "--artist":
+                values["artist"] = value
+            elif arg == "--sample-rate":
+                try:
+                    values["sample_rate"] = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported sample rate: {value}") from exc
+            elif arg == "--bit-depth":
+                try:
+                    values["bit_depth"] = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported bit depth: {value}") from exc
+            elif arg == "--file-format":
+                values["file_format"] = value
+            elif arg == "--delivery-method":
+                values["delivery_method"] = value
+            else:
+                values["deliverables"] = _parse_deliverables(value)
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+
+    if cd_seen and no_cd_seen:
+        raise ArgumentError("--cd and --no-cd cannot be used together.")
+    if dry_run and (cd_seen or no_cd_seen):
+        raise ArgumentError("--cd and --no-cd cannot be used with --dry-run.")
+
+    root = studio_root(Path.cwd())
+    return (
+        ClientCreateRequest(
+            studio_root=root,
+            client_id=client_id,
+            client_name=values["client_name"] if isinstance(values["client_name"], str) else None,
+            artist=str(values["artist"]),
+            sample_rate=values["sample_rate"] if isinstance(values["sample_rate"], int) else None,
+            bit_depth=values["bit_depth"] if isinstance(values["bit_depth"], int) else None,
+            file_format=values["file_format"] if isinstance(values["file_format"], str) else None,
+            delivery_method=values["delivery_method"] if isinstance(values["delivery_method"], str) else None,
+            deliverables=values["deliverables"] if isinstance(values["deliverables"], list) else None,
+            change_directory=cd_value,
+            dry_run=dry_run,
+        ),
+        False,
+    )
+
+
+def _shell_quote(path: Path) -> str:
+    return shlex.quote(str(path))
+
+
+def _print_summary(result, heading: str) -> None:
+    doc = result.client_document
+    defaults = doc["defaults"]
+    audio = defaults["audio"]
+    delivery = defaults["delivery"]
+    artist = defaults.get("artist") or "<not set>"
+    print(heading)
+    print()
+    print(f"Client ID:                  {doc['client_id']}")
+    print(f"Client name:                {doc['client_name']}")
+    print(f"Client folder:              {result.client_root}")
+    print(f"Default artist:             {artist}")
+    print(f"Audio format:               {audio['sample_rate']} Hz / {audio['bit_depth']}-bit / {audio['file_format']}")
+    print(f"Delivery method:            {delivery['method']}")
+    print(f"Requested deliverables:     {', '.join(delivery['requested_deliverables'])}")
+    print(f"Automatic directory change: {'enabled' if result.effective_cd else 'disabled'}")
+
+
+def _write_cd_result(path: Path) -> bool:
+    result_file = os.environ.get("JL_MIXING_CD_RESULT_FILE")
+    if not result_file:
+        return False
+    target = Path(result_file)
+    if not target.is_absolute() or target.is_symlink() or not target.is_file():
+        raise ValidationError(f"Shell-integration result file is missing or unsafe: {target}")
+    target.write_text(str(path) + "\n", encoding="utf-8", newline="\n")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    try:
+        request, help_only = _parse(args)
+        if help_only:
+            print(_USAGE, end="")
+            return 0
+        assert request is not None
+        result = create_client(request)
+        if request.dry_run:
+            _print_summary(result, "Dry run — no changes made.")
+            print("\nWould create:")
+            print("  client.json")
+            print("  Projects/")
+            print("\nAfter creation:")
+            print(f"  cd {_shell_quote(result.client_root)}")
+            print('  new-mix --project "PROJECT NAME"')
+            return 0
+
+        result_written = False
+        if result.effective_cd:
+            result_written = _write_cd_result(result.client_root)
+
+        _print_summary(result, "Client created successfully.")
+        print(f"Configuration:               {result.client_root / 'client.json'}")
+        if result.effective_cd and not result_written:
+            print(
+                "\nAutomatic directory change could not be performed because JL Mixing shell\n"
+                "integration is not active."
+            )
+        print("\nNext:")
+        if not result.effective_cd or not result_written:
+            print(f"  cd {_shell_quote(result.client_root)}")
+        print('  new-mix --project "PROJECT NAME"')
+        return 0
+    except JLMixingError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_new_client_cli.py
+++ b/tests/python/test_new_client_cli.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def make_studio(root: Path, *, auto_cd: bool = False) -> None:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio",
+            "schema_version": "1.1.0",
+            "document_id": "00000000-0000-0000-0000-000000000001",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "test-studio",
+        "studio_name": "Test Studio",
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {
+                "method": "Cloud transfer",
+                "requested_deliverables": ["main_mix", "instrumental"],
+            },
+        },
+        "cli": {"change_directory_after_create": auto_cd},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+
+
+def run_cli(cwd: Path, *args: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.new_client_cli", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class NewClientCliTests(unittest.TestCase):
+    def test_help_preserves_command_surface(self) -> None:
+        proc = run_cli(ROOT, "--help")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("Usage: new-client CLIENT_ID [options]", proc.stdout)
+        self.assertIn("--delivery-method TEXT", proc.stdout)
+        self.assertIn("--cd", proc.stdout)
+
+    def test_dry_run_inherits_defaults_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = Path(tmp)
+            make_studio(studio)
+            proc = run_cli(studio, "api-client", "--name", "API Client", "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Dry run — no changes made.", proc.stdout)
+            self.assertIn("48000 Hz / 24-bit / WAV", proc.stdout)
+            self.assertIn("main_mix, instrumental", proc.stdout)
+            self.assertFalse((studio / "Clients" / "API Client").exists())
+
+    def test_create_writes_canonical_client(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = Path(tmp)
+            make_studio(studio)
+            proc = run_cli(
+                studio,
+                "api-client",
+                "--name", "API Client",
+                "--artist", "Artist",
+                "--sample-rate", "96000",
+                "--bit-depth", "32",
+                "--file-format", "aiff",
+                "--delivery-method", "Drive",
+                "--deliverables", "main_mix,stems",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            client_file = studio / "Clients" / "API Client" / "client.json"
+            self.assertTrue(client_file.is_file())
+            doc = json.loads(client_file.read_text(encoding="utf-8"))
+            self.assertEqual(doc["client_id"], "api-client")
+            self.assertEqual(doc["defaults"]["artist"], "Artist")
+            self.assertEqual(doc["defaults"]["audio"], {"sample_rate": 96000, "bit_depth": 32, "file_format": "AIFF"})
+            self.assertEqual(doc["defaults"]["delivery"]["requested_deliverables"], ["main_mix", "stems"])
+            self.assertTrue((studio / "Clients" / "API Client" / "Projects").is_dir())
+            self.assertIn("Client created successfully.", proc.stdout)
+
+    def test_cd_result_file_receives_created_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = Path(tmp) / "studio"
+            studio.mkdir()
+            make_studio(studio)
+            result_file = Path(tmp) / "cd-result.txt"
+            result_file.write_text("", encoding="utf-8")
+            proc = run_cli(
+                studio,
+                "cd-client",
+                "--name", "CD Client",
+                "--cd",
+                extra_env={"JL_MIXING_CD_RESULT_FILE": str(result_file)},
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            expected = (studio / "Clients" / "CD Client").resolve()
+            self.assertEqual(Path(result_file.read_text(encoding="utf-8").strip()).resolve(), expected)
+            self.assertNotIn("integration is not active", proc.stdout)
+
+    def test_inherited_cd_warns_when_shell_integration_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = Path(tmp)
+            make_studio(studio, auto_cd=True)
+            proc = run_cli(studio, "auto-client", "--name", "Auto Client")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Automatic directory change: enabled", proc.stdout)
+            self.assertIn("integration is not active", proc.stdout)
+
+    def test_cd_and_no_cd_conflict_is_argument_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = Path(tmp)
+            make_studio(studio)
+            proc = run_cli(studio, "client", "--cd", "--no-cd")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("cannot be used together", proc.stderr)
+
+    def test_dry_run_rejects_cd_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = Path(tmp)
+            make_studio(studio)
+            proc = run_cli(studio, "client", "--dry-run", "--cd")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("cannot be used with --dry-run", proc.stderr)
+
+    def test_removed_option_preserves_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = Path(tmp)
+            make_studio(studio)
+            proc = run_cli(studio, "client", "--revision-limit")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("removed in JL Mixing 1.1", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by implementing the human `new-client` interface on the same cross-platform Python client service already used by Automation API 1.0 `client.create`.

## Changes

- add Python `new-client` human command implementation
- preserve the existing command options, help text, dry-run summary, creation summary, Next guidance, removed-option diagnostics, and exit-code behavior
- preserve inherited studio defaults and explicit client overrides through the shared service
- preserve `--cd` / `--no-cd` conflict rules and dry-run restrictions
- preserve inherited automatic-directory-change preference
- expose parent-shell directory handoff through `JL_MIXING_CD_RESULT_FILE` without putting shell-specific `cd` behavior into the core runtime
- expose transitional `new-client-python` entry point without changing the installed v1.4 launcher yet
- add native Windows/macOS/Linux command-level tests for help, dry-run, creation, overrides, shell handoff, inherited cd behavior, conflict handling, and removed options

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash `new-client` remains authoritative until launcher cutover
- parent-shell directory changes remain thin shell-integration glue around the shared Python service

Part of #71.