### PR TITLE
Port revision.approve service to v1.5 Python runtime

### DIFF
--- a/src/jl_mixing/approval.py
+++ b/src/jl_mixing/approval.py
@@ -1,0 +1,131 @@
+"""Authoritative cross-platform revision approval service."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .context import resolve_project, revision_root_for_number
+from .errors import ValidationError
+from .metadata import now_iso8601, write_json_document
+from .revision import _load_manifest, _validate_project_state, _validate_schema
+
+
+@dataclass(frozen=True)
+class RevisionApproveRequest:
+    project_root: Path
+    revision: int | None = None
+    approved_by: str = "Client"
+    approved_at: str | None = None
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class RevisionApproveResult:
+    project_root: Path
+    revision_root: Path
+    number: int
+    approved_by: str
+    approved_at: str | None
+    previous_approved_revision: int | None
+    current_revision: int
+    delivered_revision: int | None
+    manifest: dict[str, Any]
+    updated: bool
+
+
+def _parse_timestamp(value: str, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(f"Invalid {label}: {value}") from exc
+    if parsed.utcoffset() is None:
+        raise ValidationError(f"Invalid {label}: timestamp must include a UTC offset or Z")
+    return parsed
+
+
+def _find_revision(document: dict[str, Any], number: int) -> dict[str, Any]:
+    matches = [record for record in document.get("revisions", []) if isinstance(record, dict) and record.get("number") == number]
+    if len(matches) != 1:
+        raise ValidationError(f"Revision {number} does not exist.")
+    return matches[0]
+
+
+def derive_project_stage(document: dict[str, Any]) -> str:
+    state = document["state"]
+    current = state["current_revision"]
+    approved = state.get("approved_revision")
+    delivered = state.get("delivered_revision")
+    if current == 0:
+        return "Setup"
+    if current != approved:
+        return "In progress"
+    if delivered != current:
+        return "Approved"
+    return "Delivered"
+
+
+def approve_revision(request: RevisionApproveRequest) -> RevisionApproveResult:
+    project_root = resolve_project(request.project_root, Path.cwd())
+    manifest = _load_manifest(project_root)
+    current = _validate_project_state(manifest)
+    if current == 0:
+        raise ValidationError("No revision exists to approve.")
+
+    number = current if request.revision is None else request.revision
+    if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+        raise ValidationError(f"Revision number must be a positive integer: {number}")
+    revision = _find_revision(manifest, number)
+    revision_root = revision_root_for_number(project_root, number)
+
+    approved_by = request.approved_by.strip()
+    if not approved_by:
+        raise ValidationError("approver must not be empty.")
+
+    state = manifest["state"]
+    previous_approved = state.get("approved_revision")
+    delivered = state.get("delivered_revision")
+    if previous_approved == number:
+        raise ValidationError(f"Revision {number} is already the approved revision.")
+
+    created_at = revision.get("created_at")
+    if not isinstance(created_at, str):
+        raise ValidationError(f"Revision {number} has an invalid creation timestamp.")
+    created = _parse_timestamp(created_at, "revision creation timestamp")
+
+    approved_at = request.approved_at.strip() if request.approved_at is not None else None
+    if approved_at == "":
+        raise ValidationError("approval timestamp must not be empty.")
+    if approved_at is not None:
+        approved = _parse_timestamp(approved_at, "approval timestamp")
+        if approved < created:
+            raise ValidationError(f"Invalid approval timestamp: {approved_at}; timestamp predates revision creation")
+
+    updated = deepcopy(manifest)
+    effective_timestamp = approved_at or now_iso8601()
+    approved = _parse_timestamp(effective_timestamp, "approval timestamp")
+    if approved < created:
+        raise ValidationError(f"Invalid approval timestamp: {effective_timestamp}; timestamp predates revision creation")
+
+    target = _find_revision(updated, number)
+    target["approval"] = {"approved_at": effective_timestamp, "approved_by": approved_by}
+    updated["state"]["approved_revision"] = number
+    updated["metadata"]["last_modified_at"] = effective_timestamp
+    _validate_project_state(updated)
+    _validate_schema(updated)
+
+    if request.dry_run:
+        return RevisionApproveResult(
+            project_root, revision_root, number, approved_by, approved_at,
+            previous_approved, current, delivered, updated, False,
+        )
+
+    write_json_document(project_root / "00_Admin" / "project-manifest.json", updated)
+    return RevisionApproveResult(
+        project_root, revision_root, number, approved_by, effective_timestamp,
+        previous_approved, current, delivered, updated, True,
+    )

--- a/tests/python/test_approval_service.py
+++ b/tests/python/test_approval_service.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.approval import RevisionApproveRequest, approve_revision, derive_project_stage
+from jl_mixing.errors import ValidationError
+from jl_mixing.project import ProjectCreateRequest, create_project
+from jl_mixing.revision import RevisionCreateRequest, create_revision
+
+
+def write_project(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "approval-studio", "studio_name": "Approval Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "Approval Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "approval-client", "client_name": "Approval Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    return create_project(ProjectCreateRequest(client, "Approval Song", change_directory=False)).project_root
+
+
+class ApprovalServiceTests(unittest.TestCase):
+    def test_approve_current_revision_updates_only_approval_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            before = json.loads(manifest_path.read_text(encoding="utf-8"))
+            created = before["revisions"][0]["created_at"]
+            result = approve_revision(RevisionApproveRequest(
+                project, approved_by="Producer", approved_at=created,
+            ))
+            self.assertTrue(result.updated)
+            self.assertEqual(result.number, 1)
+            after = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(after["state"], {"current_revision": 1, "approved_revision": 1, "delivered_revision": None})
+            self.assertEqual(after["revisions"][0]["approval"], {"approved_at": created, "approved_by": "Producer"})
+            self.assertEqual(derive_project_stage(after), "Approved")
+            self.assertEqual((project / "04_Revisions" / "Revision_01" / "Revision_Notes.md").read_text(encoding="utf-8"),
+                             (project / "04_Revisions" / "Revision_01" / "Revision_Notes.md").read_text(encoding="utf-8"))
+
+    def test_approve_older_revision_preserves_current_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            create_revision(RevisionCreateRequest(project, description="Second pass"))
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            timestamp = manifest["revisions"][0]["created_at"]
+            result = approve_revision(RevisionApproveRequest(project, revision=1, approved_at=timestamp))
+            self.assertEqual(result.current_revision, 2)
+            persisted = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(persisted["state"]["current_revision"], 2)
+            self.assertEqual(persisted["state"]["approved_revision"], 1)
+            self.assertEqual(derive_project_stage(persisted), "In progress")
+
+    def test_dry_run_does_not_mutate_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            before = manifest_path.read_bytes()
+            result = approve_revision(RevisionApproveRequest(project, approved_by="Client", dry_run=True))
+            self.assertFalse(result.updated)
+            self.assertIsNone(result.approved_at)
+            self.assertEqual(before, manifest_path.read_bytes())
+            self.assertEqual(result.manifest["state"]["approved_revision"], 1)
+
+    def test_already_approved_revision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            approve_revision(RevisionApproveRequest(project))
+            with self.assertRaisesRegex(ValidationError, "already the approved revision"):
+                approve_revision(RevisionApproveRequest(project))
+
+    def test_invalid_revision_and_timestamp_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            with self.assertRaisesRegex(ValidationError, "does not exist"):
+                approve_revision(RevisionApproveRequest(project, revision=9))
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            created = manifest["revisions"][0]["created_at"]
+            date = created[:4]
+            old = f"{int(date)-1}" + created[4:]
+            with self.assertRaisesRegex(ValidationError, "predates"):
+                approve_revision(RevisionApproveRequest(project, approved_at=old))
+            with self.assertRaisesRegex(ValidationError, "UTC offset"):
+                approve_revision(RevisionApproveRequest(project, approved_at="2030-01-01T12:00:00"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by porting revision approval into the cross-platform Python runtime.

## Changes

- add authoritative Python `approve_revision()` service
- preserve default-to-current revision behavior
- preserve explicit older-revision approval while leaving current/delivered pointers unchanged
- preserve approver trimming/defaults and timezone-qualified ISO-8601 validation
- reject approval timestamps earlier than revision creation
- preserve already-approved and missing-revision validation behavior
- update only the project manifest via atomic file replacement
- preserve v1.1 schema and project-stage derivation semantics
- preserve dry-run non-mutation
- add native Windows/macOS/Linux service tests for current/older revision approval, dry-run, duplicate approval, missing revisions, and invalid timestamps

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no installed launcher or API route changes in this slice

Part of #71.