### PR TITLE
Implement v1.5 Python project.create API adapter

### DIFF
--- a/src/jl_mixing/api/project_create.py
+++ b/src/jl_mixing/api/project_create.py
@@ -1,0 +1,244 @@
+"""Automation API 1.0 adapter for project.create."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..context import resolve_client_reference
+from ..errors import ArgumentError, ContextError, JLMixingError, UnsafeOperationError, ValidationError
+from ..project import ProjectCreateRequest, create_project
+from ..versions import api_version
+
+
+@dataclass(frozen=True)
+class ProjectApiRequest:
+    project_name: str
+    client_reference: str | None = None
+    project_id: str | None = None
+    artist: str | None = None
+    album: str = ""
+    producer: str = ""
+    engineer: str | None = None
+    bpm: float | int | None = None
+    musical_key: str = ""
+    time_signature: str = ""
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    file_format: str | None = None
+    deadline: str | None = None
+    deliverables: list[str] | None = None
+    description: str = ""
+    source: Path | None = None
+    dry_run: bool = False
+
+
+def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "project.create",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [{
+            "code": code,
+            "message": message,
+            "details": {"exit_code": exit_code},
+            "retryable": False,
+        }],
+    }
+
+
+def execute(request: ProjectApiRequest) -> tuple[dict[str, Any], int]:
+    try:
+        client_root = resolve_client_reference(request.client_reference, Path.cwd())
+        result = create_project(ProjectCreateRequest(
+            client_root=client_root,
+            project_name=request.project_name,
+            project_id=request.project_id,
+            artist=request.artist,
+            album=request.album,
+            producer=request.producer,
+            engineer=request.engineer,
+            bpm=request.bpm,
+            musical_key=request.musical_key,
+            time_signature=request.time_signature,
+            sample_rate=request.sample_rate,
+            bit_depth=request.bit_depth,
+            file_format=request.file_format,
+            deadline=request.deadline,
+            deliverables=request.deliverables,
+            description=request.description,
+            source=request.source,
+            change_directory=False,
+            dry_run=request.dry_run,
+        ))
+        manifest = result.manifest
+        data: dict[str, Any] = {
+            "project": {
+                "id": manifest["project_id"],
+                "name": manifest["project_name"],
+                "artist": manifest["artist"],
+                "path": str(result.project_root),
+            },
+            "manifest_path": str(result.project_root / "00_Admin" / "project-manifest.json"),
+            "client_snapshot_path": str(result.project_root / "00_Admin" / "client-profile-snapshot.json"),
+            "initial_revision_path": str(result.initial_revision_root),
+            "client": {
+                "id": manifest["client"]["client_id"],
+                "path": str(result.client_root),
+            },
+            "workspace_path": str(result.studio_root),
+        }
+        if request.dry_run:
+            data["would_create"] = [
+                data["manifest_path"],
+                data["client_snapshot_path"],
+                data["initial_revision_path"],
+            ]
+        return {
+            "api_version": api_version(),
+            "operation": "project.create",
+            "status": "planned" if request.dry_run else "success",
+            "data": data,
+            "warnings": [],
+            "errors": [],
+        }, 0
+    except ContextError as exc:
+        message = str(exc)
+        lower = message.lower()
+        code = "CLIENT_NOT_FOUND" if "client" in lower or "studio context" in lower else "WORKSPACE_CONTEXT_ERROR"
+        return _error_envelope(code, message, exc.exit_code), exc.exit_code
+    except ValidationError as exc:
+        message = str(exc)
+        lower = message.lower()
+        code = "PROJECT_ALREADY_EXISTS" if any(token in lower for token in ("project id already exists", "path collision")) else "VALIDATION_FAILED"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except UnsafeOperationError as exc:
+        message = str(exc)
+        code = "PROJECT_ALREADY_EXISTS" if "project destination already exists" in message.lower() else "UNSAFE_OPERATION"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+
+
+def _parse_deliverables(value: str) -> list[str]:
+    raw = value.split(",")
+    if not raw or any(not item.strip() for item in raw):
+        raise ValidationError(f"Invalid --deliverables list: {value}")
+    return [item.strip() for item in raw]
+
+
+def _parse_bpm(value: str) -> float | int:
+    try:
+        if value.isdigit():
+            return int(value)
+        return float(value)
+    except ValueError as exc:
+        raise ValidationError(f"BPM must be a positive number: {value}") from exc
+
+
+def parse_args(args: list[str]) -> ProjectApiRequest:
+    project_name: str | None = None
+    positional_seen = False
+    project_option_seen = False
+    values: dict[str, Any] = {
+        "client_reference": None,
+        "project_id": None,
+        "artist": None,
+        "album": "",
+        "producer": "",
+        "engineer": None,
+        "bpm": None,
+        "musical_key": "",
+        "time_signature": "",
+        "sample_rate": None,
+        "bit_depth": None,
+        "file_format": None,
+        "deadline": None,
+        "deliverables": None,
+        "description": "",
+        "source": None,
+        "dry_run": False,
+    }
+    json_seen = 0
+    index = 0
+    option_map = {
+        "--client": "client_reference",
+        "--project-id": "project_id",
+        "--artist": "artist",
+        "--album": "album",
+        "--producer": "producer",
+        "--engineer": "engineer",
+        "--bpm": "bpm",
+        "--key": "musical_key",
+        "--time-signature": "time_signature",
+        "--sample-rate": "sample_rate",
+        "--bit-depth": "bit_depth",
+        "--file-format": "file_format",
+        "--deadline": "deadline",
+        "--deliverables": "deliverables",
+        "--description": "description",
+        "--source": "source",
+    }
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg in {"--cd", "--no-cd"}:
+            raise ArgumentError("project create JSON mode does not accept --cd or --no-cd.")
+        elif arg == "--dry-run":
+            values["dry_run"] = True
+        elif arg == "--project":
+            if positional_seen:
+                raise ArgumentError("Project name cannot be specified both positionally and with --project.")
+            index += 1
+            if index >= len(args):
+                raise ArgumentError("--project requires a value.")
+            if project_option_seen:
+                raise ArgumentError("Project name cannot be specified more than once.")
+            project_name = args[index]
+            project_option_seen = True
+        elif arg in option_map:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            field = option_map[arg]
+            if arg == "--sample-rate":
+                try:
+                    values[field] = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported sample rate: {value}") from exc
+            elif arg == "--bit-depth":
+                try:
+                    values[field] = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported bit depth: {value}") from exc
+            elif arg == "--bpm":
+                values[field] = _parse_bpm(value)
+            elif arg == "--deliverables":
+                values[field] = _parse_deliverables(value)
+            elif arg == "--source":
+                values[field] = Path(value)
+            else:
+                values[field] = value
+        elif arg in {"--project-type", "--daw", "--template", "--non-interactive"}:
+            raise ArgumentError(f"Removed option is not supported: {arg}")
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            if project_option_seen:
+                raise ArgumentError("Project name cannot be specified both positionally and with --project.")
+            if positional_seen:
+                raise ArgumentError(f"Unexpected positional argument: {arg}")
+            project_name = arg
+            positional_seen = True
+        index += 1
+
+    if json_seen != 1:
+        raise ArgumentError("project create requires exactly one --json option.")
+    if project_name is None:
+        raise ArgumentError("project create requires PROJECT_NAME and --json.")
+    return ProjectApiRequest(project_name=project_name, **values)

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -12,6 +12,9 @@ from .api.client_create import parse_args as parse_client_args
 from .api.intake_validate import _error_envelope as intake_error_envelope
 from .api.intake_validate import execute as intake_execute
 from .api.intake_validate import parse_args as parse_intake_args
+from .api.project_create import _error_envelope as project_error_envelope
+from .api.project_create import execute as project_execute
+from .api.project_create import parse_args as parse_project_args
 from .errors import ArgumentError, ValidationError
 from .system_info import document as system_info_document
 
@@ -45,6 +48,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             _emit_json(client_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
             return exc.exit_code
         payload, status = client_execute(request)
+        _emit_json(payload)
+        return status
+
+    if len(args) >= 2 and args[0:2] == ["project", "create"]:
+        try:
+            request = parse_project_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(project_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            return exc.exit_code
+        except ValidationError as exc:
+            _emit_json(project_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
+            return exc.exit_code
+        payload, status = project_execute(request)
         _emit_json(payload)
         return status
 

--- a/src/jl_mixing/context.py
+++ b/src/jl_mixing/context.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .errors import ArgumentError, ContextError, ValidationError
 from .paths import native_absolute_path
+from .validation import require_slug
 
 
 def _read_json(path: Path) -> dict[str, object]:
@@ -83,6 +84,46 @@ def resolve_client(explicit: Path | str | None, start: Path | str) -> Path:
         raise ContextError(f"Client not found or unsafe at explicit path: {explicit}")
     _require_identity(marker, "mixing-client")
     return candidate
+
+
+def resolve_client_reference(reference: str | Path | None, start: Path | str) -> Path:
+    """Resolve a v1.4 new-mix client reference by context, path, or stable ID."""
+
+    if reference is None or str(reference) == "":
+        try:
+            return client_root(start)
+        except ContextError as exc:
+            raise ContextError(
+                "Run new-mix inside a client directory or supply --client CLIENT_ID_OR_PATH."
+            ) from exc
+
+    text = str(reference)
+    base = native_absolute_path(start, base=Path.cwd())
+    candidate = Path(text).expanduser()
+    if not candidate.is_absolute():
+        candidate = base / candidate
+    if candidate.exists() or candidate.is_symlink():
+        return resolve_client(candidate, start)
+
+    client_id = require_slug(text, label="Client ID")
+    try:
+        studio = studio_root(start)
+    except ContextError as exc:
+        raise ContextError(f"A studio context is required to resolve client ID '{client_id}'.") from exc
+
+    matches: list[Path] = []
+    for client_file in (studio / "Clients").glob("*/client.json"):
+        if client_file.is_symlink() or not client_file.is_file():
+            continue
+        document = _read_json(client_file)
+        if document.get("client_id") == client_id:
+            matches.append(client_file.parent)
+    if len(matches) == 1:
+        _require_identity(matches[0] / "client.json", "mixing-client")
+        return matches[0]
+    if len(matches) > 1:
+        raise ValidationError(f"Multiple clients use the ID '{client_id}'.")
+    raise ContextError(f"Client not found: {client_id}")
 
 
 def revision_root_for_number(project: Path, number: int) -> Path:

--- a/tests/python/test_project_api.py
+++ b/tests/python/test_project_api.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_workspace(root: Path) -> tuple[Path, Path]:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio",
+            "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "api-studio",
+        "studio_name": "API Studio",
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "API Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud transfer", "requested_deliverables": ["main_mix", "instrumental"]},
+        },
+        "cli": {"change_directory_after_create": True},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+
+    client_root = root / "Clients" / "API Client"
+    (client_root / "Projects").mkdir(parents=True)
+    client = {
+        "metadata": {
+            "schema": "mixing-client",
+            "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "api-client",
+        "client_name": "API Client",
+        "defaults": {
+            "artist": "API Artist",
+            "audio": {"sample_rate": 96000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Portal", "requested_deliverables": ["main_mix", "stems"]},
+        },
+    }
+    (client_root / "client.json").write_text(json.dumps(client), encoding="utf-8")
+    return root, client_root
+
+
+def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class ProjectApiTests(unittest.TestCase):
+    def test_dry_run_from_client_context_is_structured_and_non_mutating(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, client = write_workspace(Path(tmp))
+            proc = run_cli(client, "project", "create", "Dry Song", "--json", "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "project.create")
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["data"]["project"]["id"], "dry-song")
+            self.assertEqual(payload["data"]["project"]["artist"], "API Artist")
+            self.assertEqual(payload["data"]["client"]["id"], "api-client")
+            self.assertEqual(len(payload["data"]["would_create"]), 3)
+            self.assertFalse((client / "Projects" / "Dry Song").exists())
+
+    def test_client_id_resolution_from_studio_context_and_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio, client = write_workspace(Path(tmp))
+            proc = run_cli(
+                studio,
+                "project", "create", "--project", "Created Song", "--client", "api-client", "--json",
+                "--artist", "Override Artist", "--sample-rate", "48000", "--deliverables", "main_mix,master",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "success")
+            self.assertEqual(payload["data"]["project"]["name"], "Created Song")
+            self.assertEqual(payload["data"]["project"]["artist"], "Override Artist")
+            self.assertEqual(Path(payload["data"]["project"]["path"]), (client / "Projects" / "Created Song").resolve())
+            manifest = json.loads((client / "Projects" / "Created Song" / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["audio"]["sample_rate"], 48000)
+            self.assertEqual(manifest["delivery"]["requested_deliverables"], ["main_mix", "master"])
+
+    def test_duplicate_project_is_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, client = write_workspace(Path(tmp))
+            first = run_cli(client, "project", "create", "Duplicate Song", "--json")
+            self.assertEqual(first.returncode, 0, first.stderr)
+            second = run_cli(client, "project", "create", "Different Name", "--project-id", "duplicate-song", "--json")
+            self.assertEqual(second.returncode, 5)
+            self.assertEqual(second.stderr, "")
+            payload = json.loads(second.stdout)
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["errors"][0]["code"], "PROJECT_ALREADY_EXISTS")
+
+    def test_missing_client_id_is_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            studio, _ = write_workspace(Path(tmp))
+            proc = run_cli(studio, "project", "create", "Song", "--client", "missing-client", "--json")
+            self.assertEqual(proc.returncode, 4)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["errors"][0]["code"], "CLIENT_NOT_FOUND")
+
+    def test_json_mode_rejects_shell_cd_and_duplicate_name_forms(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, client = write_workspace(Path(tmp))
+            proc = run_cli(client, "project", "create", "Song", "--json", "--cd")
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_REQUEST")
+            proc = run_cli(client, "project", "create", "Song", "--project", "Other", "--json")
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_REQUEST")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by wiring Automation API 1.0 `project.create` directly to the cross-platform Python project service.

## Changes

- add shared client-reference resolution by current context, explicit client path, or stable client ID
- add Python `project.create` request parser and API 1.0 response adapter
- route `jl_mixing.cli project create ... --json` through the Python service
- preserve positional and `--project` name forms while rejecting mixed/duplicate forms
- preserve explicit rejection of `--cd` and `--no-cd` in JSON mode
- preserve project/client/workspace paths, dry-run `would_create`, planned/success/blocked/error envelopes, and stable exit-code mapping
- preserve `PROJECT_ALREADY_EXISTS` and `CLIENT_NOT_FOUND` classifications
- keep machine failures on stdout with empty stderr
- add native Windows/macOS/Linux contract tests for dry-run, stable client-ID lookup, successful creation/overrides, duplicate project classification, missing clients, and JSON-mode argument rules

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash dispatcher remains unchanged until launcher cutover
- API adapter calls the Python project service directly and does not parse human CLI output

Part of #71.