### PR TITLE
Port create-delivery human CLI to v1.5 Python runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ new-client-python = "jl_mixing.new_client_cli:main"
 new-mix-python = "jl_mixing.new_mix_cli:main"
 new-revision-python = "jl_mixing.new_revision_cli:main"
 approve-mix-python = "jl_mixing.approve_mix_cli:main"
+create-delivery-python = "jl_mixing.create_delivery_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jl_mixing/create_delivery_cli.py
+++ b/src/jl_mixing/create_delivery_cli.py
@@ -1,0 +1,207 @@
+"""Human-facing create-delivery command backed by the cross-platform delivery service."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from .context import resolve_project
+from .delivery import DeliveryCreateRequest, DeliveryCreateResult, create_delivery
+from .errors import ArgumentError, JLMixingError
+
+_USAGE = """Usage: create-delivery [options]\n\nOptions:\n  --project PATH          Explicit project directory\n  --include PATTERN       Include matching revision files; may be repeated\n  --exclude PATTERN       Exclude matching revision files; may be repeated\n  --working-prefix TEXT   Exclude files beginning with this prefix (default: WORK )\n  --overwrite             Replace a prior package with the same delivered paths\n  --clean                 Destructively replace all contents of 05_Final_Delivery\n  --zip                   Create <project-id>-rev-<NN>-<local timestamp>.zip\n  --dry-run               Show the planned package without creating it\n  -h, --help              Show this help\n"""
+
+
+def _removed_option(option: str) -> ArgumentError:
+    guidance = {
+        "--revision": "--revision was removed in JL Mixing 1.1. create-delivery always uses state.approved_revision.",
+        "--checksum": "--checksum was removed in JL Mixing 1.1. SHA-256 verification is mandatory.",
+        "--mark-delivered": "--mark-delivered was removed in JL Mixing 1.1. Successful package creation records the delivered revision automatically.",
+        "--non-interactive": "--non-interactive was removed in JL Mixing 1.1. create-delivery does not prompt.",
+    }
+    return ArgumentError(guidance[option])
+
+
+def _parse(args: list[str]) -> tuple[DeliveryCreateRequest | None, bool]:
+    if args in (["-h"], ["--help"]):
+        return None, True
+    project: Path | None = None
+    includes: list[str] = []
+    excludes: list[str] = []
+    working_prefix = "WORK "
+    overwrite = False
+    clean = False
+    make_zip = False
+    dry_run = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in {"-h", "--help"}:
+            return None, True
+        if arg in {"--revision", "--checksum", "--mark-delivered", "--non-interactive"}:
+            raise _removed_option(arg)
+        if arg in {"--project", "--include", "--exclude", "--working-prefix"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project = Path(value)
+            elif arg == "--include":
+                if not value.strip():
+                    raise ArgumentError("--include cannot be empty.")
+                includes.append(value)
+            elif arg == "--exclude":
+                if not value.strip():
+                    raise ArgumentError("--exclude cannot be empty.")
+                excludes.append(value)
+            else:
+                if value == "":
+                    raise ArgumentError("--working-prefix cannot be empty.")
+                working_prefix = value
+        elif arg == "--overwrite":
+            overwrite = True
+        elif arg == "--clean":
+            clean = True
+        elif arg == "--zip":
+            make_zip = True
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+
+    if overwrite and clean:
+        raise ArgumentError("--overwrite and --clean are mutually exclusive.")
+    project_root = resolve_project(project, Path.cwd())
+    return DeliveryCreateRequest(
+        project_root=project_root,
+        include=tuple(includes),
+        exclude=tuple(excludes),
+        working_prefix=working_prefix,
+        overwrite=overwrite,
+        clean=clean,
+        make_zip=make_zip,
+        dry_run=dry_run,
+    ), False
+
+
+def _result_payload(result: DeliveryCreateResult, *, planned: bool) -> dict[str, object]:
+    return {
+        "status": "planned" if planned else "success",
+        "project": {
+            "id": result.manifest.get("project_id", ""),
+            "name": result.manifest.get("project_name", ""),
+            "path": str(result.project_root),
+        },
+        "revision": {"number": result.approved_revision, "path": str(result.revision_root)},
+        "current_revision": result.current_revision,
+        "approved_revision": result.approved_revision,
+        "delivered_revision": None if planned else result.approved_revision,
+        "delivery_method": result.delivery_method,
+        "replacement_mode": result.plan.mode,
+        "zip_requested": result.zip_name is not None,
+        "zip_name": result.zip_name,
+        "selected": [
+            {"source_name": item.name, "deliverable_type": item.deliverable_type, "path": item.path}
+            for item in result.plan.selected
+        ],
+        "excluded": [{"name": item.name, "reason": item.reason} for item in result.plan.excluded],
+        "deletions": list(result.plan.deletions),
+    }
+
+
+def _write_result(result: DeliveryCreateResult, *, planned: bool) -> None:
+    value = os.environ.get("JL_MIXING_DELIVERY_RESULT_FILE")
+    if not value:
+        return
+    path = Path(value)
+    if not path.is_absolute() or path.is_symlink() or not path.is_file():
+        raise ArgumentError(f"Delivery result file is missing or unsafe: {path}")
+    path.write_text(
+        json.dumps(_result_payload(result, planned=planned), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _print_plan(result: DeliveryCreateResult, *, create_zip: bool) -> None:
+    print(f"Project:             {result.manifest.get('project_name', '')}")
+    print(f"Current revision:    {result.current_revision}")
+    print(f"Approved revision:   {result.approved_revision}")
+    delivered = "null" if result.previous_delivered_revision is None else str(result.previous_delivered_revision)
+    print(f"Delivered revision:  {delivered}")
+    print(f"Delivery method:     {result.delivery_method}")
+    print(f"Replacement mode:    {result.plan.mode}")
+    print(f"Create ZIP:          {'yes' if create_zip else 'no'}")
+    print("\nSelected files:")
+    for item in result.plan.selected:
+        print(f"  {item.name}")
+        print(f"    Type: {item.deliverable_type}")
+        print(f"    Destination: {item.path}")
+    if result.plan.excluded:
+        print("\nExcluded:")
+        for item in result.plan.excluded:
+            print(f"  {item.name}    {item.reason}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    try:
+        request, help_only = _parse(args)
+        if help_only:
+            print(_USAGE, end="")
+            return 0
+        assert request is not None
+        result = create_delivery(request)
+        _write_result(result, planned=request.dry_run)
+
+        if request.dry_run:
+            print("Dry run - no changes made.\n")
+            _print_plan(result, create_zip=request.make_zip)
+            if request.clean:
+                print(f"\nWarning: --clean will remove every existing item inside:\n  {result.delivery_root}")
+                if result.plan.deletions:
+                    print("\nWould delete from 05_Final_Delivery/:")
+                    for item in result.plan.deletions:
+                        print(f"  {item}")
+            print("\nWould create:")
+            for item in result.plan.selected:
+                print(f"  {item.path}")
+            print("  Delivery_Notes.md")
+            print("  delivery-manifest.json")
+            if result.zip_name is not None:
+                print(f"  {result.zip_name}")
+            previous = "null" if result.previous_delivered_revision is None else str(result.previous_delivered_revision)
+            print("\nWould update:")
+            print(f"  state.delivered_revision: {previous} -> {result.approved_revision}")
+            print("  metadata.last_modified_at")
+            print("\nSHA-256 verification will occur during actual package creation.")
+            return 0
+
+        print("Final delivery created successfully.\n")
+        _print_plan(result, create_zip=request.make_zip)
+        print(f"Files delivered:     {result.files_delivered}")
+        if result.zip_name is not None:
+            print(f"ZIP:                 {result.zip_name}")
+        print(f"Project state:       {result.project_stage}")
+        print(f"\nDelivery folder:\n  {result.delivery_root}\n\nDelivered files:")
+        for item in result.plan.selected:
+            print(f"  {item.path}")
+        print("\nNext:")
+        if result.zip_name is not None:
+            print(f"  Transfer {result.zip_name} using the configured delivery method.")
+        else:
+            print("  Transfer the contents of 05_Final_Delivery using the configured delivery method.")
+        return 0
+    except JLMixingError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_create_delivery_cli.py
+++ b/tests/python/test_create_delivery_cli.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.approval import RevisionApproveRequest, approve_revision
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_project(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio", "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "delivery-human-studio", "studio_name": "Delivery Human Studio", "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Portal", "requested_deliverables": ["main_mix", "stems"]},
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "Delivery Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client", "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.4.0", "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "delivery-client", "client_name": "Delivery Client",
+        "defaults": {
+            "artist": "Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Portal", "requested_deliverables": ["main_mix", "stems"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    project = create_project(ProjectCreateRequest(client, "Delivery Song", change_directory=False)).project_root
+    revision = project / "04_Revisions" / "Revision_01"
+    (revision / "Delivery Song Main Mix.wav").write_bytes(b"main")
+    (revision / "Drum Stems.wav").write_bytes(b"stems")
+    (revision / "WORK scratch.wav").write_bytes(b"scratch")
+    approve_revision(RevisionApproveRequest(project_root=project, approved_at="2030-01-01T12:01:00Z"))
+    return project
+
+
+def run_cli(cwd: Path, *args: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.create_delivery_cli", *args],
+        cwd=cwd, env=env, text=True, capture_output=True, check=False,
+    )
+
+
+class CreateDeliveryCliTests(unittest.TestCase):
+    def test_help_matches_human_command_surface(self) -> None:
+        proc = run_cli(ROOT, "--help")
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("Usage: create-delivery", proc.stdout)
+        self.assertIn("--overwrite", proc.stdout)
+        self.assertIn("--clean", proc.stdout)
+        self.assertIn("--zip", proc.stdout)
+
+    def test_dry_run_lists_plan_and_writes_structured_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = write_project(root / "studio")
+            result_file = root / "result.json"
+            result_file.write_text("", encoding="utf-8")
+            proc = run_cli(
+                project, "--dry-run", "--zip",
+                extra_env={"JL_MIXING_DELIVERY_RESULT_FILE": str(result_file.resolve())},
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Dry run - no changes made.", proc.stdout)
+            self.assertIn("Selected files:", proc.stdout)
+            self.assertIn("Drum Stems.wav", proc.stdout)
+            self.assertIn("WORK scratch.wav    working prefix", proc.stdout)
+            self.assertIn("state.delivered_revision: null -> 1", proc.stdout)
+            self.assertIn("SHA-256 verification", proc.stdout)
+            payload = json.loads(result_file.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "planned")
+            self.assertIsNone(payload["delivered_revision"])
+            self.assertTrue(payload["zip_requested"])
+            manifest = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
+            self.assertIsNone(manifest["state"]["delivered_revision"])
+
+    def test_create_zip_preserves_edited_delivery_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            notes = project / "05_Final_Delivery" / "Delivery_Notes.md"
+            notes.write_text("Custom client delivery note\n", encoding="utf-8")
+            proc = run_cli(project, "--zip")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Final delivery created successfully.", proc.stdout)
+            self.assertIn("Files delivered:     2", proc.stdout)
+            self.assertIn("Project state:       Delivered", proc.stdout)
+            self.assertIn("Transfer delivery-song-rev-01-", proc.stdout)
+            self.assertEqual(notes.read_text(encoding="utf-8"), "Custom client delivery note\n")
+            archives = list((project / "05_Final_Delivery").glob("delivery-song-rev-01-*.zip"))
+            self.assertEqual(len(archives), 1)
+            self.assertTrue((project / "05_Final_Delivery" / "Stems" / "Drum Stems.wav").is_file())
+
+    def test_clean_dry_run_warns_and_lists_deletions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            delivery = project / "05_Final_Delivery"
+            (delivery / "old.txt").write_text("old", encoding="utf-8")
+            proc = run_cli(project, "--clean", "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Warning: --clean will remove every existing item inside:", proc.stdout)
+            self.assertIn("Would delete from 05_Final_Delivery/:", proc.stdout)
+            self.assertIn("old.txt", proc.stdout)
+            self.assertTrue((delivery / "old.txt").exists())
+
+    def test_argument_conflicts_and_removed_options_preserve_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            proc = run_cli(project, "--overwrite", "--clean")
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("mutually exclusive", proc.stderr)
+            expectations = {
+                "--revision": "always uses state.approved_revision",
+                "--checksum": "SHA-256 verification is mandatory",
+                "--mark-delivered": "records the delivered revision automatically",
+                "--non-interactive": "does not prompt",
+            }
+            for option, text in expectations.items():
+                proc = run_cli(project, option)
+                self.assertEqual(proc.returncode, 2)
+                self.assertIn(text, proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by implementing the human `create-delivery` interface on the same cross-platform Python delivery service already used by Automation API 1.0 `delivery.create`.

## Changes

- add Python `create-delivery` human command implementation
- preserve include/exclude filters, working-prefix, overwrite/clean/zip/dry-run behavior, selected/excluded reporting, delivered-file listing, and Next guidance
- preserve destructive clean warnings and deletion planning
- preserve removed `--revision`, `--checksum`, `--mark-delivered`, and `--non-interactive` guidance
- preserve edited Delivery_Notes.md on normal/overwrite packaging and reset on clean through the shared service
- preserve `JL_MIXING_DELIVERY_RESULT_FILE` structured handoff used by Studio
- use ASCII `->` for Windows-safe state-transition output
- expose transitional `create-delivery-python` entry point without changing the installed v1.4 launcher yet
- add native Windows/macOS/Linux command-level tests for help, dry-run/result handoff, ZIP creation, edited notes preservation, clean warnings, conflicts, and removed options

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash `create-delivery` remains authoritative until launcher cutover

Part of #71.