### PR TITLE
Port approve-mix human CLI to v1.5 Python runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ validate-intake-python = "jl_mixing.validate_intake_cli:main"
 new-client-python = "jl_mixing.new_client_cli:main"
 new-mix-python = "jl_mixing.new_mix_cli:main"
 new-revision-python = "jl_mixing.new_revision_cli:main"
+approve-mix-python = "jl_mixing.approve_mix_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jl_mixing/approve_mix_cli.py
+++ b/src/jl_mixing/approve_mix_cli.py
@@ -1,0 +1,156 @@
+"""Human-facing approve-mix command backed by the cross-platform approval service."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from .approval import RevisionApproveRequest, approve_revision, derive_project_stage
+from .context import resolve_project
+from .errors import ArgumentError, JLMixingError, ValidationError
+
+_USAGE = """Usage: approve-mix [options]\n\nOptions:\n  --project PATH       Explicit project directory\n  --revision NUMBER    Revision to approve (default: current revision)\n  --approved-by NAME   Approver identity (default: Client)\n  --date TIMESTAMP     ISO-8601 approval timestamp (default: current time)\n  --dry-run            Show the approval change without modifying the project\n  -h, --help           Show this help\n"""
+
+
+def _parse(args: list[str]) -> tuple[RevisionApproveRequest | None, bool]:
+    if args in (["-h"], ["--help"]):
+        return None, True
+    project: Path | None = None
+    revision: int | None = None
+    approved_by = "Client"
+    approved_at: str | None = None
+    dry_run = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--notes":
+            raise ArgumentError(
+                "--notes was removed in JL Mixing 1.1.\n"
+                "Revision_Notes.md is user-managed and is not changed by approve-mix."
+            )
+        if arg == "--non-interactive":
+            raise ArgumentError(
+                "--non-interactive was removed in JL Mixing 1.1.\n"
+                "approve-mix already uses supplied values and defaults without prompting."
+            )
+        if arg in {"-h", "--help"}:
+            return None, True
+        if arg == "--dry-run":
+            dry_run = True
+        elif arg in {"--project", "--revision", "--approved-by", "--date"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project = Path(value)
+            elif arg == "--revision":
+                try:
+                    revision = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Revision number must be a positive integer: {value}") from exc
+            elif arg == "--approved-by":
+                approved_by = value
+            else:
+                approved_at = value
+        else:
+            raise ArgumentError(f"Unknown option: {arg}")
+        index += 1
+
+    project_root = resolve_project(project, Path.cwd())
+    return RevisionApproveRequest(
+        project_root=project_root,
+        revision=revision,
+        approved_by=approved_by,
+        approved_at=approved_at,
+        dry_run=dry_run,
+    ), False
+
+
+def _load_before(project_root: Path) -> dict[str, object]:
+    path = project_root / "00_Admin" / "project-manifest.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    try:
+        request, help_only = _parse(args)
+        if help_only:
+            print(_USAGE, end="")
+            return 0
+        assert request is not None
+        before = _load_before(request.project_root)
+        state = before["state"]
+        current = state["current_revision"]
+        selected = current if request.revision is None else request.revision
+        prior_record = next(
+            (record for record in before.get("revisions", []) if record.get("number") == selected),
+            None,
+        )
+        prior_approved_at = None
+        if isinstance(prior_record, dict) and isinstance(prior_record.get("approval"), dict):
+            prior_approved_at = prior_record["approval"].get("approved_at")
+
+        try:
+            result = approve_revision(request)
+        except ValidationError as exc:
+            if "already the approved revision" in str(exc):
+                print(f"Error: {exc}", file=sys.stderr)
+                print("No changes made.\n\nNext:\n  create-delivery")
+                return exc.exit_code
+            raise
+
+        if request.dry_run:
+            print("Dry run — no changes made.\n")
+            print(f"Project:                     {result.manifest['project_name']}")
+            print(f"Current revision:            {result.current_revision}")
+            print(f"Selected revision:           {result.number}")
+            current_approved = "<none>" if result.previous_approved_revision is None else str(result.previous_approved_revision)
+            print(f"Current approved revision:   {current_approved}")
+            print(f"Approver:                    {result.approved_by}")
+            if request.approved_at is not None:
+                print(f"Approval timestamp:          {request.approved_at.strip()}")
+            else:
+                print("Approval timestamp:          current time at execution")
+            print("\nWould update:")
+            prior_pointer = "null" if result.previous_approved_revision is None else str(result.previous_approved_revision)
+            print(f"  state.approved_revision: {prior_pointer} -> {result.number}")
+            print(f"  Revision {result.number} approval metadata")
+            print("  metadata.last_modified_at")
+            if prior_approved_at is not None:
+                print(
+                    f"\nRevision {result.number} was approved previously; "
+                    "its prior approval metadata would be replaced."
+                )
+            print("\nWould not change:")
+            print(f"  state.current_revision: {result.current_revision}")
+            delivered = "null" if result.delivered_revision is None else str(result.delivered_revision)
+            print(f"  state.delivered_revision: {delivered}")
+            print("  Revision files")
+            print("  Final delivery package")
+            return 0
+
+        print("Revision approved successfully.\n")
+        print(f"Project:                     {result.manifest['project_name']}")
+        print(f"Approved revision:           {result.number}")
+        if result.number != result.current_revision:
+            print(f"Current revision:            {result.current_revision}")
+        print(f"Approved by:                 {result.approved_by}")
+        print(f"Approved at:                 {result.approved_at}")
+        print(f"Project state:               {derive_project_stage(result.manifest)}")
+        if result.number != result.current_revision:
+            print("\nThe approved revision is older than the current working revision.")
+        if result.delivered_revision is not None and result.delivered_revision != result.number:
+            print(f"\nCurrent final delivery represents Revision {result.delivered_revision}.")
+            print("Running create-delivery will require explicit replacement authorization.")
+        print("\nNext:\n  create-delivery")
+        return 0
+    except JLMixingError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_approve_mix_cli.py
+++ b/tests/python/test_approve_mix_cli.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.project import ProjectCreateRequest, create_project
+from jl_mixing.revision import RevisionCreateRequest, create_revision
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_project(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "approve-human-studio", "studio_name": "Approve Human Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "Approve Human Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "approve-human-client", "client_name": "Approve Human Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    return create_project(ProjectCreateRequest(client, "Approve Human Song", change_directory=False)).project_root
+
+
+def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.approve_mix_cli", *args],
+        cwd=cwd, env=env, text=True, capture_output=True, check=False,
+    )
+
+
+class ApproveMixCliTests(unittest.TestCase):
+    def test_help_matches_human_command_surface(self) -> None:
+        proc = run_cli(ROOT, "--help")
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("Usage: approve-mix", proc.stdout)
+        self.assertIn("--approved-by NAME", proc.stdout)
+        self.assertIn("--date TIMESTAMP", proc.stdout)
+
+    def test_dry_run_reports_planned_state_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            before = manifest_path.read_bytes()
+            created = json.loads(before)["revisions"][0]["created_at"]
+            proc = run_cli(project, "--approved-by", "Producer", "--date", created, "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Dry run — no changes made.", proc.stdout)
+            self.assertIn("Selected revision:           1", proc.stdout)
+            self.assertIn("Current approved revision:   <none>", proc.stdout)
+            self.assertIn("Approver:                    Producer", proc.stdout)
+            self.assertIn(f"Approval timestamp:          {created}", proc.stdout)
+            self.assertIn("state.approved_revision: null -> 1", proc.stdout)
+            self.assertIn("state.delivered_revision: null", proc.stdout)
+            self.assertEqual(before, manifest_path.read_bytes())
+
+    def test_success_defaults_to_current_revision_and_reports_approved_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            proc = run_cli(project, "--approved-by", "Client")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Revision approved successfully.", proc.stdout)
+            self.assertIn("Approved revision:           1", proc.stdout)
+            self.assertIn("Approved by:                 Client", proc.stdout)
+            self.assertIn("Project state:               Approved", proc.stdout)
+            self.assertIn("Next:\n  create-delivery", proc.stdout)
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["state"]["approved_revision"], 1)
+
+    def test_approving_older_revision_warns_and_preserves_current(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            create_revision(RevisionCreateRequest(project, description="Second pass"))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            created = manifest["revisions"][0]["created_at"]
+            proc = run_cli(project, "--revision", "1", "--date", created)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Approved revision:           1", proc.stdout)
+            self.assertIn("Current revision:            2", proc.stdout)
+            self.assertIn("Project state:               In progress", proc.stdout)
+            self.assertIn("approved revision is older than the current working revision", proc.stdout)
+            persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["state"]["current_revision"], 2)
+            self.assertEqual(persisted["state"]["approved_revision"], 1)
+
+    def test_already_approved_revision_keeps_guidance_and_exit_five(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            first = run_cli(project)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            second = run_cli(project)
+            self.assertEqual(second.returncode, 5)
+            self.assertIn("already the approved revision", second.stderr)
+            self.assertIn("No changes made.", second.stdout)
+            self.assertIn("Next:\n  create-delivery", second.stdout)
+
+    def test_removed_options_and_invalid_timestamp_keep_exit_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            proc = run_cli(project, "--notes", "legacy")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("--notes was removed", proc.stderr)
+            self.assertIn("Revision_Notes.md is user-managed", proc.stderr)
+            proc = run_cli(project, "--non-interactive")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("without prompting", proc.stderr)
+            proc = run_cli(project, "--date", "2000-01-01T00:00:00Z")
+            self.assertEqual(proc.returncode, 5)
+            self.assertIn("predates revision creation", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by implementing the human `approve-mix` interface on the same cross-platform Python approval service already used by Automation API 1.0 `revision.approve`.

## Changes

- add Python `approve-mix` human command implementation
- preserve current-revision default, explicit revision selection, approver/date options, dry-run reporting, and project-stage output
- preserve removed `--notes` / `--non-interactive` guidance
- preserve exit-5 already-approved behavior with `No changes made` and `create-delivery` guidance
- preserve older-revision and existing-delivery warnings
- use ASCII `->` in the state transition line for Windows console portability
- expose transitional `approve-mix-python` entry point without changing the installed v1.4 launcher yet
- add native Windows/macOS/Linux command-level tests for help, dry-run, success, older-revision approval, already-approved behavior, removed options, and timestamp validation

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash `approve-mix` remains authoritative until launcher cutover

Part of #71.