### PR TITLE
Implement v1.5 Python revision.create API adapter

### DIFF
--- a/src/jl_mixing/api/revision_create.py
+++ b/src/jl_mixing/api/revision_create.py
@@ -1,0 +1,126 @@
+"""Automation API 1.0 adapter for revision.create."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..context import resolve_project, studio_root
+from ..errors import ArgumentError, ContextError, JLMixingError, UnsafeOperationError, ValidationError
+from ..revision import RevisionCreateRequest, create_revision
+from ..versions import api_version
+
+
+@dataclass(frozen=True)
+class RevisionApiRequest:
+    project: Path | None = None
+    description: str | None = None
+    source: Path | None = None
+    dry_run: bool = False
+
+
+def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "revision.create",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [{
+            "code": code,
+            "message": message,
+            "details": {"exit_code": exit_code},
+            "retryable": False,
+        }],
+    }
+
+
+def execute(request: RevisionApiRequest) -> tuple[dict[str, Any], int]:
+    try:
+        project_root = resolve_project(request.project, Path.cwd())
+        result = create_revision(RevisionCreateRequest(
+            project_root=project_root,
+            description=request.description,
+            source=request.source,
+            change_directory=False,
+            dry_run=request.dry_run,
+        ))
+        manifest_path = result.project_root / "00_Admin" / "project-manifest.json"
+        workspace = studio_root(result.project_root)
+        project_id = result.manifest.get("project_id", "")
+        data: dict[str, Any] = {
+            "project": {"id": project_id, "path": str(result.project_root)},
+            "manifest_path": str(manifest_path),
+            "revision": {
+                "number": result.number,
+                "path": str(result.revision_root),
+                "description": result.description,
+            },
+            "revision_notes_path": str(result.revision_root / "Revision_Notes.md"),
+            "workspace_path": str(workspace),
+        }
+        if request.dry_run:
+            data["would_create"] = [
+                str(result.revision_root),
+                str(result.revision_root / "Revision_Notes.md"),
+            ]
+            data["would_update"] = [str(manifest_path)]
+        return {
+            "api_version": api_version(),
+            "operation": "revision.create",
+            "status": "planned" if request.dry_run else "success",
+            "data": data,
+            "warnings": [],
+            "errors": [],
+        }, 0
+    except ContextError as exc:
+        message = str(exc)
+        code = "SOURCE_NOT_FOUND" if "revision source not found" in message.lower() else "WORKSPACE_CONTEXT_ERROR"
+        return _error_envelope(code, message, exc.exit_code), exc.exit_code
+    except ValidationError as exc:
+        message = str(exc)
+        code = "REVISION_ALREADY_EXISTS" if "collision" in message.lower() or "already exists" in message.lower() else "VALIDATION_FAILED"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except UnsafeOperationError as exc:
+        message = str(exc)
+        code = "REVISION_ALREADY_EXISTS" if "already exists" in message.lower() else "UNSAFE_OPERATION"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+
+
+def parse_args(args: list[str]) -> RevisionApiRequest:
+    project: Path | None = None
+    description: str | None = None
+    source: Path | None = None
+    dry_run = False
+    json_seen = 0
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg in {"--cd", "--no-cd"}:
+            raise ArgumentError("revision create JSON mode does not accept --cd or --no-cd.")
+        elif arg in {"--project", "--description", "--source"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project = Path(value)
+            elif arg == "--description":
+                description = value
+            else:
+                source = Path(value)
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+    if json_seen != 1:
+        raise ArgumentError("revision create requires exactly one --json option.")
+    return RevisionApiRequest(project=project, description=description, source=source, dry_run=dry_run)

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -15,6 +15,9 @@ from .api.intake_validate import parse_args as parse_intake_args
 from .api.project_create import _error_envelope as project_error_envelope
 from .api.project_create import execute as project_execute
 from .api.project_create import parse_args as parse_project_args
+from .api.revision_create import _error_envelope as revision_error_envelope
+from .api.revision_create import execute as revision_execute
+from .api.revision_create import parse_args as parse_revision_args
 from .errors import ArgumentError, ValidationError
 from .system_info import document as system_info_document
 
@@ -61,6 +64,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             _emit_json(project_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
             return exc.exit_code
         payload, status = project_execute(request)
+        _emit_json(payload)
+        return status
+
+    if len(args) >= 2 and args[0:2] == ["revision", "create"]:
+        try:
+            request = parse_revision_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(revision_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            return exc.exit_code
+        except ValidationError as exc:
+            _emit_json(revision_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
+            return exc.exit_code
+        payload, status = revision_execute(request)
         _emit_json(payload)
         return status
 

--- a/tests/python/test_revision_api.py
+++ b/tests/python/test_revision_api.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_workspace(root: Path) -> tuple[Path, Path, Path]:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "api-studio", "studio_name": "API Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "API Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+        "cli": {"change_directory_after_create": True},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "API Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "api-client", "client_name": "API Client",
+        "defaults": {
+            "artist": "API Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    project = create_project(ProjectCreateRequest(client, "API Song", change_directory=False)).project_root
+    return root, client, project
+
+
+def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=cwd, env=env, text=True, capture_output=True, check=False,
+    )
+
+
+class RevisionApiTests(unittest.TestCase):
+    def test_dry_run_from_project_context_is_structured_and_non_mutating(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, project = write_workspace(Path(tmp))
+            proc = run_cli(project, "revision", "create", "--json", "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "revision.create")
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["data"]["revision"]["number"], 2)
+            self.assertEqual(payload["data"]["revision"]["description"], "Revision 2")
+            self.assertEqual(len(payload["data"]["would_create"]), 2)
+            self.assertEqual(payload["data"]["would_update"], [str((project / "00_Admin" / "project-manifest.json").resolve())])
+            self.assertFalse((project / "04_Revisions" / "Revision_02").exists())
+
+    def test_success_with_explicit_project_and_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root, _, project = write_workspace(Path(tmp))
+            source = root / "mix.wav"
+            source.write_bytes(b"mix")
+            proc = run_cli(
+                root,
+                "revision", "create", "--project", str(project), "--description", "Client notes",
+                "--source", str(source), "--json",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "success")
+            self.assertEqual(payload["data"]["revision"]["number"], 2)
+            self.assertEqual(payload["data"]["revision"]["description"], "Client notes")
+            revision_path = Path(payload["data"]["revision"]["path"])
+            self.assertEqual(revision_path, (project / "04_Revisions" / "Revision_02").resolve())
+            self.assertEqual((revision_path / "mix.wav").read_bytes(), b"mix")
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["state"]["current_revision"], 2)
+
+    def test_missing_source_is_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root, _, project = write_workspace(Path(tmp))
+            proc = run_cli(project, "revision", "create", "--source", str(root / "missing.wav"), "--json")
+            self.assertEqual(proc.returncode, 4)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["errors"][0]["code"], "SOURCE_NOT_FOUND")
+
+    def test_existing_revision_destination_is_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, project = write_workspace(Path(tmp))
+            (project / "04_Revisions" / "Revision_02").mkdir()
+            proc = run_cli(project, "revision", "create", "--json")
+            self.assertIn(proc.returncode, {5, 6})
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["errors"][0]["code"], "REVISION_ALREADY_EXISTS")
+
+    def test_json_mode_rejects_shell_cd_and_requires_exactly_one_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, project = write_workspace(Path(tmp))
+            proc = run_cli(project, "revision", "create", "--json", "--cd")
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_REQUEST")
+            proc = run_cli(project, "revision", "create")
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_REQUEST")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by wiring Automation API 1.0 `revision.create` directly to the cross-platform Python revision service.

## Changes

- add Python `revision.create` request parser and API 1.0 response adapter
- route `jl_mixing.cli revision create ... --json` through the Python service
- preserve explicit project-path/current-context resolution
- preserve explicit rejection of `--cd` and `--no-cd` in JSON mode
- preserve planned/success/blocked/error envelopes, project/revision/workspace paths, and dry-run `would_create`/`would_update`
- preserve `REVISION_ALREADY_EXISTS` and `SOURCE_NOT_FOUND` classifications
- keep machine failures on stdout with empty stderr
- add native Windows/macOS/Linux command-level tests for dry-run, success/source copy, missing sources, duplicate revision destinations, and JSON argument rules

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash dispatcher remains unchanged until launcher cutover
- API adapter calls the Python revision service directly and does not parse human CLI output

Part of #71.