### PR TITLE
Port revision.create service to v1.5 Python runtime

### DIFF
--- a/src/jl_mixing/revision.py
+++ b/src/jl_mixing/revision.py
@@ -1,0 +1,213 @@
+"""Authoritative cross-platform revision creation service."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import uuid
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from .context import resolve_project, studio_root as resolve_studio_root
+from .errors import ContextError, UnsafeOperationError, ValidationError
+from .metadata import now_iso8601, validate_v11
+from .paths import assert_no_case_insensitive_child_collision, assert_no_symlink_components
+from .revision_source import RevisionSourcePlan, build_plan, copy_from_plan
+from .versions import application_root
+
+
+@dataclass(frozen=True)
+class RevisionCreateRequest:
+    project_root: Path
+    description: str | None = None
+    source: Path | None = None
+    change_directory: bool | None = None
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class RevisionCreateResult:
+    project_root: Path
+    revision_root: Path
+    number: int
+    description: str
+    previous_revision: int
+    manifest: dict[str, Any]
+    effective_cd: bool
+    source_plan: RevisionSourcePlan | None
+    created: bool
+
+
+def _load_manifest(project_root: Path) -> dict[str, Any]:
+    manifest_path = project_root / "00_Admin" / "project-manifest.json"
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise ContextError(f"Project manifest not found or unsafe: {manifest_path}")
+    try:
+        document = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Invalid project manifest: {manifest_path}") from exc
+    validate_v11(document.get("metadata"), "mixing-project", mutability="mutable")
+    return document
+
+
+def _validate_project_state(document: dict[str, Any]) -> int:
+    state = document.get("state")
+    revisions = document.get("revisions")
+    if not isinstance(state, dict) or not isinstance(revisions, list):
+        raise ValidationError("Project manifest has invalid revision state.")
+    current = state.get("current_revision")
+    if not isinstance(current, int) or isinstance(current, bool) or current < 1:
+        raise ValidationError("Project state.current_revision must be a positive integer.")
+    numbers: list[int] = []
+    revision_ids: set[str] = set()
+    for record in revisions:
+        if not isinstance(record, dict) or not isinstance(record.get("number"), int):
+            raise ValidationError("Project manifest contains an invalid revision record.")
+        number = record["number"]
+        revision_id = record.get("revision_id")
+        if number < 1 or not isinstance(revision_id, str) or not revision_id:
+            raise ValidationError("Project manifest contains an invalid revision record.")
+        if revision_id in revision_ids:
+            raise ValidationError("Project manifest contains duplicate revision IDs.")
+        revision_ids.add(revision_id)
+        numbers.append(number)
+    if numbers != list(range(1, current + 1)):
+        raise ValidationError("Project revision records do not match state.current_revision.")
+    for pointer_name in ("approved_revision", "delivered_revision"):
+        pointer = state.get(pointer_name)
+        if pointer is not None and (not isinstance(pointer, int) or pointer not in numbers):
+            raise ValidationError(f"Project state.{pointer_name} is invalid.")
+    return current
+
+
+def _validate_schema(document: dict[str, Any]) -> None:
+    schema_path = application_root() / "schemas" / "project-manifest.schema.json"
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContextError(f"Project schema not found or invalid: {schema_path}") from exc
+    errors = sorted(Draft202012Validator(schema).iter_errors(document), key=lambda error: list(error.path))
+    if errors:
+        raise ValidationError(f"Generated project manifest failed schema validation: {errors[0].message}")
+
+
+def _load_studio_cd(project_root: Path) -> bool:
+    studio_root = resolve_studio_root(project_root)
+    studio_path = studio_root / "Studio" / "studio.json"
+    try:
+        studio = json.loads(studio_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Invalid studio configuration: {studio_path}") from exc
+    cli = studio.get("cli") if isinstance(studio.get("cli"), dict) else {}
+    return cli.get("change_directory_after_create") is True
+
+
+def _render_notes(number: int, description: str) -> str:
+    template_path = application_root() / "templates" / "Revision_Notes.md"
+    try:
+        text = template_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ContextError(f"Required template not found: {template_path}") from exc
+    return text.replace("{{REVISION_NUMBER}}", str(number)).replace("{{REVISION_DESCRIPTION}}", description)
+
+
+def create_revision(request: RevisionCreateRequest) -> RevisionCreateResult:
+    project_root = resolve_project(request.project_root, Path.cwd())
+    studio_root = resolve_studio_root(project_root)
+    assert_no_symlink_components(studio_root, project_root)
+    manifest_path = project_root / "00_Admin" / "project-manifest.json"
+    revisions_root = project_root / "04_Revisions"
+    if revisions_root.is_symlink() or not revisions_root.is_dir():
+        raise ContextError(f"Revision root is missing or unsafe: {revisions_root}")
+    assert_no_symlink_components(project_root, revisions_root)
+
+    manifest = _load_manifest(project_root)
+    previous_revision = _validate_project_state(manifest)
+    number = previous_revision + 1
+    if request.description is None:
+        description = "Initial mix" if number == 1 else f"Revision {number}"
+    else:
+        description = request.description.strip()
+        if not description:
+            raise ValidationError("revision description must not be empty.")
+
+    revision_name = f"Revision_{number:02d}"
+    assert_no_case_insensitive_child_collision(revisions_root, revision_name)
+    revision_root = revisions_root / revision_name
+    if revision_root.exists() or revision_root.is_symlink():
+        raise UnsafeOperationError(f"Revision destination already exists: {revision_root}")
+
+    source_plan = build_plan(request.source) if request.source is not None else None
+    inherited_cd = _load_studio_cd(project_root)
+    effective_cd = request.change_directory if request.change_directory is not None else inherited_cd
+
+    timestamp = now_iso8601()
+    revision_id = str(uuid.uuid4())
+    existing_ids = {record.get("revision_id") for record in manifest.get("revisions", []) if isinstance(record, dict)}
+    while revision_id in existing_ids:
+        revision_id = str(uuid.uuid4())
+    updated = deepcopy(manifest)
+    record = {
+        "number": number,
+        "revision_id": revision_id,
+        "created_at": timestamp,
+        "description": description,
+        "approval": {"approved_at": None, "approved_by": None},
+    }
+    updated["revisions"].append(record)
+    updated["state"]["current_revision"] = number
+    updated["metadata"]["last_modified_at"] = timestamp
+    _validate_project_state(updated)
+    _validate_schema(updated)
+
+    if request.dry_run:
+        return RevisionCreateResult(
+            project_root, revision_root, number, description, previous_revision,
+            updated, effective_cd, source_plan, False,
+        )
+
+    stage = Path(tempfile.mkdtemp(prefix=f".{revision_name}.jl-stage-", dir=revisions_root))
+    manifest_fd, manifest_temp_name = tempfile.mkstemp(prefix=f".{manifest_path.name}.", dir=manifest_path.parent)
+    manifest_temp = Path(manifest_temp_name)
+    committed_directory = False
+    try:
+        os.close(manifest_fd)
+        if source_plan is not None:
+            copy_from_plan(source_plan, stage)
+        (stage / "Revision_Notes.md").write_text(
+            _render_notes(number, description), encoding="utf-8", newline="\n"
+        )
+        manifest_temp.write_text(
+            json.dumps(updated, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8", newline="\n",
+        )
+        if revision_root.exists() or revision_root.is_symlink():
+            raise UnsafeOperationError(f"Revision destination already exists: {revision_root}")
+        os.replace(stage, revision_root)
+        committed_directory = True
+        try:
+            os.replace(manifest_temp, manifest_path)
+        except Exception:
+            shutil.rmtree(revision_root, ignore_errors=True)
+            committed_directory = False
+            raise
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        if committed_directory and revision_root.exists():
+            shutil.rmtree(revision_root, ignore_errors=True)
+        raise
+    finally:
+        if manifest_temp.exists():
+            manifest_temp.unlink()
+
+    return RevisionCreateResult(
+        project_root, revision_root, number, description, previous_revision,
+        updated, effective_cd, source_plan, True,
+    )

--- a/src/jl_mixing/revision_source.py
+++ b/src/jl_mixing/revision_source.py
@@ -1,0 +1,96 @@
+"""Cross-platform revision-source planning and copy primitives."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import ContextError, UnsafeOperationError, ValidationError
+
+_RESERVED_NAME = "revision_notes.md"
+
+
+@dataclass(frozen=True)
+class RevisionSourcePlan:
+    source_type: str
+    source: Path
+    files: tuple[str, ...]
+
+
+def _classify(path: Path) -> str:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError as exc:
+        raise ContextError(f"Revision source not found: {path}") from exc
+    except OSError as exc:
+        raise ValidationError(f"Unable to inspect revision source {path}: {exc}") from exc
+    if stat.S_ISLNK(mode):
+        raise UnsafeOperationError(f"Symbolic links are not allowed in revision sources: {path}")
+    if stat.S_ISREG(mode):
+        return "file"
+    if stat.S_ISDIR(mode):
+        return "directory"
+    raise ValidationError(f"Unsupported revision source filesystem object: {path}")
+
+
+def _validate_name(name: str, path: Path) -> None:
+    if not name or name in {".", ".."}:
+        raise ValidationError(f"Unsafe revision source name: {path}")
+    if any(ord(character) < 32 or ord(character) == 127 for character in name):
+        raise ValidationError(f"Control characters are not allowed in revision source names: {path}")
+    if name.casefold() == _RESERVED_NAME:
+        raise ValidationError(f"Revision source may not replace Revision_Notes.md: {path}")
+
+
+def build_plan(source: Path) -> RevisionSourcePlan:
+    source = source.expanduser()
+    if not source.is_absolute():
+        source = Path.cwd() / source
+    source_type = _classify(source)
+    source = source.resolve(strict=True)
+    names: list[str] = []
+    seen: dict[str, str] = {_RESERVED_NAME: "Revision_Notes.md"}
+
+    def add_file(path: Path) -> None:
+        _validate_name(path.name, path)
+        key = path.name.casefold()
+        if key in seen:
+            raise ValidationError(
+                f"Case-insensitive revision destination collision: {seen[key]!r} and {path.name!r}"
+            )
+        seen[key] = path.name
+        names.append(path.name)
+
+    if source_type == "file":
+        add_file(source)
+    else:
+        try:
+            children = sorted(os.scandir(source), key=lambda item: (item.name.casefold(), item.name))
+        except OSError as exc:
+            raise ValidationError(f"Unable to read revision source directory {source}: {exc}") from exc
+        for child in children:
+            child_path = Path(child.path)
+            entry_type = _classify(child_path)
+            if entry_type == "directory":
+                raise ValidationError(f"Nested directories are not allowed in revision sources: {child_path}")
+            add_file(child_path)
+
+    names.sort(key=lambda value: (value.casefold(), value))
+    return RevisionSourcePlan(source_type, source, tuple(names))
+
+
+def copy_from_plan(plan: RevisionSourcePlan, destination: Path) -> None:
+    current = build_plan(plan.source)
+    if current.source_type != plan.source_type or current.files != plan.files:
+        raise ValidationError("Revision source changed after preflight; no revision was created.")
+    if destination.is_symlink() or not destination.is_dir():
+        raise UnsafeOperationError(f"Revision destination is missing or unsafe: {destination}")
+    if any(destination.iterdir()):
+        raise UnsafeOperationError(f"Revision destination must be empty before source copying: {destination}")
+
+    for name in current.files:
+        source_file = plan.source if plan.source_type == "file" else plan.source / name
+        shutil.copy2(source_file, destination / name, follow_symlinks=False)

