### PR TITLE
Implement v1.5 Python revision.approve API adapter

### DIFF
--- a/src/jl_mixing/api/revision_approve.py
+++ b/src/jl_mixing/api/revision_approve.py
@@ -1,0 +1,143 @@
+"""Automation API 1.0 adapter for revision.approve."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..approval import RevisionApproveRequest, approve_revision
+from ..context import studio_root
+from ..errors import ArgumentError, ContextError, JLMixingError, ValidationError
+from ..versions import api_version
+
+
+@dataclass(frozen=True)
+class RevisionApproveApiRequest:
+    project: Path
+    revision: int | None = None
+    approved_by: str = "Client"
+    approved_at: str | None = None
+    dry_run: bool = False
+
+
+def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "revision.approve",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [{
+            "code": code,
+            "message": message,
+            "details": {"exit_code": exit_code},
+            "retryable": False,
+        }],
+    }
+
+
+def execute(request: RevisionApproveApiRequest) -> tuple[dict[str, Any], int]:
+    try:
+        result = approve_revision(RevisionApproveRequest(
+            project_root=request.project,
+            revision=request.revision,
+            approved_by=request.approved_by,
+            approved_at=request.approved_at,
+            dry_run=request.dry_run,
+        ))
+        manifest_path = result.project_root / "00_Admin" / "project-manifest.json"
+        workspace = studio_root(result.project_root)
+        data: dict[str, Any] = {
+            "project": {
+                "id": result.manifest.get("project_id", ""),
+                "path": str(result.project_root),
+            },
+            "manifest_path": str(manifest_path),
+            "workspace_path": str(workspace),
+            "revision": {
+                "number": result.number,
+                "path": str(result.revision_root),
+            },
+            "approved_by": result.approved_by,
+            "approved_at": None if request.dry_run else result.approved_at,
+        }
+        if request.dry_run:
+            data["would_update"] = [str(manifest_path)]
+        return {
+            "api_version": api_version(),
+            "operation": "revision.approve",
+            "status": "planned" if request.dry_run else "success",
+            "data": data,
+            "warnings": [],
+            "errors": [],
+        }, 0
+    except ContextError as exc:
+        return _error_envelope("PROJECT_NOT_FOUND", str(exc), exc.exit_code), exc.exit_code
+    except ValidationError as exc:
+        message = str(exc)
+        lowered = message.lower()
+        if "already the approved revision" in lowered:
+            code = "REVISION_ALREADY_APPROVED"
+        elif "does not exist" in lowered or "no revision exists" in lowered:
+            code = "REVISION_NOT_FOUND"
+        elif "approval timestamp" in lowered or "timestamp predates" in lowered or "utc offset" in lowered:
+            code = "INVALID_APPROVAL_TIMESTAMP"
+        else:
+            code = "VALIDATION_FAILED"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+
+
+def parse_args(args: list[str]) -> RevisionApproveApiRequest:
+    project: Path | None = None
+    revision: int | None = None
+    approved_by = "Client"
+    approved_at: str | None = None
+    dry_run = False
+    json_seen = 0
+    project_seen = 0
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg in {"--project", "--revision", "--approved-by", "--date"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project_seen += 1
+                project = Path(value)
+            elif arg == "--revision":
+                try:
+                    revision = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Revision number must be a positive integer: {value}") from exc
+            elif arg == "--approved-by":
+                approved_by = value
+            else:
+                approved_at = value
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg in {"--notes", "--non-interactive"}:
+            raise ArgumentError(f"Unknown option: {arg}")
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+
+    if json_seen != 1:
+        raise ArgumentError("revision approve requires exactly one --json option.")
+    if project_seen != 1 or project is None or str(project) == "":
+        raise ArgumentError("revision approve JSON mode requires exactly one --project PATH option.")
+    return RevisionApproveApiRequest(
+        project=project,
+        revision=revision,
+        approved_by=approved_by,
+        approved_at=approved_at,
+        dry_run=dry_run,
+    )

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -15,6 +15,9 @@ from .api.intake_validate import parse_args as parse_intake_args
 from .api.project_create import _error_envelope as project_error_envelope
 from .api.project_create import execute as project_execute
 from .api.project_create import parse_args as parse_project_args
+from .api.revision_approve import _error_envelope as approval_error_envelope
+from .api.revision_approve import execute as approval_execute
+from .api.revision_approve import parse_args as parse_approval_args
 from .api.revision_create import _error_envelope as revision_error_envelope
 from .api.revision_create import execute as revision_execute
 from .api.revision_create import parse_args as parse_revision_args
@@ -77,6 +80,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             _emit_json(revision_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
             return exc.exit_code
         payload, status = revision_execute(request)
+        _emit_json(payload)
+        return status
+
+    if len(args) >= 2 and args[0:2] == ["revision", "approve"]:
+        try:
+            request = parse_approval_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(approval_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            return exc.exit_code
+        except ValidationError as exc:
+            _emit_json(approval_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
+            return exc.exit_code
+        payload, status = approval_execute(request)
         _emit_json(payload)
         return status
 

--- a/tests/python/test_approval_api.py
+++ b/tests/python/test_approval_api.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_project(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "approval-api-studio", "studio_name": "Approval API Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "Approval API Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "approval-api-client", "client_name": "Approval API Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    return create_project(ProjectCreateRequest(client, "Approval API Song", change_directory=False)).project_root
+
+
+def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=cwd, env=env, text=True, capture_output=True, check=False,
+    )
+
+
+class ApprovalApiTests(unittest.TestCase):
+    def test_dry_run_is_structured_non_mutating_and_has_null_approved_at(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            before = manifest_path.read_bytes()
+            created = json.loads(before)["revisions"][0]["created_at"]
+            proc = run_cli(
+                ROOT, "revision", "approve", "--project", str(project), "--json",
+                "--approved-by", "Producer", "--date", created, "--dry-run",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "revision.approve")
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["data"]["revision"]["number"], 1)
+            self.assertEqual(payload["data"]["approved_by"], "Producer")
+            self.assertIsNone(payload["data"]["approved_at"])
+            self.assertEqual(payload["data"]["would_update"], [str(manifest_path.resolve())])
+            self.assertEqual(before, manifest_path.read_bytes())
+
+    def test_success_updates_manifest_and_reports_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            created = json.loads(manifest_path.read_text(encoding="utf-8"))["revisions"][0]["created_at"]
+            proc = run_cli(
+                ROOT, "revision", "approve", "--project", str(project), "--revision", "1",
+                "--approved-by", "Client", "--date", created, "--json",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "success")
+            self.assertEqual(payload["data"]["project"]["id"], "approval-api-song")
+            self.assertEqual(payload["data"]["approved_at"], created)
+            self.assertEqual(Path(payload["data"]["revision"]["path"]), (project / "04_Revisions" / "Revision_01").resolve())
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["state"]["approved_revision"], 1)
+
+    def test_already_approved_revision_is_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            first = run_cli(ROOT, "revision", "approve", "--project", str(project), "--json")
+            self.assertEqual(first.returncode, 0, first.stderr)
+            second = run_cli(ROOT, "revision", "approve", "--project", str(project), "--json")
+            self.assertEqual(second.returncode, 5)
+            self.assertEqual(second.stderr, "")
+            self.assertEqual(json.loads(second.stdout)["errors"][0]["code"], "REVISION_ALREADY_APPROVED")
+
+    def test_missing_revision_and_invalid_timestamp_are_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            proc = run_cli(ROOT, "revision", "approve", "--project", str(project), "--revision", "9", "--json")
+            self.assertEqual(proc.returncode, 5)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "REVISION_NOT_FOUND")
+            proc = run_cli(
+                ROOT, "revision", "approve", "--project", str(project),
+                "--date", "2000-01-01T00:00:00Z", "--json",
+            )
+            self.assertEqual(proc.returncode, 5)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_APPROVAL_TIMESTAMP")
+
+    def test_json_mode_requires_exactly_one_project_and_json_option(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            cases = [
+                ("revision", "approve", "--json"),
+                ("revision", "approve", "--project", str(project)),
+                ("revision", "approve", "--project", str(project), "--json", "--json"),
+                ("revision", "approve", "--project", str(project), "--project", str(project), "--json"),
+            ]
+            for args in cases:
+                proc = run_cli(ROOT, *args)
+                self.assertEqual(proc.returncode, 2)
+                self.assertEqual(proc.stderr, "")
+                self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_REQUEST")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by wiring Automation API 1.0 `revision.approve` directly to the cross-platform Python approval service.

## Changes

- add Python `revision.approve` request parser and API 1.0 response adapter
- route `jl_mixing.cli revision approve ... --json` through the Python service
- preserve JSON mode requirement for exactly one `--project PATH`
- preserve default/current and explicit revision approval behavior
- preserve planned/success/blocked/error envelopes and canonical project/revision/workspace paths
- preserve dry-run `approved_at: null` and `would_update` behavior
- preserve `REVISION_ALREADY_APPROVED`, `REVISION_NOT_FOUND`, `INVALID_APPROVAL_TIMESTAMP`, and `PROJECT_NOT_FOUND` classifications
- keep machine failures on stdout with empty stderr
- add native Windows/macOS/Linux command-level tests for dry-run, success, duplicate approval, missing revisions, invalid timestamps, and JSON argument rules

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash dispatcher remains unchanged until launcher cutover
- API adapter calls the Python approval service directly and does not parse human CLI output

Part of #71.