### PR TITLE
Add v1.5 Windows installer lifecycle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         run: make strict-test
 
   windows-python:
-    # Exercise the v1.5 authoritative Python runtime and native command glue on Windows.
+    # Exercise the v1.5 authoritative Python runtime, native command glue, and installer on Windows.
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,3 +49,6 @@ jobs:
       - name: Run native Windows command surface tests
         shell: pwsh
         run: ./tests/windows/test-command-surface.ps1
+      - name: Run Windows installation lifecycle tests
+        shell: pwsh
+        run: ./tests/windows/test-installation.ps1

--- a/tests/windows/test-installation.ps1
+++ b/tests/windows/test-installation.ps1
@@ -1,0 +1,93 @@
+$ErrorActionPreference = 'Stop'
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw "[FAIL] $Message" }
+    Write-Output "[PASS] $Message"
+}
+
+$root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+$python = (Get-Command python.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("jl-mixing-windows-install-{0}" -f [Guid]::NewGuid().ToString('N'))
+$prefix = Join-Path $tempRoot 'prefix'
+$profile = Join-Path $tempRoot 'profile\Microsoft.PowerShell_profile.ps1'
+$workspace = Join-Path $tempRoot 'workspace'
+$originalPath = $env:PATH
+$originalTestPython = $env:JL_MIXING_TEST_PYTHON
+$originalTestProfile = $env:JL_MIXING_TEST_PROFILE
+$originalRoot = $env:JL_MIXING_ROOT
+$originalFailure = $env:JL_MIXING_TEST_FAIL_INSTALL_AT
+
+try {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $profile) | Out-Null
+    Set-Content -LiteralPath $profile -Value "# user profile content`r`n" -NoNewline -Encoding utf8
+    $env:JL_MIXING_TEST_PYTHON = $python
+    $env:JL_MIXING_TEST_PROFILE = $profile
+
+    & (Join-Path $root 'windows\install.ps1') -Prefix $prefix | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'Windows installer succeeds with CI test runtime'
+
+    $app = Join-Path $prefix 'share\jl-mixing'
+    $bin = Join-Path $prefix 'bin'
+    Assert-True (Test-Path -LiteralPath (Join-Path $app 'VERSION') -PathType Leaf) 'installed application contains VERSION'
+    Assert-True (Test-Path -LiteralPath (Join-Path $app 'src\jl_mixing\__init__.py') -PathType Leaf) 'installed application contains Python package'
+    Assert-True (Test-Path -LiteralPath (Join-Path $bin 'jl-mixing.cmd') -PathType Leaf) 'installed jl-mixing launcher exists'
+    Assert-True (Test-Path -LiteralPath (Join-Path $bin 'jl-mixing-shell-integration.ps1') -PathType Leaf) 'installed PowerShell integration exists'
+
+    $state = Get-Content -LiteralPath (Join-Path $app 'install-state.json') -Raw | ConvertFrom-Json
+    Assert-True ($state.installation_prefix -eq [IO.Path]::GetFullPath($prefix)) 'install state records prefix'
+    Assert-True ($state.shell_integration.enabled -eq $true) 'install state records shell integration'
+    Assert-True ($state.test_runtime -eq $true) 'CI install state records test runtime mode'
+
+    $profileText = Get-Content -LiteralPath $profile -Raw
+    Assert-True ($profileText -match '# user profile content') 'installer preserves user PowerShell profile content'
+    Assert-True (([regex]::Matches($profileText, '# >>> JL Mixing managed configuration >>>')).Count -eq 1) 'installer adds one managed PowerShell block'
+
+    $env:PATH = "$bin;$originalPath"
+    $systemInfoText = & (Join-Path $bin 'jl-mixing.cmd') system-info --json | Out-String
+    Assert-True ($LASTEXITCODE -eq 0) 'installed jl-mixing launcher runs'
+    $systemInfo = $systemInfoText | ConvertFrom-Json
+    Assert-True ($systemInfo.api_version -eq '1.0') 'installed dispatcher reports API 1.0'
+
+    & (Join-Path $bin 'new-studio.cmd') --root $workspace --name 'Installed Windows Studio' --no-default-cd | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'installed new-studio creates workspace'
+    Assert-True (Test-Path -LiteralPath (Join-Path $workspace 'Studio\studio.json') -PathType Leaf) 'installed new-studio writes configuration'
+
+    $env:JL_MIXING_ROOT = $workspace
+    & (Join-Path $bin 'new-client.cmd') installed-client --name 'Installed Client' --no-cd | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'installed new-client creates client'
+    Assert-True (Test-Path -LiteralPath (Join-Path $workspace 'Clients\Installed Client\client.json') -PathType Leaf) 'installed client configuration exists'
+
+    & (Join-Path $root 'windows\install.ps1') -Prefix $prefix | Out-Null
+    $profileText = Get-Content -LiteralPath $profile -Raw
+    Assert-True (([regex]::Matches($profileText, '# >>> JL Mixing managed configuration >>>')).Count -eq 1) 'reinstall keeps one managed PowerShell block'
+
+    $sentinel = Join-Path $app 'rollback-sentinel.txt'
+    Set-Content -LiteralPath $sentinel -Value 'stable' -Encoding utf8
+    $env:JL_MIXING_TEST_FAIL_INSTALL_AT = 'after-application'
+    & (Join-Path $root 'windows\install.ps1') -Prefix $prefix 2>$null | Out-Null
+    Assert-True ($LASTEXITCODE -ne 0) 'injected Windows install failure is reported'
+    Remove-Item Env:JL_MIXING_TEST_FAIL_INSTALL_AT -ErrorAction SilentlyContinue
+    Assert-True (Test-Path -LiteralPath $sentinel -PathType Leaf) 'failed reinstall restores previous application'
+    Assert-True ((Get-Content -LiteralPath $sentinel -Raw).Trim() -eq 'stable') 'rollback preserves previous application bytes'
+    Assert-True ((Get-Content -LiteralPath $profile -Raw) -match '# user profile content') 'rollback preserves PowerShell profile content'
+
+    & (Join-Path $app 'windows\uninstall.ps1') -Prefix $prefix | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'Windows uninstaller succeeds'
+    Assert-True (-not (Test-Path -LiteralPath $app)) 'uninstaller removes application'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $bin 'jl-mixing.cmd'))) 'uninstaller removes managed launcher'
+    Assert-True (Test-Path -LiteralPath (Join-Path $workspace 'Studio\studio.json') -PathType Leaf) 'uninstaller preserves studio workspace'
+    $profileText = Get-Content -LiteralPath $profile -Raw
+    Assert-True ($profileText -match '# user profile content') 'uninstaller preserves user profile content'
+    Assert-True ($profileText -notmatch '# >>> JL Mixing managed configuration >>>') 'uninstaller removes managed PowerShell block'
+
+    $global:LASTEXITCODE = 0
+    Write-Output '[OK] Windows installation lifecycle'
+} finally {
+    $env:PATH = $originalPath
+    if ($null -eq $originalTestPython) { Remove-Item Env:JL_MIXING_TEST_PYTHON -ErrorAction SilentlyContinue } else { $env:JL_MIXING_TEST_PYTHON = $originalTestPython }
+    if ($null -eq $originalTestProfile) { Remove-Item Env:JL_MIXING_TEST_PROFILE -ErrorAction SilentlyContinue } else { $env:JL_MIXING_TEST_PROFILE = $originalTestProfile }
+    if ($null -eq $originalRoot) { Remove-Item Env:JL_MIXING_ROOT -ErrorAction SilentlyContinue } else { $env:JL_MIXING_ROOT = $originalRoot }
+    if ($null -eq $originalFailure) { Remove-Item Env:JL_MIXING_TEST_FAIL_INSTALL_AT -ErrorAction SilentlyContinue } else { $env:JL_MIXING_TEST_FAIL_INSTALL_AT = $originalFailure }
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/windows/test-installation.ps1
+++ b/tests/windows/test-installation.ps1
@@ -8,6 +8,7 @@ function Assert-True {
 
 $root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
 $python = (Get-Command python.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+$pwsh = (Get-Command pwsh.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
 $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("jl-mixing-windows-install-{0}" -f [Guid]::NewGuid().ToString('N'))
 $prefix = Join-Path $tempRoot 'prefix'
 $profile = Join-Path $tempRoot 'profile\Microsoft.PowerShell_profile.ps1'
@@ -24,7 +25,7 @@ try {
     $env:JL_MIXING_TEST_PYTHON = $python
     $env:JL_MIXING_TEST_PROFILE = $profile
 
-    & (Join-Path $root 'windows\install.ps1') -Prefix $prefix | Out-Null
+    & $pwsh -NoProfile -File (Join-Path $root 'windows\install.ps1') -Prefix $prefix | Out-Null
     Assert-True ($LASTEXITCODE -eq 0) 'Windows installer succeeds with CI test runtime'
 
     $app = Join-Path $prefix 'share\jl-mixing'
@@ -58,21 +59,22 @@ try {
     Assert-True ($LASTEXITCODE -eq 0) 'installed new-client creates client'
     Assert-True (Test-Path -LiteralPath (Join-Path $workspace 'Clients\Installed Client\client.json') -PathType Leaf) 'installed client configuration exists'
 
-    & (Join-Path $root 'windows\install.ps1') -Prefix $prefix | Out-Null
+    & $pwsh -NoProfile -File (Join-Path $root 'windows\install.ps1') -Prefix $prefix | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'Windows reinstall succeeds'
     $profileText = Get-Content -LiteralPath $profile -Raw
     Assert-True (([regex]::Matches($profileText, '# >>> JL Mixing managed configuration >>>')).Count -eq 1) 'reinstall keeps one managed PowerShell block'
 
     $sentinel = Join-Path $app 'rollback-sentinel.txt'
     Set-Content -LiteralPath $sentinel -Value 'stable' -Encoding utf8
     $env:JL_MIXING_TEST_FAIL_INSTALL_AT = 'after-application'
-    & (Join-Path $root 'windows\install.ps1') -Prefix $prefix 2>$null | Out-Null
+    & $pwsh -NoProfile -File (Join-Path $root 'windows\install.ps1') -Prefix $prefix 2>$null | Out-Null
     Assert-True ($LASTEXITCODE -ne 0) 'injected Windows install failure is reported'
     Remove-Item Env:JL_MIXING_TEST_FAIL_INSTALL_AT -ErrorAction SilentlyContinue
     Assert-True (Test-Path -LiteralPath $sentinel -PathType Leaf) 'failed reinstall restores previous application'
     Assert-True ((Get-Content -LiteralPath $sentinel -Raw).Trim() -eq 'stable') 'rollback preserves previous application bytes'
     Assert-True ((Get-Content -LiteralPath $profile -Raw) -match '# user profile content') 'rollback preserves PowerShell profile content'
 
-    & (Join-Path $app 'windows\uninstall.ps1') -Prefix $prefix | Out-Null
+    & $pwsh -NoProfile -File (Join-Path $app 'windows\uninstall.ps1') -Prefix $prefix | Out-Null
     Assert-True ($LASTEXITCODE -eq 0) 'Windows uninstaller succeeds'
     Assert-True (-not (Test-Path -LiteralPath $app)) 'uninstaller removes application'
     Assert-True (-not (Test-Path -LiteralPath (Join-Path $bin 'jl-mixing.cmd'))) 'uninstaller removes managed launcher'

--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -1,0 +1,249 @@
+[CmdletBinding()]
+param(
+    [string]$Prefix,
+    [switch]$NoShellIntegration
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail([string]$Message, [int]$Code = 1) {
+    [Console]::Error.WriteLine("Error: $Message")
+    exit $Code
+}
+
+function Get-DefaultPrefix {
+    if (-not [string]::IsNullOrWhiteSpace($env:JL_MIXING_INSTALL_PREFIX)) {
+        return $env:JL_MIXING_INSTALL_PREFIX
+    }
+    if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        Fail 'LOCALAPPDATA is not available; supply -Prefix explicitly.' 3
+    }
+    return (Join-Path $env:LOCALAPPDATA 'Programs\JL Mixing')
+}
+
+function Test-ManagedLauncher([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
+    return ((Get-Content -LiteralPath $Path -Raw) -match 'JL Mixing Automation managed Windows launcher')
+}
+
+function Get-ProfileTarget {
+    if (-not [string]::IsNullOrWhiteSpace($env:JL_MIXING_TEST_PROFILE)) {
+        return [IO.Path]::GetFullPath($env:JL_MIXING_TEST_PROFILE)
+    }
+    return [IO.Path]::GetFullPath($PROFILE.CurrentUserAllHosts)
+}
+
+function Remove-ManagedProfileBlock([string]$Text) {
+    $begin = '# >>> JL Mixing managed configuration >>>'
+    $end = '# <<< JL Mixing managed configuration <<<'
+    $start = $Text.IndexOf($begin, [StringComparison]::Ordinal)
+    if ($start -lt 0) { return $Text }
+    $finish = $Text.IndexOf($end, $start, [StringComparison]::Ordinal)
+    if ($finish -lt 0) { throw 'PowerShell profile contains an incomplete JL Mixing managed block.' }
+    $finish += $end.Length
+    while ($finish -lt $Text.Length -and ($Text[$finish] -eq "`r" -or $Text[$finish] -eq "`n")) { $finish++ }
+    return ($Text.Remove($start, $finish - $start)).TrimEnd("`r", "`n") + $(if ($start -gt 0) { "`r`n" } else { '' })
+}
+
+function New-ManagedProfileText([string]$Existing, [string]$BinDir) {
+    $clean = Remove-ManagedProfileBlock $Existing
+    if ($clean.Length -gt 0 -and -not $clean.EndsWith("`n")) { $clean += "`r`n" }
+    $escaped = $BinDir.Replace("'", "''")
+    $block = @"
+# >>> JL Mixing managed configuration >>>
+`$jlMixingBin = '$escaped'
+if (-not ((`$env:PATH -split ';') -contains `$jlMixingBin)) {
+    `$env:PATH = "`$jlMixingBin;`$env:PATH"
+}
+`$jlMixingIntegration = Join-Path `$jlMixingBin 'jl-mixing-shell-integration.ps1'
+if (Test-Path -LiteralPath `$jlMixingIntegration -PathType Leaf) {
+    . `$jlMixingIntegration
+}
+# <<< JL Mixing managed configuration <<<
+"@
+    return $clean + $block
+}
+
+function Maybe-Fail([string]$Point) {
+    if ($env:JL_MIXING_TEST_FAIL_INSTALL_AT -eq $Point) {
+        throw "injected installation failure at $Point"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($Prefix)) { $Prefix = Get-DefaultPrefix }
+$Prefix = [IO.Path]::GetFullPath($Prefix)
+$SourceRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$AppDir = Join-Path $Prefix 'share\jl-mixing'
+$BinDir = Join-Path $Prefix 'bin'
+$ProfilePath = Get-ProfileTarget
+
+$required = @('VERSION','API_VERSION','LICENSE','README.md','CHANGELOG.md','src','api','schemas','templates','docs','windows\bin')
+foreach ($relative in $required) {
+    if (-not (Test-Path -LiteralPath (Join-Path $SourceRoot $relative))) {
+        Fail "installation package is missing $relative" 3
+    }
+}
+
+$bundledPython = Join-Path $SourceRoot 'runtime\python.exe'
+$testPython = $env:JL_MIXING_TEST_PYTHON
+$usingTestRuntime = $false
+if (Test-Path -LiteralPath $bundledPython -PathType Leaf) {
+    $runtimeSource = Join-Path $SourceRoot 'runtime'
+} elseif (-not [string]::IsNullOrWhiteSpace($testPython) -and (Test-Path -LiteralPath $testPython -PathType Leaf)) {
+    $usingTestRuntime = $true
+    $runtimeSource = $null
+    $testPython = [IO.Path]::GetFullPath($testPython)
+} else {
+    Fail 'installation package does not contain runtime\python.exe.' 3
+}
+
+$publicCommands = @('jl-mixing','new-studio','new-client','new-mix','validate-intake','new-revision','approve-mix','create-delivery')
+New-Item -ItemType Directory -Force -Path $Prefix, $BinDir | Out-Null
+foreach ($command in $publicCommands) {
+    $destination = Join-Path $BinDir "$command.cmd"
+    if ((Test-Path -LiteralPath $destination) -and -not (Test-ManagedLauncher $destination)) {
+        Fail "refusing to overwrite unmanaged command: $destination" 5
+    }
+}
+
+$integrationDestination = Join-Path $BinDir 'jl-mixing-shell-integration.ps1'
+if ((Test-Path -LiteralPath $integrationDestination) -and ((Get-Content -LiteralPath $integrationDestination -Raw) -notmatch 'JL Mixing Automation managed PowerShell integration')) {
+    Fail "refusing to overwrite unmanaged shell integration: $integrationDestination" 5
+}
+
+$stageRoot = Join-Path $Prefix ('.jl-mixing-install-stage-' + [Guid]::NewGuid().ToString('N'))
+$backupRoot = Join-Path $Prefix ('.jl-mixing-install-backup-' + [Guid]::NewGuid().ToString('N'))
+$stageApp = Join-Path $stageRoot 'share\jl-mixing'
+$stageBin = Join-Path $stageRoot 'bin'
+$profileExisted = Test-Path -LiteralPath $ProfilePath -PathType Leaf
+$profileOriginal = if ($profileExisted) { Get-Content -LiteralPath $ProfilePath -Raw } else { '' }
+$commitStarted = $false
+
+try {
+    New-Item -ItemType Directory -Force -Path $stageApp, $stageBin | Out-Null
+    foreach ($file in @('VERSION','API_VERSION','LICENSE','README.md','CHANGELOG.md')) {
+        Copy-Item -LiteralPath (Join-Path $SourceRoot $file) -Destination $stageApp
+    }
+    foreach ($directory in @('src','api','schemas','templates','docs','windows')) {
+        Copy-Item -LiteralPath (Join-Path $SourceRoot $directory) -Destination $stageApp -Recurse
+    }
+    if (-not $usingTestRuntime) {
+        Copy-Item -LiteralPath $runtimeSource -Destination (Join-Path $stageApp 'runtime') -Recurse
+    }
+
+    foreach ($command in $publicCommands) {
+        $launcher = Join-Path $stageBin "$command.cmd"
+        $pythonLine = if ($usingTestRuntime) {
+            'set "JL_MIXING_PYTHON=' + $testPython + '"'
+        } else {
+            'set "JL_MIXING_PYTHON=%JL_MIXING_HOME%\runtime\python.exe"'
+        }
+        @"
+@echo off
+rem JL Mixing Automation managed Windows launcher. Generated by windows\install.ps1.
+setlocal
+for %%I in ("%~dp0..\share\jl-mixing") do set "JL_MIXING_HOME=%%~fI"
+$pythonLine
+call "%JL_MIXING_HOME%\windows\bin\$command.cmd" %*
+exit /b %ERRORLEVEL%
+"@ | Set-Content -LiteralPath $launcher -Encoding ascii
+    }
+    Copy-Item -LiteralPath (Join-Path $SourceRoot 'windows\bin\jl-mixing-shell-integration.ps1') -Destination $stageBin
+
+    $state = [ordered]@{
+        installation_prefix = $Prefix
+        shell_integration = [ordered]@{
+            enabled = -not $NoShellIntegration.IsPresent
+            profile = if ($NoShellIntegration) { '' } else { $ProfilePath }
+            profile_created = (-not $profileExisted)
+        }
+        test_runtime = $usingTestRuntime
+    }
+    $state | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $stageApp 'install-state.json') -Encoding utf8
+
+    if (-not (Test-Path -LiteralPath (Join-Path $stageApp 'src\jl_mixing\__init__.py') -PathType Leaf)) { throw 'staged Python package is incomplete' }
+    foreach ($command in $publicCommands) {
+        if (-not (Test-Path -LiteralPath (Join-Path $stageBin "$command.cmd") -PathType Leaf)) { throw "staged launcher missing: $command" }
+    }
+
+    $stagedProfile = $null
+    if (-not $NoShellIntegration) {
+        $stagedProfile = New-ManagedProfileText $profileOriginal $BinDir
+    }
+
+    New-Item -ItemType Directory -Force -Path $backupRoot, (Join-Path $backupRoot 'bin') | Out-Null
+    if (Test-Path -LiteralPath $AppDir) { Move-Item -LiteralPath $AppDir -Destination (Join-Path $backupRoot 'app') }
+    foreach ($command in $publicCommands) {
+        $existing = Join-Path $BinDir "$command.cmd"
+        if (Test-Path -LiteralPath $existing -PathType Leaf) { Copy-Item -LiteralPath $existing -Destination (Join-Path $backupRoot 'bin') }
+    }
+    if (Test-Path -LiteralPath $integrationDestination -PathType Leaf) { Copy-Item -LiteralPath $integrationDestination -Destination (Join-Path $backupRoot 'bin') }
+    if ($profileExisted) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent (Join-Path $backupRoot 'profile')) | Out-Null
+        Set-Content -LiteralPath (Join-Path $backupRoot 'profile') -Value $profileOriginal -NoNewline -Encoding utf8
+    }
+    $commitStarted = $true
+
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $AppDir), $BinDir | Out-Null
+    Move-Item -LiteralPath $stageApp -Destination $AppDir
+    Maybe-Fail 'after-application'
+    foreach ($command in $publicCommands) {
+        Copy-Item -LiteralPath (Join-Path $stageBin "$command.cmd") -Destination (Join-Path $BinDir "$command.cmd") -Force
+    }
+    Copy-Item -LiteralPath (Join-Path $stageBin 'jl-mixing-shell-integration.ps1') -Destination $integrationDestination -Force
+    Maybe-Fail 'after-launchers'
+
+    if (-not $NoShellIntegration) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $ProfilePath) | Out-Null
+        Set-Content -LiteralPath $ProfilePath -Value $stagedProfile -NoNewline -Encoding utf8
+    }
+    Maybe-Fail 'after-profile'
+
+    if (-not (Test-Path -LiteralPath (Join-Path $AppDir 'VERSION') -PathType Leaf)) { throw 'installed application verification failed' }
+    if (-not $usingTestRuntime -and -not (Test-Path -LiteralPath (Join-Path $AppDir 'runtime\python.exe') -PathType Leaf)) { throw 'installed runtime verification failed' }
+
+    Remove-Item -LiteralPath $backupRoot -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+    $commitStarted = $false
+} catch {
+    $failure = $_
+    if ($commitStarted) {
+        Remove-Item -LiteralPath $AppDir -Recurse -Force -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath (Join-Path $backupRoot 'app') -PathType Container) {
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $AppDir) | Out-Null
+            Move-Item -LiteralPath (Join-Path $backupRoot 'app') -Destination $AppDir
+        }
+        foreach ($command in $publicCommands) {
+            $destination = Join-Path $BinDir "$command.cmd"
+            Remove-Item -LiteralPath $destination -Force -ErrorAction SilentlyContinue
+            $backup = Join-Path $backupRoot "bin\$command.cmd"
+            if (Test-Path -LiteralPath $backup -PathType Leaf) { Copy-Item -LiteralPath $backup -Destination $destination }
+        }
+        Remove-Item -LiteralPath $integrationDestination -Force -ErrorAction SilentlyContinue
+        $integrationBackup = Join-Path $backupRoot 'bin\jl-mixing-shell-integration.ps1'
+        if (Test-Path -LiteralPath $integrationBackup -PathType Leaf) { Copy-Item -LiteralPath $integrationBackup -Destination $integrationDestination }
+        if (-not $NoShellIntegration) {
+            if ($profileExisted) {
+                Set-Content -LiteralPath $ProfilePath -Value $profileOriginal -NoNewline -Encoding utf8
+            } else {
+                Remove-Item -LiteralPath $ProfilePath -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $backupRoot -Recurse -Force -ErrorAction SilentlyContinue
+    [Console]::Error.WriteLine("Installation failed; previous installation restored.")
+    [Console]::Error.WriteLine("Error: $($failure.Exception.Message)")
+    exit 1
+}
+
+$version = (Get-Content -LiteralPath (Join-Path $AppDir 'VERSION') -Raw).Trim()
+Write-Output "Installed JL Mixing Automation $version"
+Write-Output "Application: $AppDir"
+Write-Output "Commands:    $BinDir"
+if ($NoShellIntegration) {
+    Write-Output 'PowerShell profile: not modified (-NoShellIntegration)'
+} else {
+    Write-Output "PowerShell profile: $ProfilePath"
+    Write-Output 'Open a new PowerShell session to activate JL Mixing shell integration.'
+}

--- a/windows/uninstall.ps1
+++ b/windows/uninstall.ps1
@@ -1,0 +1,97 @@
+[CmdletBinding()]
+param(
+    [string]$Prefix
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail([string]$Message, [int]$Code = 1) {
+    [Console]::Error.WriteLine("Error: $Message")
+    exit $Code
+}
+
+function Get-DefaultPrefix {
+    if (-not [string]::IsNullOrWhiteSpace($env:JL_MIXING_INSTALL_PREFIX)) {
+        return $env:JL_MIXING_INSTALL_PREFIX
+    }
+    if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        Fail 'LOCALAPPDATA is not available; supply -Prefix explicitly.' 3
+    }
+    return (Join-Path $env:LOCALAPPDATA 'Programs\JL Mixing')
+}
+
+function Test-ManagedLauncher([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
+    return ((Get-Content -LiteralPath $Path -Raw) -match 'JL Mixing Automation managed Windows launcher')
+}
+
+function Remove-ManagedProfileBlock([string]$Text) {
+    $begin = '# >>> JL Mixing managed configuration >>>'
+    $end = '# <<< JL Mixing managed configuration <<<'
+    $start = $Text.IndexOf($begin, [StringComparison]::Ordinal)
+    if ($start -lt 0) { return $Text }
+    $finish = $Text.IndexOf($end, $start, [StringComparison]::Ordinal)
+    if ($finish -lt 0) { throw 'PowerShell profile contains an incomplete JL Mixing managed block.' }
+    $finish += $end.Length
+    while ($finish -lt $Text.Length -and ($Text[$finish] -eq "`r" -or $Text[$finish] -eq "`n")) { $finish++ }
+    $before = $Text.Substring(0, $start).TrimEnd("`r", "`n")
+    $after = $Text.Substring($finish).TrimStart("`r", "`n")
+    if ($before.Length -gt 0 -and $after.Length -gt 0) { return "$before`r`n$after" }
+    return $before + $after
+}
+
+if ([string]::IsNullOrWhiteSpace($Prefix)) { $Prefix = Get-DefaultPrefix }
+$Prefix = [IO.Path]::GetFullPath($Prefix)
+$AppDir = Join-Path $Prefix 'share\jl-mixing'
+$BinDir = Join-Path $Prefix 'bin'
+$StateFile = Join-Path $AppDir 'install-state.json'
+
+$state = $null
+if (Test-Path -LiteralPath $StateFile -PathType Leaf) {
+    try { $state = Get-Content -LiteralPath $StateFile -Raw | ConvertFrom-Json } catch { Fail 'install-state.json is invalid; refusing unsafe uninstall.' 5 }
+}
+
+$publicCommands = @('jl-mixing','new-studio','new-client','new-mix','validate-intake','new-revision','approve-mix','create-delivery')
+foreach ($command in $publicCommands) {
+    $path = Join-Path $BinDir "$command.cmd"
+    if (Test-Path -LiteralPath $path) {
+        if (-not (Test-ManagedLauncher $path)) { Fail "refusing to remove unmanaged command: $path" 5 }
+        Remove-Item -LiteralPath $path -Force
+    }
+}
+
+$integration = Join-Path $BinDir 'jl-mixing-shell-integration.ps1'
+if (Test-Path -LiteralPath $integration -PathType Leaf) {
+    $text = Get-Content -LiteralPath $integration -Raw
+    if ($text -notmatch 'JL Mixing Automation managed PowerShell integration') {
+        Fail "refusing to remove unmanaged shell integration: $integration" 5
+    }
+    Remove-Item -LiteralPath $integration -Force
+}
+
+if ($null -ne $state -and $state.shell_integration.enabled -eq $true -and -not [string]::IsNullOrWhiteSpace([string]$state.shell_integration.profile)) {
+    $profilePath = [IO.Path]::GetFullPath([string]$state.shell_integration.profile)
+    if (Test-Path -LiteralPath $profilePath -PathType Leaf) {
+        $original = Get-Content -LiteralPath $profilePath -Raw
+        $clean = Remove-ManagedProfileBlock $original
+        if ($state.shell_integration.profile_created -eq $true -and [string]::IsNullOrWhiteSpace($clean)) {
+            Remove-Item -LiteralPath $profilePath -Force
+        } else {
+            Set-Content -LiteralPath $profilePath -Value $clean -NoNewline -Encoding utf8
+        }
+    }
+}
+
+if (Test-Path -LiteralPath $AppDir) {
+    Remove-Item -LiteralPath $AppDir -Recurse -Force
+}
+
+foreach ($directory in @((Join-Path $Prefix 'share'), $BinDir, $Prefix)) {
+    if (Test-Path -LiteralPath $directory -PathType Container) {
+        $remaining = @(Get-ChildItem -LiteralPath $directory -Force)
+        if ($remaining.Count -eq 0) { Remove-Item -LiteralPath $directory -Force }
+    }
+}
+
+Write-Output 'JL Mixing Automation uninstalled.'
+Write-Output 'Studio workspaces were not modified.'


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 cross-platform work under #71 by adding the transactional Windows install/uninstall lifecycle on top of the native command surface merged in #96.

## Changes

- add `windows/install.ps1` with staged application installation, managed command launchers, PowerShell profile integration, collision protection, and rollback on commit failure
- require a package-bundled `runtime\python.exe` for production installs
- allow an explicit `JL_MIXING_TEST_PYTHON` override only for CI so installer semantics can be tested before the final self-contained runtime packaging slice
- add `windows/uninstall.ps1` that removes only JL-managed application/launcher/profile state and preserves studio workspaces
- add a Windows lifecycle test covering install, installed API/CLI execution, reinstall idempotence, injected rollback, uninstall, and workspace/profile preservation
- run the lifecycle test in the native Windows CI job

## Compatibility

- authoritative workflow code remains in `src/jl_mixing`
- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no workspace migration or workflow redesign
- final bundled-runtime construction remains a separate packaging slice

Part of #71.