--- a/tests/python/test_revision_service.py
+++ b/tests/python/test_revision_service.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.errors import UnsafeOperationError, ValidationError
+from jl_mixing.project import ProjectCreateRequest, create_project
+from jl_mixing.revision import RevisionCreateRequest, create_revision
+
+
+def write_studio(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "test-studio", "studio_name": "Test Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+        "cli": {"change_directory_after_create": True},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    return root
+
+
+def write_client(studio: Path) -> Path:
+    root = studio / "Clients" / "Client"
+    (root / "Projects").mkdir(parents=True)
+    client = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "client", "client_name": "Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+    }
+    (root / "client.json").write_text(json.dumps(client), encoding="utf-8")
+    return root
+
+
+def make_project(root: Path) -> Path:
+    studio = write_studio(root)
+    client = write_client(studio)
+    return create_project(ProjectCreateRequest(client, "Song", change_directory=False)).project_root
+
+
+class RevisionServiceTests(unittest.TestCase):
+    def test_dry_run_plans_revision_two_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = make_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            before = manifest_path.read_text(encoding="utf-8")
+            result = create_revision(RevisionCreateRequest(project, dry_run=True))
+            self.assertFalse(result.created)
+            self.assertEqual(result.previous_revision, 1)
+            self.assertEqual(result.number, 2)
+            self.assertEqual(result.description, "Revision 2")
+            self.assertTrue(result.effective_cd)
+            self.assertFalse(result.revision_root.exists())
+            self.assertEqual(manifest_path.read_text(encoding="utf-8"), before)
+
+    def test_create_revision_updates_manifest_and_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = make_project(Path(tmp))
+            result = create_revision(RevisionCreateRequest(project, description="Vocal up 1 dB", change_directory=False))
+            self.assertTrue(result.created)
+            self.assertTrue((result.revision_root / "Revision_Notes.md").is_file())
+            self.assertIn("Vocal up 1 dB", (result.revision_root / "Revision_Notes.md").read_text(encoding="utf-8"))
+            persisted = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(persisted["state"]["current_revision"], 2)
+            self.assertEqual(persisted["revisions"][-1]["number"], 2)
+            self.assertEqual(persisted["revisions"][-1]["description"], "Vocal up 1 dB")
+            self.assertFalse(result.effective_cd)
+
+    def test_approval_and_delivery_pointers_are_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = make_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["state"]["approved_revision"] = 1
+            manifest["state"]["delivered_revision"] = 1
+            manifest["revisions"][0]["approval"] = {"approved_at": "2030-01-02T12:00:00Z", "approved_by": "Client"}
+            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+            create_revision(RevisionCreateRequest(project))
+            updated = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(updated["state"]["approved_revision"], 1)
+            self.assertEqual(updated["state"]["delivered_revision"], 1)
+            self.assertEqual(updated["revisions"][0]["approval"]["approved_by"], "Client")
+
+    def test_source_files_are_copied_but_nested_directories_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = make_project(root / "studio")
+            source = root / "prints"
+            source.mkdir()
+            (source / "Mix.wav").write_bytes(b"mix")
+            (source / "Instrumental.wav").write_bytes(b"inst")
+            result = create_revision(RevisionCreateRequest(project, source=source))
+            self.assertEqual((result.revision_root / "Mix.wav").read_bytes(), b"mix")
+            self.assertEqual((result.revision_root / "Instrumental.wav").read_bytes(), b"inst")
+
+            nested = root / "nested"
+            (nested / "folder").mkdir(parents=True)
+            (nested / "folder" / "Mix.wav").write_bytes(b"mix")
+            with self.assertRaises(ValidationError):
+                create_revision(RevisionCreateRequest(project, source=nested))
+            self.assertFalse((project / "04_Revisions" / "Revision_03").exists())
+
+    def test_revision_notes_name_collision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = make_project(root / "studio")
+            source = root / "Revision_Notes.md"
+            source.write_text("not allowed", encoding="utf-8")
+            with self.assertRaises(ValidationError):
+                create_revision(RevisionCreateRequest(project, source=source))
+            self.assertFalse((project / "04_Revisions" / "Revision_02").exists())
+
+    def test_case_insensitive_destination_collision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = make_project(Path(tmp))
+            (project / "04_Revisions" / "revision_02").mkdir()
+            with self.assertRaises((ValidationError, UnsafeOperationError)):
+                create_revision(RevisionCreateRequest(project))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by porting the authoritative revision-creation workflow into the cross-platform Python runtime.

## Changes

- promote revision-source scan/copy logic into the Python package
- preserve no-symlink, no-nested-directory, reserved Revision_Notes.md, and case-insensitive collision rules
- add transactional `create_revision()` service
- preserve revision numbering/default descriptions and existing approval/delivery pointers
- stage the revision directory and updated manifest together with rollback if the manifest commit fails
- preserve studio automatic-directory-change inheritance and dry-run non-mutation
- validate the generated project manifest against v1.1 schema and revision-state invariants before mutation
- add native Windows/macOS/Linux service tests for dry-run, state updates, pointer preservation, source imports, reserved names, and case-insensitive collisions

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no installed launcher or API route changes in this slice

Part of #71.