### PR TITLE
Port project.create service to v1.5 Python runtime

### DIFF
--- a/src/jl_mixing/naming.py
+++ b/src/jl_mixing/naming.py
@@ -16,6 +16,17 @@ def title_from_slug(slug: str) -> str:
     return " ".join(part[:1].upper() + part[1:] for part in slug.split("-"))
 
 
+def slugify(value: str) -> str:
+    """Derive the v1.4-compatible lowercase ASCII project/client slug."""
+
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii").lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_value).strip("-")
+    if not slug:
+        raise ValidationError("Project name does not produce a usable project ID.")
+    return slug
+
+
 def sanitize_folder_name(value: str) -> str:
     value = unicodedata.normalize("NFC", value)
     characters: list[str] = []

--- a/src/jl_mixing/project.py
+++ b/src/jl_mixing/project.py
@@ -1,0 +1,345 @@
+"""Authoritative cross-platform project creation service."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from .context import studio_root as resolve_studio_root
+from .errors import ContextError, UnsafeOperationError, ValidationError
+from .metadata import create_v11, now_iso8601
+from .naming import sanitize_folder_name, slugify
+from .paths import assert_no_case_insensitive_child_collision, assert_no_symlink_components
+from .source_import import SourcePlan, build_plan, copy_from_plan
+from .validation import (
+    require_bit_depth,
+    require_deliverables,
+    require_file_format,
+    require_sample_rate,
+    require_slug,
+)
+from .versions import application_root
+
+
+@dataclass(frozen=True)
+class ProjectCreateRequest:
+    client_root: Path
+    project_name: str
+    project_id: str | None = None
+    artist: str | None = None
+    album: str = ""
+    producer: str = ""
+    engineer: str | None = None
+    bpm: float | int | None = None
+    musical_key: str = ""
+    time_signature: str = ""
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    file_format: str | None = None
+    deadline: str | None = None
+    deliverables: list[str] | None = None
+    description: str = ""
+    source: Path | None = None
+    change_directory: bool | None = None
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class ProjectCreateResult:
+    project_root: Path
+    manifest: dict[str, Any]
+    client_snapshot: dict[str, Any]
+    initial_revision_root: Path
+    client_root: Path
+    studio_root: Path
+    effective_cd: bool
+    source_plan: SourcePlan | None
+    created: bool
+
+
+def _load_json(path: Path, schema: str) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ContextError(f"Required configuration not found or unsafe: {path}")
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Invalid JSON document: {path}") from exc
+    metadata = document.get("metadata")
+    if not isinstance(metadata, dict) or metadata.get("schema") != schema or metadata.get("schema_version") != "1.1.0":
+        raise ValidationError(f"Unexpected schema identity in: {path}")
+    return document
+
+
+def _nonempty(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must not be empty.")
+    return value.strip()
+
+
+def _optional_text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _validate_deadline(value: str | None) -> str | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValidationError(f"Deadline must be a valid calendar date in YYYY-MM-DD form: {value}") from exc
+    if parsed.isoformat() != value:
+        raise ValidationError(f"Deadline must be a valid calendar date in YYYY-MM-DD form: {value}")
+    return value
+
+
+def _validate_bpm(value: float | int | None) -> float | int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValidationError(f"BPM must be a positive number: {value}")
+    return value
+
+
+def _project_id_available(projects_root: Path, candidate: str) -> None:
+    wanted = candidate.casefold()
+    for manifest in projects_root.glob("*/00_Admin/project-manifest.json"):
+        if manifest.is_symlink() or not manifest.is_file():
+            continue
+        try:
+            existing = json.loads(manifest.read_text(encoding="utf-8")).get("project_id")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(existing, str) and existing.casefold() == wanted:
+            raise ValidationError(f"Project ID already exists for this client: {candidate}")
+
+
+def _write_template(name: str, destination: Path, replacements: dict[str, str] | None = None) -> None:
+    source = application_root() / "templates" / name
+    try:
+        text = source.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ContextError(f"Required template not found: {source}") from exc
+    for key, value in (replacements or {}).items():
+        text = text.replace("{{" + key + "}}", value)
+    destination.write_text(text, encoding="utf-8", newline="\n")
+
+
+def _resolve_inputs(request: ProjectCreateRequest) -> tuple[
+    Path, Path, dict[str, Any], dict[str, Any], dict[str, Any], str, str, str, str,
+    int, int, str, str, list[str], bool, SourcePlan | None
+]:
+    client_root = request.client_root.expanduser().resolve(strict=False)
+    client_file = client_root / "client.json"
+    client = _load_json(client_file, "mixing-client")
+    studio_root = resolve_studio_root(client_root)
+    studio = _load_json(studio_root / "Studio" / "studio.json", "mixing-studio")
+    clients_root = studio_root / "Clients"
+    try:
+        client_root.relative_to(clients_root)
+    except ValueError as exc:
+        raise ContextError(f"Selected client is not owned by the resolved studio: {client_root}") from exc
+    assert_no_symlink_components(studio_root, client_root)
+
+    projects_root = client_root / "Projects"
+    if projects_root.is_symlink() or not projects_root.is_dir():
+        raise ContextError(f"Client Projects directory is missing or unsafe: {projects_root}")
+    assert_no_symlink_components(studio_root, projects_root)
+
+    project_name = _nonempty(request.project_name, "project name")
+    folder_name = sanitize_folder_name(project_name)
+    project_id = require_slug(request.project_id if request.project_id is not None else slugify(project_name), label="Project ID")
+    _project_id_available(projects_root, project_id)
+    assert_no_case_insensitive_child_collision(projects_root, folder_name)
+    project_root = projects_root / folder_name
+    if project_root.exists() or project_root.is_symlink():
+        raise UnsafeOperationError(f"Project destination already exists: {project_root}")
+
+    client_name = _nonempty(client.get("client_name"), "client name")
+    client_id = _nonempty(client.get("client_id"), "client ID")
+    client_metadata = client.get("metadata") if isinstance(client.get("metadata"), dict) else {}
+    client_document_id = _nonempty(client_metadata.get("document_id"), "client document ID")
+    client_defaults = client.get("defaults") if isinstance(client.get("defaults"), dict) else {}
+    client_audio = client_defaults.get("audio") if isinstance(client_defaults.get("audio"), dict) else {}
+    client_delivery = client_defaults.get("delivery") if isinstance(client_defaults.get("delivery"), dict) else {}
+    studio_defaults = studio.get("defaults") if isinstance(studio.get("defaults"), dict) else {}
+    studio_audio = studio_defaults.get("audio") if isinstance(studio_defaults.get("audio"), dict) else {}
+    studio_delivery = studio_defaults.get("delivery") if isinstance(studio_defaults.get("delivery"), dict) else {}
+
+    if request.artist is None:
+        artist = _optional_text(client_defaults.get("artist")) or client_name
+    else:
+        artist = _nonempty(request.artist, "Artist")
+    engineer = _optional_text(request.engineer) if request.engineer is not None else _optional_text(studio_defaults.get("mix_engineer"))
+
+    sample_rate = require_sample_rate(request.sample_rate if request.sample_rate is not None else client_audio.get("sample_rate", studio_audio.get("sample_rate")))
+    bit_depth = require_bit_depth(request.bit_depth if request.bit_depth is not None else client_audio.get("bit_depth", studio_audio.get("bit_depth")))
+    file_format = require_file_format(request.file_format if request.file_format is not None else client_audio.get("file_format", studio_audio.get("file_format")))
+    delivery_method = _nonempty(client_delivery.get("method") or studio_delivery.get("method"), "delivery method")
+    inherited_deliverables = client_delivery.get("requested_deliverables")
+    if not isinstance(inherited_deliverables, list) or not inherited_deliverables:
+        inherited_deliverables = studio_delivery.get("requested_deliverables")
+    deliverables = require_deliverables(request.deliverables if request.deliverables is not None else inherited_deliverables)
+
+    cli = studio.get("cli") if isinstance(studio.get("cli"), dict) else {}
+    inherited_cd = cli.get("change_directory_after_create") is True
+    effective_cd = request.change_directory if request.change_directory is not None else inherited_cd
+
+    source_plan = None
+    if request.source is not None:
+        source = request.source.expanduser().resolve(strict=False)
+        if source.is_dir():
+            try:
+                projects_root.resolve(strict=False).relative_to(source)
+            except ValueError:
+                pass
+            else:
+                raise UnsafeOperationError(f"Source directory cannot contain the client Projects directory: {source}")
+        source_plan = build_plan(source)
+
+    context = {
+        "project_name": project_name,
+        "project_id": project_id,
+        "folder_name": folder_name,
+        "client_name": client_name,
+        "client_id": client_id,
+        "client_document_id": client_document_id,
+        "artist": artist,
+        "engineer": engineer,
+    }
+    return (
+        studio_root, client_root, studio, client, context, project_root,
+        _optional_text(request.album), _optional_text(request.producer), _optional_text(request.musical_key),
+        sample_rate, bit_depth, file_format, delivery_method, deliverables, effective_cd, source_plan,
+    )
+
+
+def create_project(request: ProjectCreateRequest) -> ProjectCreateResult:
+    (
+        studio_root, client_root, studio, client, context, project_root,
+        album, producer, musical_key, sample_rate, bit_depth, file_format,
+        delivery_method, deliverables, effective_cd, source_plan,
+    ) = _resolve_inputs(request)
+
+    bpm = _validate_bpm(request.bpm)
+    deadline = _validate_deadline(request.deadline)
+    timestamp = now_iso8601()
+    project_metadata = create_v11("mixing-project", mutability="mutable", timestamp=timestamp)
+    snapshot_metadata = create_v11("mixing-client-profile-snapshot", mutability="immutable", timestamp=timestamp)
+    revision_metadata_id = create_v11("placeholder", mutability="immutable", timestamp=timestamp)["document_id"]
+    revision_record = {
+        "number": 1,
+        "revision_id": revision_metadata_id,
+        "created_at": timestamp,
+        "description": "Initial mix",
+        "approval": {"approved_at": None, "approved_by": None},
+    }
+    manifest: dict[str, Any] = {
+        "metadata": project_metadata,
+        "project_id": context["project_id"],
+        "project_name": context["project_name"],
+        "client": {
+            "client_document_id": context["client_document_id"],
+            "client_id": context["client_id"],
+        },
+        "artist": context["artist"],
+        "album": album,
+        "producer": producer,
+        "mix_engineer": context["engineer"],
+        "music": {
+            "bpm": bpm,
+            "key": musical_key,
+            "time_signature": _optional_text(request.time_signature),
+        },
+        "audio": {
+            "sample_rate": sample_rate,
+            "bit_depth": bit_depth,
+            "file_format": file_format,
+        },
+        "delivery": {
+            "method": delivery_method,
+            "requested_deliverables": deliverables,
+        },
+        "schedule": {"deadline": deadline},
+        "creative_direction": _optional_text(request.description),
+        "state": {
+            "current_revision": 1,
+            "approved_revision": None,
+            "delivered_revision": None,
+        },
+        "revisions": [revision_record],
+    }
+    snapshot: dict[str, Any] = {
+        "metadata": snapshot_metadata,
+        "source_client": {
+            "client_document_id": context["client_document_id"],
+            "client_id": context["client_id"],
+            "client_name": context["client_name"],
+        },
+        "defaults": deepcopy(client.get("defaults") if isinstance(client.get("defaults"), dict) else {}),
+    }
+    initial_revision_root = project_root / "04_Revisions" / "Revision_01"
+
+    if request.dry_run:
+        return ProjectCreateResult(
+            project_root, manifest, snapshot, initial_revision_root,
+            client_root, studio_root, effective_cd, source_plan, False,
+        )
+
+    projects_root = client_root / "Projects"
+    stage = Path(tempfile.mkdtemp(prefix=f".{project_root.name}.jl-stage-", dir=projects_root))
+    try:
+        directories = [
+            "00_Admin",
+            "01_Client_Files/Original_Delivery",
+            "01_Client_Files/References",
+            "01_Client_Files/Documentation",
+            "02_Audio_Preparation/Working_Audio",
+            "02_Audio_Preparation/Rejected_Files",
+            "03_DAW_Project",
+            "04_Revisions/Revision_01",
+            "05_Final_Delivery/Stems",
+            "06_Recall/External_Files",
+            "06_Recall/Screenshots",
+        ]
+        for relative in directories:
+            stage.joinpath(*relative.split("/")).mkdir(parents=True, exist_ok=True)
+
+        (stage / "00_Admin" / "project-manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n"
+        )
+        (stage / "00_Admin" / "client-profile-snapshot.json").write_text(
+            json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n"
+        )
+        _write_template("Intake_Report.md", stage / "00_Admin" / "Intake_Report.md")
+        _write_template("Project_Notes.md", stage / "00_Admin" / "Project_Notes.md")
+        _write_template("Preparation_Report.md", stage / "02_Audio_Preparation" / "Preparation_Report.md")
+        _write_template(
+            "Revision_Notes.md",
+            stage / "04_Revisions" / "Revision_01" / "Revision_Notes.md",
+            {"REVISION_NUMBER": "1", "REVISION_DESCRIPTION": "Initial mix"},
+        )
+        _write_template("Delivery_Notes.md", stage / "05_Final_Delivery" / "Delivery_Notes.md")
+        _write_template("Recall_Sheet.md", stage / "06_Recall" / "Recall_Sheet.md")
+
+        if source_plan is not None:
+            copy_from_plan(source_plan, stage / "01_Client_Files" / "Original_Delivery")
+
+        if project_root.exists() or project_root.is_symlink():
+            raise UnsafeOperationError(f"Project destination already exists: {project_root}")
+        os.replace(stage, project_root)
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+    return ProjectCreateResult(
+        project_root, manifest, snapshot, initial_revision_root,
+        client_root, studio_root, effective_cd, source_plan, True,
+    )

--- a/src/jl_mixing/project.py
+++ b/src/jl_mixing/project.py
@@ -6,25 +6,22 @@ import json
 import os
 import shutil
 import tempfile
+import uuid
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Any
 
+import jsonschema
+
 from .context import studio_root as resolve_studio_root
 from .errors import ContextError, UnsafeOperationError, ValidationError
-from .metadata import create_v11, now_iso8601
+from .metadata import create_v11, now_iso8601, validate_v11
 from .naming import sanitize_folder_name, slugify
 from .paths import assert_no_case_insensitive_child_collision, assert_no_symlink_components
 from .source_import import SourcePlan, build_plan, copy_from_plan
-from .validation import (
-    require_bit_depth,
-    require_deliverables,
-    require_file_format,
-    require_sample_rate,
-    require_slug,
-)
+from .validation import require_bit_depth, require_deliverables, require_file_format, require_sample_rate, require_slug
 from .versions import application_root
 
 
@@ -72,8 +69,7 @@ def _load_json(path: Path, schema: str) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError) as exc:
         raise ValidationError(f"Invalid JSON document: {path}") from exc
     metadata = document.get("metadata")
-    if not isinstance(metadata, dict) or metadata.get("schema") != schema or metadata.get("schema_version") != "1.1.0":
-        raise ValidationError(f"Unexpected schema identity in: {path}")
+    validate_v11(metadata, schema, mutability="mutable")
     return document
 
 
@@ -120,6 +116,17 @@ def _project_id_available(projects_root: Path, candidate: str) -> None:
             raise ValidationError(f"Project ID already exists for this client: {candidate}")
 
 
+def _validate_schema(filename: str, document: dict[str, Any]) -> None:
+    schema_path = application_root() / "schemas" / filename
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(document)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContextError(f"Required schema is unreadable: {schema_path}") from exc
+    except jsonschema.ValidationError as exc:
+        raise ValidationError(f"Generated document failed {filename}: {exc.message}") from exc
+
+
 def _write_template(name: str, destination: Path, replacements: dict[str, str] | None = None) -> None:
     source = application_root() / "templates" / name
     try:
@@ -131,13 +138,9 @@ def _write_template(name: str, destination: Path, replacements: dict[str, str] |
     destination.write_text(text, encoding="utf-8", newline="\n")
 
 
-def _resolve_inputs(request: ProjectCreateRequest) -> tuple[
-    Path, Path, dict[str, Any], dict[str, Any], dict[str, Any], str, str, str, str,
-    int, int, str, str, list[str], bool, SourcePlan | None
-]:
+def _resolve_inputs(request: ProjectCreateRequest) -> dict[str, Any]:
     client_root = request.client_root.expanduser().resolve(strict=False)
-    client_file = client_root / "client.json"
-    client = _load_json(client_file, "mixing-client")
+    client = _load_json(client_root / "client.json", "mixing-client")
     studio_root = resolve_studio_root(client_root)
     studio = _load_json(studio_root / "Studio" / "studio.json", "mixing-studio")
     clients_root = studio_root / "Clients"
@@ -172,15 +175,22 @@ def _resolve_inputs(request: ProjectCreateRequest) -> tuple[
     studio_audio = studio_defaults.get("audio") if isinstance(studio_defaults.get("audio"), dict) else {}
     studio_delivery = studio_defaults.get("delivery") if isinstance(studio_defaults.get("delivery"), dict) else {}
 
-    if request.artist is None:
-        artist = _optional_text(client_defaults.get("artist")) or client_name
-    else:
-        artist = _nonempty(request.artist, "Artist")
-    engineer = _optional_text(request.engineer) if request.engineer is not None else _optional_text(studio_defaults.get("mix_engineer"))
+    artist = (_optional_text(client_defaults.get("artist")) or client_name) if request.artist is None else _nonempty(request.artist, "Artist")
+    engineer = _optional_text(studio_defaults.get("mix_engineer")) if request.engineer is None else _optional_text(request.engineer)
 
-    sample_rate = require_sample_rate(request.sample_rate if request.sample_rate is not None else client_audio.get("sample_rate", studio_audio.get("sample_rate")))
-    bit_depth = require_bit_depth(request.bit_depth if request.bit_depth is not None else client_audio.get("bit_depth", studio_audio.get("bit_depth")))
-    file_format = require_file_format(request.file_format if request.file_format is not None else client_audio.get("file_format", studio_audio.get("file_format")))
+    sample_rate_source = request.sample_rate if request.sample_rate is not None else client_audio.get("sample_rate")
+    if sample_rate_source in {None, ""}:
+        sample_rate_source = studio_audio.get("sample_rate")
+    bit_depth_source = request.bit_depth if request.bit_depth is not None else client_audio.get("bit_depth")
+    if bit_depth_source in {None, ""}:
+        bit_depth_source = studio_audio.get("bit_depth")
+    format_source = request.file_format if request.file_format is not None else client_audio.get("file_format")
+    if format_source in {None, ""}:
+        format_source = studio_audio.get("file_format")
+    sample_rate = require_sample_rate(sample_rate_source)
+    bit_depth = require_bit_depth(bit_depth_source)
+    file_format = require_file_format(format_source)
+
     delivery_method = _nonempty(client_delivery.get("method") or studio_delivery.get("method"), "delivery method")
     inherited_deliverables = client_delivery.get("requested_deliverables")
     if not isinstance(inherited_deliverables, list) or not inherited_deliverables:
@@ -188,114 +198,91 @@ def _resolve_inputs(request: ProjectCreateRequest) -> tuple[
     deliverables = require_deliverables(request.deliverables if request.deliverables is not None else inherited_deliverables)
 
     cli = studio.get("cli") if isinstance(studio.get("cli"), dict) else {}
-    inherited_cd = cli.get("change_directory_after_create") is True
-    effective_cd = request.change_directory if request.change_directory is not None else inherited_cd
+    effective_cd = request.change_directory if request.change_directory is not None else cli.get("change_directory_after_create") is True
 
-    source_plan = None
-    if request.source is not None:
-        source = request.source.expanduser().resolve(strict=False)
-        if source.is_dir():
-            try:
-                projects_root.resolve(strict=False).relative_to(source)
-            except ValueError:
-                pass
-            else:
-                raise UnsafeOperationError(f"Source directory cannot contain the client Projects directory: {source}")
-        source_plan = build_plan(source)
+    source_plan = build_plan(request.source) if request.source is not None else None
+    if source_plan is not None and source_plan.source_type == "directory":
+        try:
+            projects_root.resolve(strict=False).relative_to(source_plan.source)
+        except ValueError:
+            pass
+        else:
+            raise UnsafeOperationError(f"Source directory cannot contain the client Projects directory: {source_plan.source}")
 
-    context = {
+    return {
+        "studio_root": studio_root,
+        "client_root": client_root,
+        "client": client,
+        "project_root": project_root,
         "project_name": project_name,
         "project_id": project_id,
-        "folder_name": folder_name,
         "client_name": client_name,
         "client_id": client_id,
         "client_document_id": client_document_id,
         "artist": artist,
         "engineer": engineer,
+        "sample_rate": sample_rate,
+        "bit_depth": bit_depth,
+        "file_format": file_format,
+        "delivery_method": delivery_method,
+        "deliverables": deliverables,
+        "effective_cd": effective_cd,
+        "source_plan": source_plan,
     }
-    return (
-        studio_root, client_root, studio, client, context, project_root,
-        _optional_text(request.album), _optional_text(request.producer), _optional_text(request.musical_key),
-        sample_rate, bit_depth, file_format, delivery_method, deliverables, effective_cd, source_plan,
-    )
 
 
 def create_project(request: ProjectCreateRequest) -> ProjectCreateResult:
-    (
-        studio_root, client_root, studio, client, context, project_root,
-        album, producer, musical_key, sample_rate, bit_depth, file_format,
-        delivery_method, deliverables, effective_cd, source_plan,
-    ) = _resolve_inputs(request)
-
+    values = _resolve_inputs(request)
     bpm = _validate_bpm(request.bpm)
     deadline = _validate_deadline(request.deadline)
     timestamp = now_iso8601()
-    project_metadata = create_v11("mixing-project", mutability="mutable", timestamp=timestamp)
-    snapshot_metadata = create_v11("mixing-client-profile-snapshot", mutability="immutable", timestamp=timestamp)
-    revision_metadata_id = create_v11("placeholder", mutability="immutable", timestamp=timestamp)["document_id"]
-    revision_record = {
-        "number": 1,
-        "revision_id": revision_metadata_id,
-        "created_at": timestamp,
-        "description": "Initial mix",
-        "approval": {"approved_at": None, "approved_by": None},
-    }
+
     manifest: dict[str, Any] = {
-        "metadata": project_metadata,
-        "project_id": context["project_id"],
-        "project_name": context["project_name"],
-        "client": {
-            "client_document_id": context["client_document_id"],
-            "client_id": context["client_id"],
-        },
-        "artist": context["artist"],
-        "album": album,
-        "producer": producer,
-        "mix_engineer": context["engineer"],
-        "music": {
-            "bpm": bpm,
-            "key": musical_key,
-            "time_signature": _optional_text(request.time_signature),
-        },
-        "audio": {
-            "sample_rate": sample_rate,
-            "bit_depth": bit_depth,
-            "file_format": file_format,
-        },
-        "delivery": {
-            "method": delivery_method,
-            "requested_deliverables": deliverables,
-        },
+        "metadata": create_v11("mixing-project", mutability="mutable", timestamp=timestamp),
+        "project_id": values["project_id"],
+        "project_name": values["project_name"],
+        "client": {"client_document_id": values["client_document_id"], "client_id": values["client_id"]},
+        "artist": values["artist"],
+        "album": _optional_text(request.album),
+        "producer": _optional_text(request.producer),
+        "mix_engineer": values["engineer"],
+        "music": {"bpm": bpm, "key": _optional_text(request.musical_key), "time_signature": _optional_text(request.time_signature)},
+        "audio": {"sample_rate": values["sample_rate"], "bit_depth": values["bit_depth"], "file_format": values["file_format"]},
+        "delivery": {"method": values["delivery_method"], "requested_deliverables": values["deliverables"]},
         "schedule": {"deadline": deadline},
         "creative_direction": _optional_text(request.description),
-        "state": {
-            "current_revision": 1,
-            "approved_revision": None,
-            "delivered_revision": None,
-        },
-        "revisions": [revision_record],
+        "state": {"current_revision": 1, "approved_revision": None, "delivered_revision": None},
+        "revisions": [{
+            "number": 1,
+            "revision_id": str(uuid.uuid4()),
+            "created_at": timestamp,
+            "description": "Initial mix",
+            "approval": {"approved_at": None, "approved_by": None},
+        }],
     }
     snapshot: dict[str, Any] = {
-        "metadata": snapshot_metadata,
+        "metadata": create_v11("mixing-client-profile-snapshot", mutability="immutable", timestamp=timestamp),
         "source_client": {
-            "client_document_id": context["client_document_id"],
-            "client_id": context["client_id"],
-            "client_name": context["client_name"],
+            "client_document_id": values["client_document_id"],
+            "client_id": values["client_id"],
+            "client_name": values["client_name"],
         },
-        "defaults": deepcopy(client.get("defaults") if isinstance(client.get("defaults"), dict) else {}),
+        "defaults": deepcopy(values["client"].get("defaults") if isinstance(values["client"].get("defaults"), dict) else {}),
     }
+    validate_v11(manifest["metadata"], "mixing-project", mutability="mutable")
+    validate_v11(snapshot["metadata"], "mixing-client-profile-snapshot", mutability="immutable")
+    _validate_schema("project-manifest.schema.json", manifest)
+    _validate_schema("client-profile-snapshot.schema.json", snapshot)
+
+    project_root: Path = values["project_root"]
     initial_revision_root = project_root / "04_Revisions" / "Revision_01"
-
     if request.dry_run:
-        return ProjectCreateResult(
-            project_root, manifest, snapshot, initial_revision_root,
-            client_root, studio_root, effective_cd, source_plan, False,
-        )
+        return ProjectCreateResult(project_root, manifest, snapshot, initial_revision_root, values["client_root"], values["studio_root"], values["effective_cd"], values["source_plan"], False)
 
-    projects_root = client_root / "Projects"
+    projects_root = values["client_root"] / "Projects"
     stage = Path(tempfile.mkdtemp(prefix=f".{project_root.name}.jl-stage-", dir=projects_root))
     try:
-        directories = [
+        for relative in (
             "00_Admin",
             "01_Client_Files/Original_Delivery",
             "01_Client_Files/References",
@@ -307,30 +294,19 @@ def create_project(request: ProjectCreateRequest) -> ProjectCreateResult:
             "05_Final_Delivery/Stems",
             "06_Recall/External_Files",
             "06_Recall/Screenshots",
-        ]
-        for relative in directories:
+        ):
             stage.joinpath(*relative.split("/")).mkdir(parents=True, exist_ok=True)
 
-        (stage / "00_Admin" / "project-manifest.json").write_text(
-            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n"
-        )
-        (stage / "00_Admin" / "client-profile-snapshot.json").write_text(
-            json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n"
-        )
+        (stage / "00_Admin" / "project-manifest.json").write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n")
+        (stage / "00_Admin" / "client-profile-snapshot.json").write_text(json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n")
         _write_template("Intake_Report.md", stage / "00_Admin" / "Intake_Report.md")
         _write_template("Project_Notes.md", stage / "00_Admin" / "Project_Notes.md")
         _write_template("Preparation_Report.md", stage / "02_Audio_Preparation" / "Preparation_Report.md")
-        _write_template(
-            "Revision_Notes.md",
-            stage / "04_Revisions" / "Revision_01" / "Revision_Notes.md",
-            {"REVISION_NUMBER": "1", "REVISION_DESCRIPTION": "Initial mix"},
-        )
+        _write_template("Revision_Notes.md", stage / "04_Revisions" / "Revision_01" / "Revision_Notes.md", {"REVISION_NUMBER": "1", "REVISION_DESCRIPTION": "Initial mix"})
         _write_template("Delivery_Notes.md", stage / "05_Final_Delivery" / "Delivery_Notes.md")
         _write_template("Recall_Sheet.md", stage / "06_Recall" / "Recall_Sheet.md")
-
-        if source_plan is not None:
-            copy_from_plan(source_plan, stage / "01_Client_Files" / "Original_Delivery")
-
+        if values["source_plan"] is not None:
+            copy_from_plan(values["source_plan"], stage / "01_Client_Files" / "Original_Delivery")
         if project_root.exists() or project_root.is_symlink():
             raise UnsafeOperationError(f"Project destination already exists: {project_root}")
         os.replace(stage, project_root)
@@ -339,7 +315,4 @@ def create_project(request: ProjectCreateRequest) -> ProjectCreateResult:
             shutil.rmtree(stage, ignore_errors=True)
         raise
 
-    return ProjectCreateResult(
-        project_root, manifest, snapshot, initial_revision_root,
-        client_root, studio_root, effective_cd, source_plan, True,
-    )
+    return ProjectCreateResult(project_root, manifest, snapshot, initial_revision_root, values["client_root"], values["studio_root"], values["effective_cd"], values["source_plan"], True)

--- a/src/jl_mixing/source_import.py
+++ b/src/jl_mixing/source_import.py
@@ -53,6 +53,9 @@ def _absolute_without_following(path: Path) -> Path:
 def build_plan(source: Path) -> SourcePlan:
     source = _absolute_without_following(source)
     source_type = _classify(source)
+    # It is safe to canonicalize only after lstat() has rejected a top-level
+    # symlink. Canonical paths keep containment comparisons stable on Windows.
+    source = source.resolve(strict=True)
     entries: list[SourceEntry] = []
     seen: dict[str, str] = {}
 

--- a/src/jl_mixing/source_import.py
+++ b/src/jl_mixing/source_import.py
@@ -1,0 +1,110 @@
+"""Cross-platform source-import planning and copy primitives."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import UnsafeOperationError, ValidationError
+
+
+@dataclass(frozen=True)
+class SourceEntry:
+    type: str
+    path: str
+
+
+@dataclass(frozen=True)
+class SourcePlan:
+    source_type: str
+    source: Path
+    entries: tuple[SourceEntry, ...]
+
+
+def _validate_component(name: str, path: Path) -> None:
+    if any(ord(character) < 32 or ord(character) == 127 for character in name):
+        raise ValidationError(f"Control characters are not allowed in source names: {path}")
+
+
+def _classify(path: Path) -> str:
+    try:
+        mode = path.lstat().st_mode
+    except OSError as exc:
+        raise ValidationError(f"Unable to inspect source path {path}: {exc}") from exc
+    if stat.S_ISLNK(mode):
+        raise UnsafeOperationError(f"Symbolic links are not allowed in source imports: {path}")
+    if stat.S_ISREG(mode):
+        return "file"
+    if stat.S_ISDIR(mode):
+        return "directory"
+    raise ValidationError(f"Unsupported source filesystem object: {path}")
+
+
+def build_plan(source: Path) -> SourcePlan:
+    source = source.expanduser().resolve(strict=False)
+    source_type = _classify(source)
+    entries: list[SourceEntry] = []
+    seen: dict[str, str] = {}
+
+    def add_entry(relative: Path, entry_type: str) -> None:
+        display = relative.as_posix()
+        key = display.casefold()
+        if key in seen:
+            raise ValidationError(
+                f"Case-insensitive source-path collision: {seen[key]!r} and {display!r}"
+            )
+        seen[key] = display
+        entries.append(SourceEntry(entry_type, display))
+
+    if source_type == "file":
+        _validate_component(source.name, source)
+        add_entry(Path(source.name), "file")
+    else:
+        def walk(directory: Path, relative_directory: Path) -> None:
+            try:
+                children = sorted(os.scandir(directory), key=lambda item: (item.name.casefold(), item.name))
+            except OSError as exc:
+                raise ValidationError(f"Unable to read source directory {directory}: {exc}") from exc
+            for child in children:
+                child_path = Path(child.path)
+                _validate_component(child.name, child_path)
+                relative = relative_directory / child.name
+                entry_type = _classify(child_path)
+                add_entry(relative, entry_type)
+                if entry_type == "directory":
+                    walk(child_path, relative)
+
+        walk(source, Path())
+
+    entries.sort(key=lambda item: (item.path.casefold(), item.path, item.type))
+    return SourcePlan(source_type, source, tuple(entries))
+
+
+def copy_from_plan(plan: SourcePlan, destination: Path) -> None:
+    current = build_plan(plan.source)
+    if current.source_type != plan.source_type or current.entries != plan.entries:
+        raise ValidationError("Source import changed after preflight; no project was created.")
+    if destination.is_symlink() or not destination.is_dir():
+        raise UnsafeOperationError(f"Source-import destination is missing or unsafe: {destination}")
+    if any(destination.iterdir()):
+        raise UnsafeOperationError(f"Source-import destination must be empty: {destination}")
+
+    directories = [entry for entry in plan.entries if entry.type == "directory"]
+    files = [entry for entry in plan.entries if entry.type == "file"]
+    for entry in sorted(directories, key=lambda value: (value.path.count("/"), value.path)):
+        destination.joinpath(*Path(entry.path).parts).mkdir(parents=True, exist_ok=False)
+
+    for entry in files:
+        relative = Path(entry.path)
+        source_file = plan.source if plan.source_type == "file" else plan.source / relative
+        destination_file = destination / relative
+        destination_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_file, destination_file, follow_symlinks=False)
+
+    if plan.source_type == "directory":
+        for entry in sorted(directories, key=lambda value: value.path.count("/"), reverse=True):
+            relative = Path(entry.path)
+            shutil.copystat(plan.source / relative, destination / relative, follow_symlinks=False)

