### PR TITLE
Port delivery.create service to v1.5 Python runtime

### DIFF
--- a/src/jl_mixing/delivery.py
+++ b/src/jl_mixing/delivery.py
@@ -1,0 +1,582 @@
+"""Authoritative cross-platform final-delivery planning and creation service."""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+import uuid
+import zipfile
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from .approval import derive_project_stage
+from .context import resolve_project, revision_root_for_number, studio_root as resolve_studio_root
+from .errors import ContextError, UnsafeOperationError, ValidationError
+from .metadata import create_v11, now_iso8601
+from .revision import _load_manifest, _validate_project_state, _validate_schema
+from .versions import application_root
+
+DeliveryMode = Literal["default", "overwrite", "clean"]
+
+
+@dataclass(frozen=True)
+class DeliverySelection:
+    source: Path
+    name: str
+    deliverable_type: str
+    path: str
+
+
+@dataclass(frozen=True)
+class DeliveryExclusion:
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DeliveryPlan:
+    selected: tuple[DeliverySelection, ...]
+    excluded: tuple[DeliveryExclusion, ...]
+    deletions: tuple[str, ...]
+    old_files: tuple[str, ...]
+    mode: DeliveryMode
+
+
+@dataclass(frozen=True)
+class DeliveryCreateRequest:
+    project_root: Path
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    working_prefix: str = "WORK "
+    overwrite: bool = False
+    clean: bool = False
+    make_zip: bool = False
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class DeliveryCreateResult:
+    project_root: Path
+    delivery_root: Path
+    revision_root: Path
+    approved_revision: int
+    current_revision: int
+    previous_delivered_revision: int | None
+    delivery_method: str
+    plan: DeliveryPlan
+    manifest: dict[str, Any]
+    delivery_manifest: dict[str, Any] | None
+    zip_name: str | None
+    files_delivered: int
+    project_stage: str
+    created: bool
+
+
+def _split_patterns(values: tuple[str, ...]) -> tuple[str, ...]:
+    result: list[str] = []
+    for value in values:
+        for item in value.split(","):
+            item = item.strip()
+            if not item:
+                raise ValidationError("Empty include/exclude pattern is not allowed")
+            result.append(item)
+    return tuple(result)
+
+
+def _normalize(name: str) -> str:
+    return re.sub(r"[\s_-]+", " ", name.casefold()).strip()
+
+
+def _has_word(text: str, word: str) -> bool:
+    return re.search(rf"(?<![a-z0-9]){re.escape(word)}(?![a-z0-9])", text) is not None
+
+
+def classify_deliverable(name: str) -> str:
+    text = _normalize(name)
+    if _has_word(text, "stem") or _has_word(text, "stems"):
+        return "stems"
+    if _has_word(text, "instrumental"):
+        return "instrumental"
+    if _has_word(text, "acapella") or re.search(r"(?<![a-z0-9])a cappella(?![a-z0-9])", text):
+        return "acapella"
+    if re.search(r"(?<![a-z0-9])tv mix(?![a-z0-9])", text):
+        return "tv_mix"
+    if re.search(r"(?<![a-z0-9])performance mix(?![a-z0-9])", text):
+        return "performance_mix"
+    if _has_word(text, "master"):
+        return "master"
+    if re.search(r"(?<![a-z0-9])main mix(?![a-z0-9])", text):
+        return "main_mix"
+    return "unclassified"
+
+
+def _safe_relative(value: str) -> PurePosixPath:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValidationError(f"Unsafe delivery path: {value!r}")
+    pure = PurePosixPath(value)
+    parts = value.split("/")
+    if pure.is_absolute() or any(part in ("", ".", "..") for part in parts):
+        raise ValidationError(f"Unsafe delivery path: {value}")
+    return pure
+
+
+def _regular_no_symlink(path: Path) -> bool:
+    try:
+        return path.is_file() and not path.is_symlink()
+    except OSError:
+        return False
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _recursive_listing(root: Path) -> tuple[str, ...]:
+    if not root.exists():
+        return ()
+    items: list[str] = []
+    for path in sorted(root.rglob("*"), key=lambda value: (value.relative_to(root).as_posix().casefold(), value.relative_to(root).as_posix())):
+        suffix = "/" if path.is_dir() and not path.is_symlink() else ""
+        items.append(path.relative_to(root).as_posix() + suffix)
+    return tuple(items)
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ValidationError(f"{label} is missing or unsafe: {path}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Unable to read {label}: {path}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _copy_existing_no_follow(source: Path, destination: Path) -> None:
+    if not source.exists():
+        return
+    for item in source.iterdir():
+        target = destination / item.name
+        if item.is_symlink():
+            try:
+                os.symlink(os.readlink(item), target, target_is_directory=item.is_dir())
+            except OSError as exc:
+                raise ValidationError(f"Unable to preserve existing delivery symbolic link: {item}") from exc
+        elif item.is_dir():
+            shutil.copytree(item, target, symlinks=True)
+        elif _regular_no_symlink(item):
+            shutil.copy2(item, target, follow_symlinks=False)
+        else:
+            raise ValidationError(f"Unsupported existing delivery item: {item}")
+
+
+def _remove_entry(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _generated_zip_pattern(project_id: str) -> re.Pattern[str]:
+    return re.compile(rf"^{re.escape(project_id)}-rev-[0-9]{{2}}-[0-9]{{14}}\.zip$")
+
+
+def _zip_stage(stage: Path, zip_name: str, project_id: str) -> None:
+    archive = stage / zip_name
+    generated = _generated_zip_pattern(project_id)
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+        for path in sorted(stage.rglob("*"), key=lambda value: (value.relative_to(stage).as_posix().casefold(), value.relative_to(stage).as_posix())):
+            relative = path.relative_to(stage).as_posix()
+            if path == archive or generated.fullmatch(path.name):
+                continue
+            if path.is_symlink():
+                raise ValidationError(f"Symbolic links cannot be archived in a delivery ZIP: {path}")
+            if path.is_dir():
+                continue
+            handle.write(path, relative)
+
+
+def _uuid_available(studio_root: Path, candidate: str) -> bool:
+    for path in studio_root.rglob("*.json"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        metadata = document.get("metadata") if isinstance(document, dict) else None
+        if isinstance(metadata, dict) and metadata.get("document_id") == candidate:
+            return False
+    return True
+
+
+def _document_id(studio_root: Path) -> str:
+    while True:
+        candidate = str(uuid.uuid4())
+        if _uuid_available(studio_root, candidate):
+            return candidate
+
+
+def _delivery_notes_template() -> Path:
+    path = application_root() / "templates" / "Delivery_Notes.md"
+    if not path.is_file():
+        raise ContextError(f"Required template not found: {path}")
+    return path
+
+
+def plan_delivery(
+    revision_root: Path,
+    delivery_root: Path,
+    project_manifest: dict[str, Any],
+    *,
+    mode: DeliveryMode,
+    working_prefix: str,
+    includes: tuple[str, ...],
+    excludes: tuple[str, ...],
+    zip_name: str | None,
+) -> DeliveryPlan:
+    if revision_root.is_symlink() or not revision_root.is_dir():
+        raise ValidationError(f"Revision directory is missing or unsafe: {revision_root}")
+    include_patterns = _split_patterns(includes)
+    exclude_patterns = _split_patterns(excludes)
+    selected: list[DeliverySelection] = []
+    excluded: list[DeliveryExclusion] = []
+
+    for item in sorted(revision_root.iterdir(), key=lambda path: (path.name.casefold(), path.name)):
+        if item.name == "Revision_Notes.md":
+            excluded.append(DeliveryExclusion(item.name, "revision notes"))
+            continue
+        if item.is_symlink():
+            raise ValidationError(f"Symbolic links are not allowed in a delivery source: {item}")
+        if item.is_dir():
+            raise ValidationError(f"Subdirectories are not allowed in a delivery source: {item}")
+        if not _regular_no_symlink(item):
+            raise ValidationError(f"Unsupported source item: {item}")
+        if working_prefix and item.name.startswith(working_prefix):
+            excluded.append(DeliveryExclusion(item.name, "working prefix"))
+            continue
+        if include_patterns and not any(fnmatch.fnmatchcase(item.name, pattern) for pattern in include_patterns):
+            excluded.append(DeliveryExclusion(item.name, "include pattern"))
+            continue
+        if exclude_patterns and any(fnmatch.fnmatchcase(item.name, pattern) for pattern in exclude_patterns):
+            excluded.append(DeliveryExclusion(item.name, "exclude pattern"))
+            continue
+        kind = classify_deliverable(item.name)
+        relative = f"Stems/{item.name}" if kind == "stems" else item.name
+        selected.append(DeliverySelection(item, item.name, kind, relative))
+
+    if not selected:
+        raise ValidationError("No deliverable files were found after applying filters")
+    seen: dict[str, str] = {}
+    for record in selected:
+        key = record.path.casefold()
+        if key in seen:
+            raise ValidationError(f"Case-insensitive destination collision: {seen[key]} and {record.path}")
+        seen[key] = record.path
+
+    delivery_manifest_path = delivery_root / "delivery-manifest.json"
+    old_files: tuple[str, ...] = ()
+    if mode == "default":
+        if delivery_manifest_path.exists() or delivery_manifest_path.is_symlink():
+            raise ValidationError("A final-delivery package already exists. Use --overwrite or --clean")
+        for record in selected:
+            destination = delivery_root.joinpath(*_safe_relative(record.path).parts)
+            if destination.exists() or destination.is_symlink():
+                raise ValidationError(f"Destination is already occupied: {destination}")
+        if zip_name and ((delivery_root / zip_name).exists() or (delivery_root / zip_name).is_symlink()):
+            raise ValidationError(f"ZIP destination already exists: {delivery_root / zip_name}")
+    elif mode == "overwrite":
+        prior = _load_json(delivery_manifest_path, "prior delivery manifest")
+        records = prior.get("files")
+        if not isinstance(records, list):
+            raise ValidationError("--overwrite requires a valid prior delivery manifest")
+        extracted: list[str] = []
+        for record in records:
+            if isinstance(record, dict) and isinstance(record.get("path"), str):
+                extracted.append(record["path"])
+        old_files = tuple(extracted)
+        old_map = {path.casefold(): path for path in old_files}
+        new_map = {record.path.casefold(): record.path for record in selected}
+        if set(old_map) != set(new_map):
+            missing = sorted(set(old_map) - set(new_map))
+            extra = sorted(set(new_map) - set(old_map))
+            details: list[str] = []
+            if missing:
+                details.append("stale prior files: " + ", ".join(old_map[key] for key in missing))
+            if extra:
+                details.append("new paths not present in prior package: " + ", ".join(new_map[key] for key in extra))
+            raise ValidationError("--overwrite requires the same delivery path set; use --clean (" + "; ".join(details) + ")")
+        for record in selected:
+            destination = delivery_root.joinpath(*_safe_relative(record.path).parts)
+            if (destination.exists() or destination.is_symlink()) and record.path.casefold() not in old_map:
+                raise ValidationError(f"Destination is occupied by an untracked item: {destination}")
+    elif mode != "clean":
+        raise ValidationError(f"Unknown delivery replacement mode: {mode}")
+
+    requested = project_manifest.get("delivery", {}).get("requested_deliverables", [])
+    if not isinstance(requested, list):
+        requested = []
+    fixed = ["stems", "instrumental", "acapella", "tv_mix", "performance_mix", "master", "main_mix", "unclassified"]
+    order: list[str] = []
+    for item in [*requested, *fixed]:
+        if isinstance(item, str) and item not in order:
+            order.append(item)
+    rank = {item: index for index, item in enumerate(order)}
+    selected.sort(key=lambda record: (rank.get(record.deliverable_type, 999), record.path.casefold(), record.path))
+    deletions = _recursive_listing(delivery_root) if mode == "clean" else ()
+    return DeliveryPlan(tuple(selected), tuple(excluded), deletions, old_files, mode)
+
+
+def _stage_delivery(
+    plan: DeliveryPlan,
+    project_manifest: dict[str, Any],
+    delivery_root: Path,
+    stage: Path,
+    *,
+    document_id: str,
+    timestamp: str,
+    zip_name: str | None,
+) -> dict[str, Any]:
+    if any(stage.iterdir()):
+        raise ValidationError(f"Staging directory is not empty: {stage}")
+    if plan.mode != "clean":
+        _copy_existing_no_follow(delivery_root, stage)
+    else:
+        (stage / "Stems").mkdir(parents=True, exist_ok=True)
+        shutil.copy2(_delivery_notes_template(), stage / "Delivery_Notes.md")
+
+    stems = stage / "Stems"
+    if stems.exists() or stems.is_symlink():
+        if stems.is_symlink() or not stems.is_dir():
+            raise ValidationError(f"Stems path is unsafe: {stems}")
+    else:
+        stems.mkdir(parents=True)
+    notes = stage / "Delivery_Notes.md"
+    if notes.exists() or notes.is_symlink():
+        if not _regular_no_symlink(notes):
+            raise ValidationError(f"Delivery notes path is unsafe: {notes}")
+    else:
+        shutil.copy2(_delivery_notes_template(), notes)
+
+    delivery_manifest_path = stage / "delivery-manifest.json"
+    if delivery_manifest_path.exists() or delivery_manifest_path.is_symlink():
+        _remove_entry(delivery_manifest_path)
+    if plan.mode == "overwrite":
+        for relative in plan.old_files:
+            path = stage.joinpath(*_safe_relative(relative).parts)
+            if path.exists() or path.is_symlink():
+                _remove_entry(path)
+
+    records: list[dict[str, Any]] = []
+    for record in plan.selected:
+        source = record.source
+        if not _regular_no_symlink(source):
+            raise ValidationError(f"Source changed or became unsafe: {source}")
+        before = _sha256(source)
+        destination = stage.joinpath(*_safe_relative(record.path).parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists() or destination.is_symlink():
+            if plan.mode == "default":
+                raise ValidationError(f"Staged destination conflict: {destination}")
+            _remove_entry(destination)
+        shutil.copy2(source, destination, follow_symlinks=False)
+        after = _sha256(destination)
+        if before != after:
+            raise ValidationError(f"Copy verification failed: {source}")
+        records.append({
+            "path": record.path,
+            "deliverable_type": record.deliverable_type,
+            "size_bytes": destination.stat().st_size,
+            "sha256": after,
+        })
+
+    approved_revision = project_manifest["state"]["approved_revision"]
+    revision = next(
+        (item for item in project_manifest["revisions"] if item.get("number") == approved_revision),
+        None,
+    )
+    if not isinstance(revision, dict):
+        raise ValidationError(f"Approved Revision {approved_revision} does not exist")
+    delivery_manifest: dict[str, Any] = {
+        "metadata": create_v11(
+            "mixing-delivery",
+            mutability="immutable",
+            document_id=document_id,
+            timestamp=timestamp,
+        ),
+        "project": {
+            "project_document_id": project_manifest["metadata"]["document_id"],
+            "project_id": project_manifest["project_id"],
+            "project_name": project_manifest["project_name"],
+        },
+        "client": {
+            "client_document_id": project_manifest["client"]["client_document_id"],
+            "client_id": project_manifest["client"]["client_id"],
+        },
+        "revision": {
+            "number": approved_revision,
+            "revision_id": revision["revision_id"],
+            "description": revision["description"],
+            "approval": deepcopy(revision["approval"]),
+        },
+        "delivery": {"method": project_manifest["delivery"]["method"]},
+        "files": records,
+    }
+    delivery_manifest_path.write_text(
+        json.dumps(delivery_manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    if zip_name is not None:
+        _zip_stage(stage, zip_name, project_manifest["project_id"])
+    return delivery_manifest
+
+
+def _commit_delivery_and_manifest(stage: Path, delivery_root: Path, manifest_temp: Path, manifest_path: Path) -> None:
+    parent = delivery_root.parent
+    backup = Path(tempfile.mkdtemp(prefix=f".{delivery_root.name}.jl-backup-", dir=parent))
+    backup.rmdir()
+    moved_old = False
+    installed_new = False
+    try:
+        if delivery_root.exists() or delivery_root.is_symlink():
+            if delivery_root.is_symlink() or not delivery_root.is_dir():
+                raise UnsafeOperationError(f"Delivery root is missing or unsafe: {delivery_root}")
+            os.replace(delivery_root, backup)
+            moved_old = True
+        os.replace(stage, delivery_root)
+        installed_new = True
+        try:
+            os.replace(manifest_temp, manifest_path)
+        except Exception:
+            if installed_new and delivery_root.exists():
+                shutil.rmtree(delivery_root, ignore_errors=True)
+            installed_new = False
+            if moved_old:
+                os.replace(backup, delivery_root)
+                moved_old = False
+            raise
+        if moved_old and backup.exists():
+            shutil.rmtree(backup)
+            moved_old = False
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        if installed_new and delivery_root.exists():
+            shutil.rmtree(delivery_root, ignore_errors=True)
+        if moved_old and backup.exists() and not delivery_root.exists():
+            os.replace(backup, delivery_root)
+        raise
+    finally:
+        if backup.exists():
+            shutil.rmtree(backup, ignore_errors=True)
+
+
+def create_delivery(request: DeliveryCreateRequest) -> DeliveryCreateResult:
+    if request.overwrite and request.clean:
+        raise ValidationError("--overwrite and --clean are mutually exclusive.")
+    if request.working_prefix == "":
+        raise ValidationError("--working-prefix cannot be empty.")
+    mode: DeliveryMode = "clean" if request.clean else "overwrite" if request.overwrite else "default"
+
+    project_root = resolve_project(request.project_root, Path.cwd())
+    manifest_path = project_root / "00_Admin" / "project-manifest.json"
+    manifest = _load_manifest(project_root)
+    current_revision = _validate_project_state(manifest)
+    state = manifest["state"]
+    approved_revision = state.get("approved_revision")
+    if not isinstance(approved_revision, int) or isinstance(approved_revision, bool) or approved_revision < 1:
+        raise ValidationError("A revision must be approved before delivery can be created.")
+    revision_root = revision_root_for_number(project_root, approved_revision)
+    delivery_root = project_root / "05_Final_Delivery"
+    if delivery_root.is_symlink() or not delivery_root.is_dir():
+        raise ContextError(f"Delivery root is missing or unsafe: {delivery_root}")
+
+    timestamp = now_iso8601()
+    local_timestamp = datetime.now().astimezone().strftime("%Y%m%d%H%M%S")
+    zip_name = f"{manifest['project_id']}-rev-{approved_revision:02d}-{local_timestamp}.zip" if request.make_zip else None
+    plan = plan_delivery(
+        revision_root,
+        delivery_root,
+        manifest,
+        mode=mode,
+        working_prefix=request.working_prefix,
+        includes=request.include,
+        excludes=request.exclude,
+        zip_name=zip_name,
+    )
+    previous_delivered = state.get("delivered_revision")
+    delivery_method = manifest["delivery"]["method"]
+
+    updated_manifest = deepcopy(manifest)
+    updated_manifest["state"]["delivered_revision"] = approved_revision
+    updated_manifest["metadata"]["last_modified_at"] = timestamp
+    _validate_project_state(updated_manifest)
+    _validate_schema(updated_manifest)
+
+    if request.dry_run:
+        return DeliveryCreateResult(
+            project_root, delivery_root, revision_root, approved_revision, current_revision,
+            previous_delivered, delivery_method, plan, updated_manifest, None, zip_name,
+            0, derive_project_stage(updated_manifest), False,
+        )
+
+    studio_root = resolve_studio_root(project_root)
+    document_id = _document_id(studio_root)
+    stage = Path(tempfile.mkdtemp(prefix=f".{delivery_root.name}.jl-stage-", dir=delivery_root.parent))
+    manifest_fd, manifest_temp_name = tempfile.mkstemp(prefix=f".{manifest_path.name}.", dir=manifest_path.parent)
+    os.close(manifest_fd)
+    manifest_temp = Path(manifest_temp_name)
+    try:
+        delivery_manifest = _stage_delivery(
+            plan,
+            manifest,
+            delivery_root,
+            stage,
+            document_id=document_id,
+            timestamp=timestamp,
+            zip_name=zip_name,
+        )
+        schema_path = application_root() / "schemas" / "delivery-manifest.schema.json"
+        try:
+            import jsonschema
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+            jsonschema.Draft202012Validator(schema).validate(delivery_manifest)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ContextError(f"Required delivery schema is unreadable: {schema_path}") from exc
+        except jsonschema.ValidationError as exc:
+            raise ValidationError(f"Generated delivery manifest failed schema validation: {exc.message}") from exc
+        manifest_temp.write_text(
+            json.dumps(updated_manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        _commit_delivery_and_manifest(stage, delivery_root, manifest_temp, manifest_path)
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        if manifest_temp.exists():
+            manifest_temp.unlink()
+        raise
+    finally:
+        if manifest_temp.exists():
+            manifest_temp.unlink()
+
+    return DeliveryCreateResult(
+        project_root, delivery_root, revision_root, approved_revision, current_revision,
+        previous_delivered, delivery_method, plan, updated_manifest, delivery_manifest, zip_name,
+        len(plan.selected), derive_project_stage(updated_manifest), True,
+    )

--- a/tests/python/test_delivery_service.py
+++ b/tests/python/test_delivery_service.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from jl_mixing.approval import RevisionApproveRequest, approve_revision
+from jl_mixing.delivery import DeliveryCreateRequest, create_delivery
+from jl_mixing.errors import ValidationError
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+
+def write_project(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "delivery-studio", "studio_name": "Delivery Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Client portal", "requested_deliverables": ["main_mix", "instrumental", "stems"]},
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "Delivery Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "delivery-client", "client_name": "Delivery Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Client portal", "requested_deliverables": ["main_mix", "instrumental", "stems"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    project = create_project(ProjectCreateRequest(client, "Delivery Song", change_directory=False)).project_root
+    revision = project / "04_Revisions" / "Revision_01"
+    (revision / "Delivery Song Main Mix.wav").write_bytes(b"main")
+    (revision / "Delivery Song Instrumental.wav").write_bytes(b"instrumental")
+    (revision / "Drum Stems.wav").write_bytes(b"stems")
+    (revision / "WORK rough.wav").write_bytes(b"work")
+    approve_revision(RevisionApproveRequest(project))
+    return project
+
+
+class DeliveryServiceTests(unittest.TestCase):
+    def test_dry_run_plans_files_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            delivery = project / "05_Final_Delivery"
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            before_manifest = manifest_path.read_bytes()
+            before_listing = sorted(path.relative_to(delivery).as_posix() for path in delivery.rglob("*"))
+            result = create_delivery(DeliveryCreateRequest(project, dry_run=True))
+            self.assertFalse(result.created)
+            self.assertEqual(result.files_delivered, 0)
+            self.assertEqual([record.path for record in result.plan.selected], [
+                "Delivery Song Main Mix.wav",
+                "Delivery Song Instrumental.wav",
+                "Stems/Drum Stems.wav",
+            ])
+            reasons = {item.name: item.reason for item in result.plan.excluded}
+            self.assertEqual(reasons["Revision_Notes.md"], "revision notes")
+            self.assertEqual(reasons["WORK rough.wav"], "working prefix")
+            self.assertEqual(before_manifest, manifest_path.read_bytes())
+            self.assertEqual(before_listing, sorted(path.relative_to(delivery).as_posix() for path in delivery.rglob("*")))
+
+    def test_create_copies_verifies_and_records_delivery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            delivery = project / "05_Final_Delivery"
+            notes = delivery / "Delivery_Notes.md"
+            notes.write_text("Client-specific delivery note\n", encoding="utf-8")
+            result = create_delivery(DeliveryCreateRequest(project))
+            self.assertTrue(result.created)
+            self.assertEqual(result.files_delivered, 3)
+            self.assertEqual(result.project_stage, "Delivered")
+            self.assertEqual(notes.read_text(encoding="utf-8"), "Client-specific delivery note\n")
+            self.assertEqual((delivery / "Delivery Song Main Mix.wav").read_bytes(), b"main")
+            self.assertEqual((delivery / "Stems" / "Drum Stems.wav").read_bytes(), b"stems")
+            package = json.loads((delivery / "delivery-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(package["revision"]["number"], 1)
+            self.assertEqual(len(package["files"]), 3)
+            self.assertTrue(all(len(record["sha256"]) == 64 for record in package["files"]))
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["state"]["delivered_revision"], 1)
+
+    def test_overwrite_requires_same_path_set_and_preserves_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            delivery = project / "05_Final_Delivery"
+            create_delivery(DeliveryCreateRequest(project))
+            notes = delivery / "Delivery_Notes.md"
+            notes.write_text("Edited after first package\n", encoding="utf-8")
+            revision = project / "04_Revisions" / "Revision_01"
+            (revision / "Delivery Song Main Mix.wav").write_bytes(b"main-v2")
+            result = create_delivery(DeliveryCreateRequest(project, overwrite=True))
+            self.assertTrue(result.created)
+            self.assertEqual((delivery / "Delivery Song Main Mix.wav").read_bytes(), b"main-v2")
+            self.assertEqual(notes.read_text(encoding="utf-8"), "Edited after first package\n")
+            (revision / "Delivery Song Instrumental.wav").unlink()
+            with self.assertRaisesRegex(ValidationError, "same delivery path set"):
+                create_delivery(DeliveryCreateRequest(project, overwrite=True))
+
+    def test_clean_allows_new_path_set_and_resets_delivery_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            delivery = project / "05_Final_Delivery"
+            create_delivery(DeliveryCreateRequest(project))
+            (delivery / "Untracked.txt").write_text("old\n", encoding="utf-8")
+            (delivery / "Delivery_Notes.md").write_text("old notes\n", encoding="utf-8")
+            revision = project / "04_Revisions" / "Revision_01"
+            (revision / "Delivery Song Instrumental.wav").unlink()
+            result = create_delivery(DeliveryCreateRequest(project, clean=True))
+            self.assertTrue(result.created)
+            self.assertIn("Untracked.txt", result.plan.deletions)
+            self.assertFalse((delivery / "Untracked.txt").exists())
+            self.assertFalse((delivery / "Delivery Song Instrumental.wav").exists())
+            self.assertNotEqual((delivery / "Delivery_Notes.md").read_text(encoding="utf-8"), "old notes\n")
+
+    def test_zip_is_created_without_nesting_generated_archives(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            delivery = project / "05_Final_Delivery"
+            historical = delivery / "delivery-song-rev-01-20000101000000.zip"
+            historical.write_bytes(b"old zip")
+            result = create_delivery(DeliveryCreateRequest(project, make_zip=True))
+            self.assertIsNotNone(result.zip_name)
+            archive = delivery / str(result.zip_name)
+            self.assertTrue(archive.is_file())
+            with zipfile.ZipFile(archive) as handle:
+                names = set(handle.namelist())
+            self.assertIn("delivery-manifest.json", names)
+            self.assertIn("Delivery Song Main Mix.wav", names)
+            self.assertIn("Stems/Drum Stems.wav", names)
+            self.assertNotIn(historical.name, names)
+            self.assertNotIn(archive.name, names)
+            self.assertTrue(historical.is_file())
+
+    def test_filters_and_validation_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            result = create_delivery(DeliveryCreateRequest(project, include=("*Main Mix.wav",), dry_run=True))
+            self.assertEqual([record.name for record in result.plan.selected], ["Delivery Song Main Mix.wav"])
+            with self.assertRaisesRegex(ValidationError, "mutually exclusive"):
+                create_delivery(DeliveryCreateRequest(project, overwrite=True, clean=True, dry_run=True))
+            with self.assertRaisesRegex(ValidationError, "working-prefix"):
+                create_delivery(DeliveryCreateRequest(project, working_prefix="", dry_run=True))
+
+    def test_delivery_requires_approved_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["state"]["approved_revision"] = None
+            manifest["revisions"][0]["approval"] = {"approved_at": None, "approved_by": None}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValidationError, "must be approved"):
+                create_delivery(DeliveryCreateRequest(project, dry_run=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by porting final-delivery planning, packaging, hashing, replacement, ZIP creation, and project-state update into the cross-platform Python runtime.

## Changes

- promote v1.4 delivery selection/classification semantics into the Python package
- preserve include/exclude filtering, working-prefix exclusion, requested-deliverable ordering, stems routing, and immediate-file safety rules
- preserve default / `--overwrite` / `--clean` replacement semantics and clean deletion planning
- preserve edited Delivery_Notes.md for normal/overwrite packaging and reset it on clean replacement
- preserve mandatory SHA-256 copy verification and delivery-manifest records
- create delivery ZIPs with Python `zipfile`, removing the Windows dependency on an external `zip` executable
- exclude generated historical delivery archives from newly generated ZIP contents while preserving them in the delivery folder
- update `state.delivered_revision` and project metadata together with the delivery directory using a rollback-capable cross-platform directory+manifest transaction
- preserve UTC metadata timestamps and local-wall-clock ZIP naming
- add native Windows/macOS/Linux service tests for dry-run, hashes, stems routing, notes preservation, overwrite path-set enforcement, clean replacement, ZIP contents, filtering, and approval requirements

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no installed launcher or API route changes in this slice

Part of #71.