### PR TITLE
Port new-studio to v1.5 cross-platform Python runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {text = "Apache-2.0"}
 
 [project.scripts]
 jl-mixing-python = "jl_mixing.cli:main"
+new-studio-python = "jl_mixing.new_studio_cli:main"
 validate-intake-python = "jl_mixing.validate_intake_cli:main"
 new-client-python = "jl_mixing.new_client_cli:main"
 new-mix-python = "jl_mixing.new_mix_cli:main"

--- a/schemas/studio.schema.json
+++ b/schemas/studio.schema.json
@@ -58,7 +58,7 @@
     },
     "root_path": {
       "type": "string",
-      "pattern": "^/"
+      "pattern": "^(?:/|[A-Za-z]:[\\\\/]|\\\\\\\\[^\\\\/]+[\\\\/][^\\\\/]+)"
     },
     "defaults": {
       "type": "object",

--- a/src/jl_mixing/new_studio_cli.py
+++ b/src/jl_mixing/new_studio_cli.py
@@ -1,0 +1,146 @@
+"""Human-facing new-studio command backed by the cross-platform studio service."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from .errors import ArgumentError, JLMixingError, ValidationError
+from .studio import StudioCreateRequest, create_studio
+
+_USAGE = """Usage: new-studio [options]\n\nOptions:\n  --root PATH          Workspace root (default: ~/Music/Mixes)\n  --name NAME          Studio name (default: Mixing Studio)\n  --engineer NAME      Default mix engineer\n  --sample-rate HZ     Default sample rate (default: 48000)\n  --bit-depth BITS     Default bit depth (default: 24)\n  --file-format FORMAT WAV or AIFF (default: WAV)\n  --default-cd         Enable automatic directory changes by default\n  --no-default-cd      Disable automatic directory changes by default\n  --dry-run            Show the planned workspace without creating it\n  -h, --help           Show this help\n"""
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse(args: list[str]) -> tuple[StudioCreateRequest | None, bool]:
+    if args in (["-h"], ["--help"]):
+        return None, True
+    default_root = os.environ.get("JL_MIXING_ROOT") or str(Path.home() / "Music" / "Mixes")
+    root = Path(default_root)
+    name = "Mixing Studio"
+    engineer = ""
+    sample_rate = 48000
+    bit_depth = 24
+    file_format = "WAV"
+    default_cd = False
+    default_cd_seen = False
+    no_default_cd_seen = False
+    dry_run = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in {"-h", "--help"}:
+            return None, True
+        if arg == "--daw":
+            raise ArgumentError("--daw was removed in JL Mixing 1.1.\nDAW projects and templates are no longer managed by JL Mixing.")
+        if arg == "--non-interactive":
+            raise ArgumentError("--non-interactive was removed in JL Mixing 1.1.\nnew-studio already uses supplied values and defaults without prompting.")
+        if arg in {"--root", "--name", "--engineer", "--sample-rate", "--bit-depth", "--file-format"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--root":
+                root = Path(value)
+            elif arg == "--name":
+                name = value
+            elif arg == "--engineer":
+                engineer = value
+            elif arg == "--sample-rate":
+                try:
+                    sample_rate = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported sample rate: {value}") from exc
+            elif arg == "--bit-depth":
+                try:
+                    bit_depth = int(value)
+                except ValueError as exc:
+                    raise ValidationError(f"Unsupported bit depth: {value}") from exc
+            else:
+                file_format = value
+        elif arg == "--default-cd":
+            default_cd_seen = True
+            default_cd = True
+        elif arg == "--no-default-cd":
+            no_default_cd_seen = True
+            default_cd = False
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+
+    if default_cd_seen and no_default_cd_seen:
+        raise ArgumentError("--default-cd and --no-default-cd cannot be used together.")
+    if not str(root).strip():
+        raise ValidationError("studio root must not be empty.")
+    return StudioCreateRequest(
+        root=root,
+        name=name,
+        engineer=engineer,
+        sample_rate=sample_rate,
+        bit_depth=bit_depth,
+        file_format=file_format,
+        default_cd=default_cd,
+        dry_run=dry_run,
+    ), False
+
+
+def _print_summary(result, heading: str) -> None:
+    document = result.document
+    defaults = document["defaults"]
+    audio = defaults["audio"]
+    engineer = defaults["mix_engineer"] or "<not set>"
+    default_cd = document["cli"]["change_directory_after_create"] is True
+    print(heading)
+    print()
+    print(f"Root:                       {result.root}")
+    print(f"Studio:                     {document['studio_name']}")
+    print(f"Engineer:                   {engineer}")
+    print(f"Audio format:               {audio['sample_rate']} Hz / {audio['bit_depth']}-bit / {audio['file_format']}")
+    print(f"Automatic directory change: {'enabled' if default_cd else 'disabled'}")
+    if default_cd:
+        shell = "active" if _truthy(os.environ.get("JL_MIXING_SHELL_INTEGRATION")) else "not detected"
+        print(f"Shell integration:           {shell}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    try:
+        request, help_only = _parse(args)
+        if help_only:
+            print(_USAGE, end="")
+            return 0
+        assert request is not None
+        result = create_studio(request)
+        default_cd = result.document["cli"]["change_directory_after_create"] is True
+        shell_active = _truthy(os.environ.get("JL_MIXING_SHELL_INTEGRATION"))
+        if request.dry_run:
+            _print_summary(result, "Dry run - no changes made.")
+            print("\nWould create:\n  Clients/\n  Studio/\n  Studio/studio.json")
+            print("\nAfter creation:\n  new-client <client-id>")
+            if default_cd and not shell_active:
+                print("\nAutomatic directory changes require JL Mixing shell integration.")
+                print("Until it is active, creation commands will print a copy-and-paste cd command.")
+            return 0
+
+        _print_summary(result, "Studio created successfully.")
+        print(f"Configuration:                {result.studio_config}")
+        if default_cd and not shell_active:
+            print("\nAutomatic directory changes require JL Mixing shell integration.")
+            print("Until it is active, creation commands will print a copy-and-paste cd command.")
+        print("\nNext:\n  new-client <client-id>")
+        return 0
+    except JLMixingError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jl_mixing/studio.py
+++ b/src/jl_mixing/studio.py
@@ -1,0 +1,127 @@
+"""Authoritative cross-platform studio workspace creation service."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from .errors import ContextError, UnsafeOperationError, ValidationError
+from .metadata import create_v11, validate_v11
+from .naming import slugify
+from .paths import assert_no_symlink_components
+from .validation import require_bit_depth, require_file_format, require_sample_rate, require_slug
+from .versions import application_root
+
+
+@dataclass(frozen=True)
+class StudioCreateRequest:
+    root: Path
+    name: str = "Mixing Studio"
+    engineer: str = ""
+    sample_rate: int = 48000
+    bit_depth: int = 24
+    file_format: str = "WAV"
+    default_cd: bool = False
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class StudioCreateResult:
+    root: Path
+    studio_config: Path
+    document: dict[str, Any]
+    created: bool
+
+
+def _native_lexical_absolute(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(str(path))))
+
+
+def _validate_schema(document: dict[str, Any]) -> None:
+    schema_path = application_root() / "schemas" / "studio.schema.json"
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(document)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContextError(f"Required studio schema is unreadable: {schema_path}") from exc
+    except jsonschema.ValidationError as exc:
+        raise ValidationError(f"Generated studio configuration failed schema validation: {exc.message}") from exc
+
+
+def create_studio(request: StudioCreateRequest) -> StudioCreateResult:
+    root = _native_lexical_absolute(request.root)
+    if root.parent == root:
+        raise UnsafeOperationError("The filesystem root cannot be used as a studio workspace.")
+    if root.exists() or root.is_symlink():
+        raise UnsafeOperationError(f"Studio root already exists: {root}")
+
+    parent = root.parent
+    if parent.is_symlink() or not parent.is_dir():
+        raise ContextError(f"Studio root parent must be an existing directory: {parent}")
+    anchor = Path(root.anchor)
+    if not anchor.exists():
+        raise ContextError(f"Studio root anchor does not exist: {anchor}")
+    assert_no_symlink_components(anchor, root)
+    if not os.access(parent, os.W_OK):
+        raise UnsafeOperationError(f"Studio root parent is not writable: {parent}")
+
+    name = request.name.strip()
+    engineer = request.engineer.strip()
+    if not name:
+        raise ValidationError("studio name must not be empty.")
+    studio_id = require_slug(slugify(name), label="Studio ID")
+    sample_rate = require_sample_rate(request.sample_rate)
+    bit_depth = require_bit_depth(request.bit_depth)
+    file_format = require_file_format(request.file_format)
+
+    document: dict[str, Any] = {
+        "metadata": create_v11("mixing-studio", mutability="mutable"),
+        "studio_id": studio_id,
+        "studio_name": name,
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": engineer,
+            "audio": {
+                "sample_rate": sample_rate,
+                "bit_depth": bit_depth,
+                "file_format": file_format,
+            },
+            "delivery": {
+                "method": "Cloud transfer",
+                "requested_deliverables": ["main_mix", "instrumental"],
+            },
+        },
+        "cli": {"change_directory_after_create": request.default_cd},
+    }
+    validate_v11(document["metadata"], "mixing-studio", mutability="mutable")
+    _validate_schema(document)
+    config = root / "Studio" / "studio.json"
+
+    if request.dry_run:
+        return StudioCreateResult(root, config, document, False)
+
+    stage = Path(tempfile.mkdtemp(prefix=f".{root.name}.jl-stage-", dir=parent))
+    try:
+        (stage / "Clients").mkdir()
+        (stage / "Studio").mkdir()
+        (stage / "Studio" / "studio.json").write_text(
+            json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        if root.exists() or root.is_symlink():
+            raise UnsafeOperationError(f"Studio root already exists: {root}")
+        os.replace(stage, root)
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+    return StudioCreateResult(root, config, document, True)

--- a/tests/python/test_new_studio_cli.py
+++ b/tests/python/test_new_studio_cli.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def run_cli(cwd: Path, *args: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.new_studio_cli", *args],
+        cwd=cwd, env=env, text=True, capture_output=True, check=False,
+    )
+
+
+class NewStudioCliTests(unittest.TestCase):
+    def test_help_matches_human_command_surface(self) -> None:
+        proc = run_cli(ROOT, "--help")
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("Usage: new-studio", proc.stdout)
+        self.assertIn("--default-cd", proc.stdout)
+        self.assertIn("--no-default-cd", proc.stdout)
+
+    def test_dry_run_is_non_mutating_and_reports_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp)
+            target = parent / "My Studio"
+            proc = run_cli(
+                parent,
+                "--root", str(target),
+                "--name", "My Studio",
+                "--engineer", "Mix Engineer",
+                "--sample-rate", "96000",
+                "--bit-depth", "32",
+                "--file-format", "aiff",
+                "--default-cd",
+                "--dry-run",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Dry run - no changes made.", proc.stdout)
+            self.assertIn("Studio:                     My Studio", proc.stdout)
+            self.assertIn("Audio format:               96000 Hz / 32-bit / AIFF", proc.stdout)
+            self.assertIn("Automatic directory change: enabled", proc.stdout)
+            self.assertIn("Shell integration:           not detected", proc.stdout)
+            self.assertIn("Studio/studio.json", proc.stdout)
+            self.assertFalse(target.exists())
+
+    def test_create_writes_minimal_workspace_and_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp)
+            target = parent / "Studio Root"
+            proc = run_cli(parent, "--root", str(target), "--name", "JL Room", "--engineer", "Jake", "--no-default-cd")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Studio created successfully.", proc.stdout)
+            self.assertTrue((target / "Clients").is_dir())
+            self.assertTrue((target / "Studio").is_dir())
+            config_path = target / "Studio" / "studio.json"
+            self.assertTrue(config_path.is_file())
+            document = json.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(document["metadata"]["schema"], "mixing-studio")
+            self.assertEqual(document["metadata"]["schema_version"], "1.1.0")
+            self.assertEqual(document["studio_id"], "jl-room")
+            self.assertEqual(document["root_path"], str(target.resolve()))
+            self.assertEqual(document["defaults"]["mix_engineer"], "Jake")
+            self.assertFalse(document["cli"]["change_directory_after_create"])
+            self.assertEqual(sorted(path.name for path in target.iterdir()), ["Clients", "Studio"])
+
+    def test_existing_root_is_refused_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "existing"
+            target.mkdir()
+            marker = target / "keep.txt"
+            marker.write_text("keep", encoding="utf-8")
+            proc = run_cli(Path(tmp), "--root", str(target))
+            self.assertEqual(proc.returncode, 6)
+            self.assertIn("Studio root already exists", proc.stderr)
+            self.assertEqual(marker.read_text(encoding="utf-8"), "keep")
+
+    def test_validation_and_argument_conflicts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp)
+            cases = (
+                (5, ("--root", str(parent / "a"), "--sample-rate", "12345")),
+                (5, ("--root", str(parent / "b"), "--bit-depth", "20")),
+                (5, ("--root", str(parent / "c"), "--file-format", "mp3")),
+                (2, ("--root", str(parent / "d"), "--default-cd", "--no-default-cd")),
+            )
+            for expected, args in cases:
+                proc = run_cli(parent, *args)
+                self.assertEqual(proc.returncode, expected, proc.stderr)
+
+    def test_removed_options_keep_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp)
+            for option, text in {
+                "--daw": "DAW projects and templates are no longer managed",
+                "--non-interactive": "without prompting",
+            }.items():
+                proc = run_cli(parent, "--root", str(parent / option.removeprefix("--")), option)
+                self.assertEqual(proc.returncode, 2)
+                self.assertIn(text, proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_new_studio_cli.py
+++ b/tests/python/test_new_studio_cli.py
@@ -70,7 +70,7 @@ class NewStudioCliTests(unittest.TestCase):
             self.assertEqual(document["metadata"]["schema"], "mixing-studio")
             self.assertEqual(document["metadata"]["schema_version"], "1.1.0")
             self.assertEqual(document["studio_id"], "jl-room")
-            self.assertEqual(document["root_path"], str(target.resolve()))
+            self.assertEqual(document["root_path"], os.path.abspath(os.path.expanduser(str(target))))
             self.assertEqual(document["defaults"]["mix_engineer"], "Jake")
             self.assertFalse(document["cli"]["change_directory_after_create"])
             self.assertEqual(sorted(path.name for path in target.iterdir()), ["Clients", "Studio"])


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 Windows support under #71 by porting studio workspace creation and the human `new-studio` command into the cross-platform Python runtime.

## Changes

- add authoritative Python studio creation service
- preserve minimal workspace layout: only `Clients/` and `Studio/studio.json`
- preserve strict refusal of any existing destination
- preserve studio name/ID, engineer, audio defaults, default-CD preference, and v1.1 metadata/schema identity
- preserve removed `--daw` and `--non-interactive` guidance
- normalize native workspace paths without silently dereferencing symlinked parent components
- stage beside the requested workspace and atomically rename into place
- use Windows-safe human output and shell-integration reporting
- expose transitional `new-studio-python` entry point without changing the installed v1.4 launcher yet
- add native Windows/macOS/Linux tests for dry-run, workspace creation, configuration contents, existing-root refusal, validation, conflicts, and removed options

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- installed Bash `new-studio` remains authoritative until launcher cutover

Part of #71.