--- a/src/jl_mixing/source_import.py
+++ b/src/jl_mixing/source_import.py
@@ -43,8 +43,15 @@ def _classify(path: Path) -> str:
     raise ValidationError(f"Unsupported source filesystem object: {path}")
 
 
+def _absolute_without_following(path: Path) -> Path:
+    expanded = path.expanduser()
+    if not expanded.is_absolute():
+        expanded = Path.cwd() / expanded
+    return Path(os.path.abspath(expanded))
+
+
 def build_plan(source: Path) -> SourcePlan:
-    source = source.expanduser().resolve(strict=False)
+    source = _absolute_without_following(source)
     source_type = _classify(source)
     entries: list[SourceEntry] = []
     seen: dict[str, str] = {}

--- a/tests/python/test_project_service.py
+++ b/tests/python/test_project_service.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.errors import UnsafeOperationError, ValidationError
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+
+def write_studio(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio",
+            "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "test-studio",
+        "studio_name": "Test Studio",
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Mix Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud transfer", "requested_deliverables": ["main_mix", "instrumental"]},
+        },
+        "cli": {"change_directory_after_create": True},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    return root
+
+
+def write_client(studio_root: Path, *, artist: str = "Client Artist") -> Path:
+    client_root = studio_root / "Clients" / "Test Client"
+    (client_root / "Projects").mkdir(parents=True)
+    client = {
+        "metadata": {
+            "schema": "mixing-client",
+            "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "test-client",
+        "client_name": "Test Client",
+        "defaults": {
+            "artist": artist,
+            "audio": {"sample_rate": 96000, "bit_depth": 32, "file_format": "AIFF"},
+            "delivery": {"method": "Client portal", "requested_deliverables": ["main_mix", "stems"]},
+        },
+    }
+    (client_root / "client.json").write_text(json.dumps(client), encoding="utf-8")
+    return client_root
+
+
+class ProjectServiceTests(unittest.TestCase):
+    def test_dry_run_inherits_defaults_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            client = write_client(studio)
+            result = create_project(ProjectCreateRequest(client, "First Song", dry_run=True))
+            self.assertFalse(result.created)
+            self.assertFalse(result.project_root.exists())
+            self.assertEqual(result.manifest["project_id"], "first-song")
+            self.assertEqual(result.manifest["artist"], "Client Artist")
+            self.assertEqual(result.manifest["mix_engineer"], "Mix Engineer")
+            self.assertEqual(result.manifest["audio"], {"sample_rate": 96000, "bit_depth": 32, "file_format": "AIFF"})
+            self.assertEqual(result.manifest["delivery"]["requested_deliverables"], ["main_mix", "stems"])
+            self.assertTrue(result.effective_cd)
+            self.assertEqual(result.manifest["state"]["current_revision"], 1)
+            self.assertEqual(result.manifest["revisions"][0]["description"], "Initial mix")
+
+    def test_create_commits_canonical_layout_and_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            client = write_client(studio)
+            result = create_project(ProjectCreateRequest(
+                client,
+                "Second Song",
+                album="Album",
+                producer="Producer",
+                bpm=123.5,
+                musical_key="A minor",
+                time_signature="4/4",
+                deadline="2030-12-31",
+                description="Keep the vocal intimate",
+                change_directory=False,
+            ))
+            self.assertTrue(result.created)
+            manifest_path = result.project_root / "00_Admin" / "project-manifest.json"
+            snapshot_path = result.project_root / "00_Admin" / "client-profile-snapshot.json"
+            self.assertTrue(manifest_path.is_file())
+            self.assertTrue(snapshot_path.is_file())
+            self.assertTrue((result.project_root / "01_Client_Files" / "Original_Delivery").is_dir())
+            self.assertTrue((result.project_root / "03_DAW_Project").is_dir())
+            self.assertTrue((result.initial_revision_root / "Revision_Notes.md").is_file())
+            self.assertTrue((result.project_root / "05_Final_Delivery" / "Delivery_Notes.md").is_file())
+            persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["music"]["bpm"], 123.5)
+            self.assertEqual(persisted["schedule"]["deadline"], "2030-12-31")
+            self.assertEqual(persisted["state"], {"current_revision": 1, "approved_revision": None, "delivered_revision": None})
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            self.assertEqual(snapshot["source_client"]["client_id"], "test-client")
+            self.assertNotIn("last_modified_at", snapshot["metadata"])
+            self.assertFalse(result.effective_cd)
+
+    def test_source_import_is_preflighted_and_copied(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            studio = write_studio(root / "studio")
+            client = write_client(studio)
+            source = root / "incoming"
+            (source / "Audio").mkdir(parents=True)
+            (source / "Audio" / "Kick.wav").write_bytes(b"audio")
+            (source / "Notes.txt").write_text("notes\n", encoding="utf-8")
+            result = create_project(ProjectCreateRequest(client, "Imported Song", source=source))
+            delivery = result.project_root / "01_Client_Files" / "Original_Delivery"
+            self.assertEqual((delivery / "Audio" / "Kick.wav").read_bytes(), b"audio")
+            self.assertEqual((delivery / "Notes.txt").read_text(encoding="utf-8"), "notes\n")
+            self.assertIsNotNone(result.source_plan)
+
+    def test_duplicate_project_id_and_case_collision_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            client = write_client(studio)
+            create_project(ProjectCreateRequest(client, "Existing Song", project_id="stable-id"))
+            with self.assertRaises(ValidationError):
+                create_project(ProjectCreateRequest(client, "Different Folder", project_id="stable-id"))
+            with self.assertRaises(ValidationError):
+                create_project(ProjectCreateRequest(client, "existing song", project_id="different-id"))
+
+    def test_invalid_deadline_and_unsafe_source_fail_before_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            studio = write_studio(root / "studio")
+            client = write_client(studio)
+            with self.assertRaises(ValidationError):
+                create_project(ProjectCreateRequest(client, "Bad Date", deadline="2030-02-30"))
+            self.assertFalse((client / "Projects" / "Bad Date").exists())
+            with self.assertRaises(UnsafeOperationError):
+                create_project(ProjectCreateRequest(client, "Bad Source", source=studio))
+            self.assertFalse((client / "Projects" / "Bad Source").exists())
+
+    def test_empty_client_artist_falls_back_to_client_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio = write_studio(Path(tmp))
+            client = write_client(studio, artist="")
+            result = create_project(ProjectCreateRequest(client, "Artist Fallback", dry_run=True))
+            self.assertEqual(result.manifest["artist"], "Test Client")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by porting the authoritative project-creation workflow into the cross-platform Python runtime.

## Changes

- add v1.4-compatible project slug derivation
- promote source-import preflight/copy logic into the Python package with no symlink following and deterministic case-insensitive collision checks
- add transactional `create_project()` service using a staged sibling directory and one atomic rename
- preserve client/studio default inheritance for artist, engineer, audio format, delivery method, deliverables, and automatic directory-change preference
- preserve project ID/folder collision checks, BPM/deadline validation, initial state, and canonical Revision_01 record
- create the full canonical project directory layout, project manifest, immutable client snapshot, notes/reports, and initial revision notes
- preserve optional source import into immutable `01_Client_Files/Original_Delivery`
- validate generated project/snapshot metadata and JSON Schemas before mutation
- preserve dry-run non-mutation
- add native Python tests for defaults, layout/state, snapshot identity, source import, collision rejection, invalid dates/unsafe sources, and artist fallback

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no installed launcher is changed in this slice
- API/client resolution and parent-shell `--cd` behavior remain adapter responsibilities

Part of #71.