### PR TITLE
Port new-revision human CLI to v1.5 Python runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ jl-mixing-python = "jl_mixing.cli:main"
 validate-intake-python = "jl_mixing.validate_intake_cli:main"
 new-client-python = "jl_mixing.new_client_cli:main"
 new-mix-python = "jl_mixing.new_mix_cli:main"
+new-revision-python = "jl_mixing.new_revision_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jl_mixing/new_revision_cli.py
+++ b/src/jl_mixing/new_revision_cli.py
@@ -1,0 +1,165 @@
+"""Human-facing new-revision command backed by the cross-platform revision service."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from pathlib import Path
+
+from .context import resolve_project
+from .errors import ArgumentError, JLMixingError
+from .revision import RevisionCreateRequest, RevisionCreateResult, create_revision
+
+_USAGE = """Usage: new-revision [options]\n\nOptions:\n  --project PATH       Explicit project directory\n  --description TEXT   Revision description\n  --source PATH        Mix-print file or directory of immediate files to copy\n  --cd                 Enter the new revision directory after creation\n  --no-cd              Remain in the current directory after creation\n  --dry-run            Show the planned revision without creating it\n  -h, --help           Show this help\n"""
+
+
+def _parse(args: list[str]) -> tuple[RevisionCreateRequest | None, bool]:
+    if args in (["-h"], ["--help"]):
+        return None, True
+    project: Path | None = None
+    description: str | None = None
+    source: Path | None = None
+    cd_value: bool | None = None
+    cd_seen = False
+    no_cd_seen = False
+    dry_run = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--non-interactive":
+            raise ArgumentError(
+                "--non-interactive was removed in JL Mixing 1.1.\n"
+                "new-revision already uses supplied values and defaults without prompting."
+            )
+        if arg in {"-h", "--help"}:
+            return None, True
+        if arg == "--cd":
+            cd_seen = True
+            cd_value = True
+        elif arg == "--no-cd":
+            no_cd_seen = True
+            cd_value = False
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg in {"--project", "--description", "--source"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project = Path(value)
+            elif arg == "--description":
+                description = value
+            else:
+                source = Path(value)
+        else:
+            raise ArgumentError(f"Unknown option: {arg}")
+        index += 1
+
+    if cd_seen and no_cd_seen:
+        raise ArgumentError("--cd and --no-cd are mutually exclusive.")
+    if dry_run and (cd_seen or no_cd_seen):
+        raise ArgumentError("--cd and --no-cd cannot be combined with --dry-run.")
+
+    project_root = resolve_project(project, Path.cwd())
+    return RevisionCreateRequest(
+        project_root=project_root,
+        description=description,
+        source=source,
+        change_directory=cd_value,
+        dry_run=dry_run,
+    ), False
+
+
+def _shell_quote(path: Path) -> str:
+    return shlex.quote(str(path))
+
+
+def _write_cd_result(path: Path) -> bool:
+    result_file = os.environ.get("JL_MIXING_CD_RESULT_FILE")
+    if not result_file:
+        return False
+    target = Path(result_file)
+    if not target.is_absolute() or target.is_symlink() or not target.is_file():
+        raise ArgumentError(f"Shell-integration result file is missing or unsafe: {target}")
+    target.write_text(str(path) + "\n", encoding="utf-8", newline="\n")
+    return True
+
+
+def _pointer(value: object) -> str:
+    return "null" if value is None else str(value)
+
+
+def _print_summary(result: RevisionCreateResult, heading: str, *, planned: bool) -> None:
+    print(heading)
+    print()
+    print(f"Project:                    {result.manifest['project_name']}")
+    if planned:
+        print(f"Current revision:           {result.previous_revision}")
+        print(f"New revision:               {result.number}")
+    else:
+        print(f"Revision:                   {result.number}")
+    print(f"Description:                {result.description}")
+    print(f"Revision folder:            {result.revision_root}")
+    source_display = str(result.source_plan.source) if result.source_plan is not None else "<none>"
+    print(f"Source:                     {source_display}")
+    print(f"Automatic directory change: {'enabled' if result.effective_cd else 'disabled'}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    try:
+        request, help_only = _parse(args)
+        if help_only:
+            print(_USAGE, end="")
+            return 0
+        assert request is not None
+        result = create_revision(request)
+        if request.dry_run:
+            _print_summary(result, "Dry run — no changes made.", planned=True)
+            revision_name = result.revision_root.name
+            print("\nWould create:")
+            print(f"  {revision_name}/")
+            print(f"  {revision_name}/Revision_Notes.md")
+            if result.source_plan is not None:
+                if not result.source_plan.files:
+                    print("  <source directory contains no files>")
+                else:
+                    for name in result.source_plan.files:
+                        print(f"  {revision_name}/{name}")
+            print("\nWould update:")
+            print(f"  state.current_revision: {result.previous_revision} → {result.number}")
+            print(f"  revisions: append Revision {result.number}")
+            print("  metadata.last_modified_at")
+            print("\nWould preserve:")
+            print(f"  state.approved_revision: {_pointer(result.manifest['state']['approved_revision'])}")
+            print(f"  state.delivered_revision: {_pointer(result.manifest['state']['delivered_revision'])}")
+            print("\nAfter creation:")
+            print(f"  cd {_shell_quote(result.revision_root)}")
+            print("  approve-mix")
+            return 0
+
+        result_written = False
+        if result.effective_cd:
+            result_written = _write_cd_result(result.revision_root)
+
+        _print_summary(result, "Revision created successfully.", planned=False)
+        print("Project state:              In progress")
+        if result.effective_cd and not result_written:
+            print(
+                "\nAutomatic directory change could not be performed because JL Mixing shell\n"
+                "integration is not active."
+            )
+        print("\nNext:")
+        if not result.effective_cd or not result_written:
+            print(f"  cd {_shell_quote(result.revision_root)}")
+        print("  approve-mix")
+        return 0
+    except JLMixingError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jl_mixing/new_revision_cli.py
+++ b/src/jl_mixing/new_revision_cli.py
@@ -129,7 +129,7 @@ def main(argv: list[str] | None = None) -> int:
                     for name in result.source_plan.files:
                         print(f"  {revision_name}/{name}")
             print("\nWould update:")
-            print(f"  state.current_revision: {result.previous_revision} → {result.number}")
+            print(f"  state.current_revision: {result.previous_revision} -> {result.number}")
             print(f"  revisions: append Revision {result.number}")
             print("  metadata.last_modified_at")
             print("\nWould preserve:")

--- a/tests/python/test_new_revision_cli.py
+++ b/tests/python/test_new_revision_cli.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_project(root: Path, *, inherited_cd: bool = False) -> tuple[Path, Path]:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "human-studio", "studio_name": "Human Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+        "cli": {"change_directory_after_create": inherited_cd},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "Human Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "human-client", "client_name": "Human Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    project = create_project(ProjectCreateRequest(client, "Human Song", change_directory=False)).project_root
+    return root, project
+
+
+def run_cli(cwd: Path, *args: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.new_revision_cli", *args],
+        cwd=cwd, env=env, text=True, capture_output=True, check=False,
+    )
+
+
+class NewRevisionCliTests(unittest.TestCase):
+    def test_help_matches_human_command_surface(self) -> None:
+        proc = run_cli(ROOT, "--help")
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("Usage: new-revision", proc.stdout)
+        self.assertIn("--description TEXT", proc.stdout)
+        self.assertIn("--source PATH", proc.stdout)
+        self.assertIn("--cd", proc.stdout)
+
+    def test_dry_run_lists_state_and_source_plan_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, project = write_project(root / "studio")
+            source = root / "prints"
+            source.mkdir()
+            (source / "Mix.wav").write_bytes(b"mix")
+            proc = run_cli(project, "--description", "Client notes", "--source", str(source), "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Dry run — no changes made.", proc.stdout)
+            self.assertIn("Current revision:           1", proc.stdout)
+            self.assertIn("New revision:               2", proc.stdout)
+            self.assertIn("Description:                Client notes", proc.stdout)
+            self.assertIn("Revision_02/Mix.wav", proc.stdout)
+            self.assertIn("state.current_revision: 1 → 2", proc.stdout)
+            self.assertIn("state.approved_revision: null", proc.stdout)
+            self.assertIn("approve-mix", proc.stdout)
+            self.assertFalse((project / "04_Revisions" / "Revision_02").exists())
+
+    def test_create_from_explicit_project_and_no_cd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root, project = write_project(Path(tmp))
+            proc = run_cli(root, "--project", str(project), "--description", "More vocal", "--no-cd")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Revision created successfully.", proc.stdout)
+            self.assertIn("Revision:                   2", proc.stdout)
+            self.assertIn("Automatic directory change: disabled", proc.stdout)
+            self.assertIn("Project state:              In progress", proc.stdout)
+            self.assertTrue((project / "04_Revisions" / "Revision_02" / "Revision_Notes.md").is_file())
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["state"]["current_revision"], 2)
+            self.assertEqual(manifest["revisions"][-1]["description"], "More vocal")
+
+    def test_explicit_cd_writes_shell_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, project = write_project(root / "studio")
+            result_file = root / "cd-result.txt"
+            result_file.write_text("", encoding="utf-8")
+            proc = run_cli(project, "--cd", extra_env={"JL_MIXING_CD_RESULT_FILE": str(result_file.resolve())})
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            expected = (project / "04_Revisions" / "Revision_02").resolve()
+            self.assertEqual(result_file.read_text(encoding="utf-8").strip(), str(expected))
+            next_section = proc.stdout.split("Next:\n", 1)[1]
+            self.assertNotIn("  cd ", next_section)
+            self.assertIn("  approve-mix", next_section)
+
+    def test_inherited_cd_writes_shell_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, project = write_project(root / "studio", inherited_cd=True)
+            result_file = root / "cd-result.txt"
+            result_file.write_text("", encoding="utf-8")
+            proc = run_cli(project, extra_env={"JL_MIXING_CD_RESULT_FILE": str(result_file.resolve())})
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Automatic directory change: enabled", proc.stdout)
+            self.assertEqual(
+                result_file.read_text(encoding="utf-8").strip(),
+                str((project / "04_Revisions" / "Revision_02").resolve()),
+            )
+
+    def test_cd_conflicts_and_removed_option_are_argument_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, project = write_project(Path(tmp))
+            for args in (("--cd", "--no-cd"), ("--cd", "--dry-run")):
+                proc = run_cli(project, *args)
+                self.assertEqual(proc.returncode, 2)
+                self.assertTrue(proc.stderr.startswith("Error:"))
+            proc = run_cli(project, "--non-interactive")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("removed in JL Mixing 1.1", proc.stderr)
+            self.assertIn("without prompting", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_new_revision_cli.py
+++ b/tests/python/test_new_revision_cli.py
@@ -88,7 +88,7 @@ class NewRevisionCliTests(unittest.TestCase):
             self.assertIn("New revision:               2", proc.stdout)
             self.assertIn("Description:                Client notes", proc.stdout)
             self.assertIn("Revision_02/Mix.wav", proc.stdout)
-            self.assertIn("state.current_revision: 1 → 2", proc.stdout)
+            self.assertIn("state.current_revision: 1 -> 2", proc.stdout)
             self.assertIn("state.approved_revision: null", proc.stdout)
             self.assertIn("approve-mix", proc.stdout)
             self.assertFalse((project / "04_Revisions" / "Revision_02").exists())


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by implementing the human `new-revision` interface on the same cross-platform Python revision service already used by Automation API 1.0 `revision.create`.

## Changes

- add Python `new-revision` human command implementation
- preserve project-path/current-context resolution, revision descriptions, source imports, dry-run behavior, and human summary output
- preserve `--cd` / `--no-cd` conflicts and dry-run restrictions
- preserve inherited automatic-directory-change preference
- expose parent-shell directory handoff through `JL_MIXING_CD_RESULT_FILE`
- preserve dry-run revision/state/source plan output and `approve-mix` Next guidance
- preserve removed `--non-interactive` guidance
- expose transitional `new-revision-python` entry point without changing the installed v1.4 launcher yet
- add native Windows/macOS/Linux command-level tests for help, dry-run, creation, source plans, explicit/inherited shell handoff, conflicts, and removed options

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash `new-revision` remains authoritative until launcher cutover
- parent-shell directory changes remain thin shell-integration glue around the shared Python service

Part of #71.