### PR TITLE
Implement v1.5 Python delivery.create API adapter

### DIFF
--- a/src/jl_mixing/api/delivery_create.py
+++ b/src/jl_mixing/api/delivery_create.py
@@ -1,0 +1,193 @@
+"""Automation API 1.0 adapter for delivery.create."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..context import studio_root
+from ..delivery import DeliveryCreateRequest, create_delivery
+from ..errors import ArgumentError, ContextError, JLMixingError, UnsafeOperationError, ValidationError
+from ..versions import api_version
+
+
+@dataclass(frozen=True)
+class DeliveryCreateApiRequest:
+    project: Path
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    working_prefix: str = "WORK "
+    overwrite: bool = False
+    clean: bool = False
+    make_zip: bool = False
+    dry_run: bool = False
+
+
+def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "delivery.create",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [{
+            "code": code,
+            "message": message,
+            "details": {"exit_code": exit_code},
+            "retryable": False,
+        }],
+    }
+
+
+def execute(request: DeliveryCreateApiRequest) -> tuple[dict[str, Any], int]:
+    try:
+        result = create_delivery(DeliveryCreateRequest(
+            project_root=request.project,
+            include=request.include,
+            exclude=request.exclude,
+            working_prefix=request.working_prefix,
+            overwrite=request.overwrite,
+            clean=request.clean,
+            make_zip=request.make_zip,
+            dry_run=request.dry_run,
+        ))
+        manifest_path = result.project_root / "00_Admin" / "project-manifest.json"
+        delivery_notes_path = result.delivery_root / "Delivery_Notes.md"
+        delivery_manifest_path = result.delivery_root / "delivery-manifest.json"
+        workspace = studio_root(result.project_root)
+        data: dict[str, Any] = {
+            "project": {
+                "id": result.manifest.get("project_id", ""),
+                "name": result.manifest.get("project_name", ""),
+                "path": str(result.project_root),
+            },
+            "revision": {
+                "number": result.approved_revision,
+                "path": str(result.revision_root),
+            },
+            "current_revision": result.current_revision,
+            "approved_revision": result.approved_revision,
+            "delivered_revision": None if request.dry_run else result.approved_revision,
+            "delivery_method": result.delivery_method,
+            "replacement_mode": result.plan.mode,
+            "zip_requested": request.make_zip,
+            "zip_name": result.zip_name,
+            "selected": [
+                {
+                    "source_name": item.name,
+                    "deliverable_type": item.deliverable_type,
+                    "path": item.path,
+                }
+                for item in result.plan.selected
+            ],
+            "excluded": [
+                {"name": item.name, "reason": item.reason}
+                for item in result.plan.excluded
+            ],
+            "deletions": list(result.plan.deletions),
+            "manifest_path": str(manifest_path),
+            "delivery_path": str(result.delivery_root),
+            "delivery_notes_path": str(delivery_notes_path),
+            "delivery_manifest_path": str(delivery_manifest_path),
+            "workspace_path": str(workspace),
+            "files_delivered": 0 if request.dry_run else result.files_delivered,
+        }
+        if result.zip_name is not None:
+            data["zip_path"] = str(result.delivery_root / result.zip_name)
+        if request.dry_run:
+            data["would_update"] = [str(manifest_path), str(result.delivery_root)]
+        return {
+            "api_version": api_version(),
+            "operation": "delivery.create",
+            "status": "planned" if request.dry_run else "success",
+            "data": data,
+            "warnings": [],
+            "errors": [],
+        }, 0
+    except ContextError as exc:
+        return _error_envelope("PROJECT_NOT_FOUND", str(exc), exc.exit_code), exc.exit_code
+    except UnsafeOperationError as exc:
+        return _error_envelope("UNSAFE_DELIVERY_OPERATION", str(exc), exc.exit_code, status="blocked"), exc.exit_code
+    except ValidationError as exc:
+        message = str(exc)
+        lowered = message.lower()
+        if "must be approved" in lowered or "approved revision" in lowered:
+            code = "REVISION_NOT_APPROVED"
+        elif "overwrite" in lowered or "already exists" in lowered or "replacement" in lowered:
+            code = "DELIVERY_REPLACEMENT_REQUIRED"
+        elif "unsafe" in lowered or "clean" in lowered or "symbolic link" in lowered:
+            code = "UNSAFE_DELIVERY_OPERATION"
+        else:
+            code = "DELIVERY_VALIDATION_FAILED"
+        return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+
+
+def parse_args(args: list[str]) -> DeliveryCreateApiRequest:
+    project: Path | None = None
+    includes: list[str] = []
+    excludes: list[str] = []
+    working_prefix = "WORK "
+    overwrite = False
+    clean = False
+    make_zip = False
+    dry_run = False
+    json_seen = 0
+    project_seen = 0
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg in {"--project", "--include", "--exclude", "--working-prefix"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project_seen += 1
+                project = Path(value)
+            elif arg == "--include":
+                if not value.strip():
+                    raise ArgumentError("--include cannot be empty.")
+                includes.append(value)
+            elif arg == "--exclude":
+                if not value.strip():
+                    raise ArgumentError("--exclude cannot be empty.")
+                excludes.append(value)
+            else:
+                if value == "":
+                    raise ArgumentError("--working-prefix cannot be empty.")
+                working_prefix = value
+        elif arg == "--overwrite":
+            overwrite = True
+        elif arg == "--clean":
+            clean = True
+        elif arg == "--zip":
+            make_zip = True
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg in {"--revision", "--checksum", "--mark-delivered", "--non-interactive"}:
+            raise ArgumentError(f"Unknown option: {arg}")
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+
+    if json_seen != 1 or project_seen != 1 or project is None or str(project) == "":
+        raise ArgumentError("delivery create requires exactly one --json option and one explicit --project PATH.")
+    if overwrite and clean:
+        raise ArgumentError("--overwrite and --clean are mutually exclusive.")
+    return DeliveryCreateApiRequest(
+        project=project,
+        include=tuple(includes),
+        exclude=tuple(excludes),
+        working_prefix=working_prefix,
+        overwrite=overwrite,
+        clean=clean,
+        make_zip=make_zip,
+        dry_run=dry_run,
+    )

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -9,6 +9,9 @@ from collections.abc import Sequence
 from .api.client_create import _error_envelope as client_error_envelope
 from .api.client_create import execute as client_execute
 from .api.client_create import parse_args as parse_client_args
+from .api.delivery_create import _error_envelope as delivery_error_envelope
+from .api.delivery_create import execute as delivery_execute
+from .api.delivery_create import parse_args as parse_delivery_args
 from .api.intake_validate import _error_envelope as intake_error_envelope
 from .api.intake_validate import execute as intake_execute
 from .api.intake_validate import parse_args as parse_intake_args
@@ -93,6 +96,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             _emit_json(approval_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
             return exc.exit_code
         payload, status = approval_execute(request)
+        _emit_json(payload)
+        return status
+
+    if len(args) >= 2 and args[0:2] == ["delivery", "create"]:
+        try:
+            request = parse_delivery_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(delivery_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            return exc.exit_code
+        except ValidationError as exc:
+            _emit_json(delivery_error_envelope("DELIVERY_VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
+            return exc.exit_code
+        payload, status = delivery_execute(request)
         _emit_json(payload)
         return status
 

--- a/tests/python/test_delivery_api.py
+++ b/tests/python/test_delivery_api.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.approval import RevisionApproveRequest, approve_revision
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_project(root: Path, *, approve: bool = True) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "delivery-studio", "studio_name": "Delivery Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Portal", "requested_deliverables": ["main_mix", "stems"]},
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "Delivery Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "delivery-client", "client_name": "Delivery Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Portal", "requested_deliverables": ["main_mix", "stems"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    project = create_project(ProjectCreateRequest(client, "Delivery Song", change_directory=False)).project_root
+    revision = project / "04_Revisions" / "Revision_01"
+    (revision / "Delivery Song Main Mix.wav").write_bytes(b"main")
+    (revision / "Drum Stems.wav").write_bytes(b"stems")
+    if approve:
+        approve_revision(RevisionApproveRequest(project_root=project, approved_at="2030-01-01T12:01:00Z"))
+    return project
+
+
+def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=cwd, env=env, text=True, capture_output=True, check=False,
+    )
+
+
+class DeliveryApiTests(unittest.TestCase):
+    def test_dry_run_returns_planned_envelope_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            proc = run_cli(project, "delivery", "create", "--project", str(project), "--json", "--dry-run", "--zip")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "delivery.create")
+            self.assertEqual(payload["status"], "planned")
+            data = payload["data"]
+            self.assertEqual(data["approved_revision"], 1)
+            self.assertIsNone(data["delivered_revision"])
+            self.assertEqual(data["files_delivered"], 0)
+            self.assertTrue(data["zip_requested"])
+            self.assertTrue(data["zip_name"].endswith(".zip"))
+            self.assertEqual(len(data["selected"]), 2)
+            self.assertEqual(data["would_update"], [data["manifest_path"], data["delivery_path"]])
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertIsNone(manifest["state"]["delivered_revision"])
+
+    def test_success_returns_paths_and_creates_zip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            proc = run_cli(project, "delivery", "create", "--project", str(project), "--json", "--zip")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "success")
+            data = payload["data"]
+            self.assertEqual(data["delivered_revision"], 1)
+            self.assertEqual(data["files_delivered"], 2)
+            self.assertTrue(Path(data["delivery_manifest_path"]).is_file())
+            self.assertTrue(Path(data["zip_path"]).is_file())
+            self.assertTrue((project / "05_Final_Delivery" / "Stems" / "Drum Stems.wav").is_file())
+
+    def test_second_default_delivery_requires_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            first = run_cli(project, "delivery", "create", "--project", str(project), "--json")
+            self.assertEqual(first.returncode, 0, first.stderr)
+            second = run_cli(project, "delivery", "create", "--project", str(project), "--json")
+            self.assertEqual(second.returncode, 5)
+            payload = json.loads(second.stdout)
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["errors"][0]["code"], "DELIVERY_REPLACEMENT_REQUIRED")
+
+    def test_unapproved_project_is_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp), approve=False)
+            proc = run_cli(project, "delivery", "create", "--project", str(project), "--json")
+            self.assertEqual(proc.returncode, 5)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "REVISION_NOT_APPROVED")
+
+    def test_json_mode_and_replacement_argument_rules(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            cases = (
+                ("delivery", "create", "--project", str(project)),
+                ("delivery", "create", "--json"),
+                ("delivery", "create", "--project", str(project), "--json", "--overwrite", "--clean"),
+                ("delivery", "create", "--project", str(project), "--json", "--include", ""),
+            )
+            for args in cases:
+                proc = run_cli(project, *args)
+                self.assertEqual(proc.returncode, 2)
+                self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_REQUEST")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by wiring Automation API 1.0 `delivery.create` directly to the cross-platform Python delivery service.

## Changes

- add Python `delivery.create` request parser and API 1.0 response adapter
- route `jl_mixing.cli delivery create ... --json` through the Python service
- preserve JSON mode requirement for exactly one `--project PATH`
- preserve include/exclude filters, working-prefix, overwrite/clean/zip/dry-run options
- preserve planned/success/blocked/error envelopes and canonical manifest/delivery/revision/workspace paths
- preserve `REVISION_NOT_APPROVED`, `DELIVERY_REPLACEMENT_REQUIRED`, `UNSAFE_DELIVERY_OPERATION`, and generic delivery-validation classifications
- preserve dry-run `delivered_revision: null`, `files_delivered: 0`, and `would_update`
- preserve ZIP name/path reporting without requiring external zip tooling
- preserve argument-error behavior for overwrite+clean and empty filter values
- add native Windows/macOS/Linux command-level tests for dry-run, success+ZIP, replacement blocking, approval requirements, and JSON argument rules

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash dispatcher remains unchanged until launcher cutover
- API adapter calls the Python delivery service directly and does not parse human CLI output

Part of #71.