### PR TITLE
Bundle self-contained Windows runtime for v1.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,8 @@ jobs:
         run: make strict-test
 
   windows-python:
-    # Exercise the v1.5 authoritative Python runtime, native command glue, and installer on Windows.
+    # Exercise the v1.5 authoritative Python runtime, native command glue,
+    # self-contained runtime bundle, and installer on Windows.
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +43,8 @@ jobs:
           python-version: '3.12'
       - name: Install Python validation dependency
         run: python -m pip install -r packaging/requirements.txt
+      - name: Install Windows runtime bundler
+        run: python -m pip install -r packaging/windows-build-requirements.txt
       - name: Run v1.5 Python runtime tests
         env:
           PYTHONPATH: ${{ github.workspace }}\src
@@ -49,6 +52,12 @@ jobs:
       - name: Run native Windows command surface tests
         shell: pwsh
         run: ./tests/windows/test-command-surface.ps1
+      - name: Build self-contained Windows runtime
+        shell: pwsh
+        run: ./windows/build-runtime.ps1
+      - name: Run bundled Windows runtime smoke tests
+        shell: pwsh
+        run: ./tests/windows/test-runtime-bundle.ps1
       - name: Run Windows installation lifecycle tests
         shell: pwsh
         run: ./tests/windows/test-installation.ps1

--- a/packaging/windows-build-requirements.txt
+++ b/packaging/windows-build-requirements.txt
@@ -1,0 +1,1 @@
+pyinstaller==6.21.0

--- a/tests/windows/test-installation.ps1
+++ b/tests/windows/test-installation.ps1
@@ -9,6 +9,7 @@ function Assert-True {
 $root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
 $python = (Get-Command python.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
 $pwsh = (Get-Command pwsh.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+$bundledRuntime = Join-Path $root 'runtime\python.exe'
 $tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("jl-mixing-windows-install-{0}" -f [Guid]::NewGuid().ToString('N'))
 $prefix = Join-Path $tempRoot 'prefix'
 $profile = Join-Path $tempRoot 'profile\Microsoft.PowerShell_profile.ps1'
@@ -22,11 +23,17 @@ $originalFailure = $env:JL_MIXING_TEST_FAIL_INSTALL_AT
 try {
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $profile) | Out-Null
     Set-Content -LiteralPath $profile -Value "# user profile content`r`n" -NoNewline -Encoding utf8
-    $env:JL_MIXING_TEST_PYTHON = $python
     $env:JL_MIXING_TEST_PROFILE = $profile
 
+    $expectedTestRuntime = -not (Test-Path -LiteralPath $bundledRuntime -PathType Leaf)
+    if ($expectedTestRuntime) {
+        $env:JL_MIXING_TEST_PYTHON = $python
+    } else {
+        Remove-Item Env:JL_MIXING_TEST_PYTHON -ErrorAction SilentlyContinue
+    }
+
     & $pwsh -NoProfile -File (Join-Path $root 'windows\install.ps1') -Prefix $prefix | Out-Null
-    Assert-True ($LASTEXITCODE -eq 0) 'Windows installer succeeds with CI test runtime'
+    Assert-True ($LASTEXITCODE -eq 0) 'Windows installer succeeds'
 
     $app = Join-Path $prefix 'share\jl-mixing'
     $bin = Join-Path $prefix 'bin'
@@ -34,11 +41,14 @@ try {
     Assert-True (Test-Path -LiteralPath (Join-Path $app 'src\jl_mixing\__init__.py') -PathType Leaf) 'installed application contains Python package'
     Assert-True (Test-Path -LiteralPath (Join-Path $bin 'jl-mixing.cmd') -PathType Leaf) 'installed jl-mixing launcher exists'
     Assert-True (Test-Path -LiteralPath (Join-Path $bin 'jl-mixing-shell-integration.ps1') -PathType Leaf) 'installed PowerShell integration exists'
+    if (-not $expectedTestRuntime) {
+        Assert-True (Test-Path -LiteralPath (Join-Path $app 'runtime\python.exe') -PathType Leaf) 'installer copies bundled Windows runtime'
+    }
 
     $state = Get-Content -LiteralPath (Join-Path $app 'install-state.json') -Raw | ConvertFrom-Json
     Assert-True ($state.installation_prefix -eq [IO.Path]::GetFullPath($prefix)) 'install state records prefix'
     Assert-True ($state.shell_integration.enabled -eq $true) 'install state records shell integration'
-    Assert-True ($state.test_runtime -eq $true) 'CI install state records test runtime mode'
+    Assert-True ($state.test_runtime -eq $expectedTestRuntime) 'install state records runtime mode'
 
     $profileText = Get-Content -LiteralPath $profile -Raw
     Assert-True ($profileText -match '# user profile content') 'installer preserves user PowerShell profile content'

--- a/tests/windows/test-runtime-bundle.ps1
+++ b/tests/windows/test-runtime-bundle.ps1
@@ -1,0 +1,38 @@
+$ErrorActionPreference = 'Stop'
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw "[FAIL] $Message" }
+    Write-Output "[PASS] $Message"
+}
+
+$root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+$runtime = Join-Path $root 'runtime\python.exe'
+$originalHome = $env:JL_MIXING_HOME
+$originalPythonPath = $env:PYTHONPATH
+
+try {
+    Assert-True (Test-Path -LiteralPath $runtime -PathType Leaf) 'bundled Windows runtime executable exists'
+    $env:JL_MIXING_HOME = $root
+    Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
+
+    $systemInfoText = & $runtime -m jl_mixing.cli system-info --json 2>&1 | Out-String
+    Assert-True ($LASTEXITCODE -eq 0) 'bundled runtime executes API dispatcher'
+    $systemInfo = $systemInfoText | ConvertFrom-Json
+    Assert-True ($systemInfo.api_version -eq '1.0') 'bundled runtime preserves API version'
+    Assert-True ($systemInfo.application.name -eq 'jl-mixing') 'bundled runtime preserves application identity'
+
+    $help = & $runtime -m jl_mixing.new_studio_cli --help 2>&1 | Out-String
+    Assert-True ($LASTEXITCODE -eq 0) 'bundled runtime executes human CLI module'
+    Assert-True ($help -match 'Usage: new-studio') 'bundled runtime preserves human help output'
+
+    $unsupported = & $runtime -m jl_mixing.not_a_command 2>&1 | Out-String
+    Assert-True ($LASTEXITCODE -eq 2) 'bundled runtime rejects unsupported module with argument exit code'
+    Assert-True ($unsupported -match 'unsupported JL Mixing runtime module') 'bundled runtime reports unsupported module'
+
+    $global:LASTEXITCODE = 0
+    Write-Output '[OK] Windows bundled runtime'
+} finally {
+    if ($null -eq $originalHome) { Remove-Item Env:JL_MIXING_HOME -ErrorAction SilentlyContinue } else { $env:JL_MIXING_HOME = $originalHome }
+    if ($null -eq $originalPythonPath) { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue } else { $env:PYTHONPATH = $originalPythonPath }
+}

--- a/windows/build-runtime.ps1
+++ b/windows/build-runtime.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [string]$OutputDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+$root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $OutputDir = Join-Path $root 'runtime'
+}
+$OutputDir = [IO.Path]::GetFullPath($OutputDir)
+
+$python = (Get-Command python.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1)
+if ($null -eq $python) {
+    throw 'Python is required to build the Windows runtime.'
+}
+
+& $python.Source -c 'import PyInstaller' 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw 'PyInstaller is not installed. Install packaging/windows-build-requirements.txt first.'
+}
+
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("jl-mixing-pyinstaller-{0}" -f [Guid]::NewGuid().ToString('N'))
+$dist = Join-Path $tempRoot 'dist'
+$work = Join-Path $tempRoot 'work'
+$spec = Join-Path $tempRoot 'spec'
+
+try {
+    New-Item -ItemType Directory -Force -Path $dist, $work, $spec | Out-Null
+    & $python.Source -m PyInstaller `
+        --noconfirm `
+        --clean `
+        --onedir `
+        --console `
+        --name python `
+        --paths (Join-Path $root 'src') `
+        --distpath $dist `
+        --workpath $work `
+        --specpath $spec `
+        (Join-Path $root 'windows\runtime_bootstrap.py')
+    if ($LASTEXITCODE -ne 0) {
+        throw "PyInstaller failed with exit code $LASTEXITCODE."
+    }
+
+    $built = Join-Path $dist 'python'
+    if (-not (Test-Path -LiteralPath (Join-Path $built 'python.exe') -PathType Leaf)) {
+        throw 'PyInstaller output is missing python.exe.'
+    }
+
+    if (Test-Path -LiteralPath $OutputDir) {
+        Remove-Item -LiteralPath $OutputDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $OutputDir) | Out-Null
+    Move-Item -LiteralPath $built -Destination $OutputDir
+} finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output "Built JL Mixing Windows runtime: $OutputDir"

--- a/windows/runtime_bootstrap.py
+++ b/windows/runtime_bootstrap.py
@@ -1,0 +1,71 @@
+"""Frozen Windows runtime bootstrap for JL Mixing Automation.
+
+The public Windows launchers invoke this bundled executable using the same
+internal shape as CPython: ``python.exe -m jl_mixing.<module> ...``.  Only the
+JL Mixing command modules listed below are accepted; this is an application
+runtime, not a general-purpose Python interpreter.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+
+from jl_mixing import (
+    approve_mix_cli,
+    cli,
+    create_delivery_cli,
+    new_client_cli,
+    new_mix_cli,
+    new_revision_cli,
+    new_studio_cli,
+    validate_intake_cli,
+)
+
+EntryPoint = Callable[[], int | None]
+
+ENTRY_POINTS: dict[str, EntryPoint] = {
+    "jl_mixing.cli": cli.main,
+    "jl_mixing.new_studio_cli": new_studio_cli.main,
+    "jl_mixing.new_client_cli": new_client_cli.main,
+    "jl_mixing.new_mix_cli": new_mix_cli.main,
+    "jl_mixing.validate_intake_cli": validate_intake_cli.main,
+    "jl_mixing.new_revision_cli": new_revision_cli.main,
+    "jl_mixing.approve_mix_cli": approve_mix_cli.main,
+    "jl_mixing.create_delivery_cli": create_delivery_cli.main,
+}
+
+
+def _exit_code(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    print(value, file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if len(sys.argv) < 3 or sys.argv[1] != "-m":
+        print(
+            "Error: JL Mixing bundled runtime requires '-m <jl_mixing module>'.",
+            file=sys.stderr,
+        )
+        return 2
+
+    module_name = sys.argv[2]
+    entry_point = ENTRY_POINTS.get(module_name)
+    if entry_point is None:
+        print(f"Error: unsupported JL Mixing runtime module: {module_name}", file=sys.stderr)
+        return 2
+
+    sys.argv = [module_name, *sys.argv[3:]]
+    try:
+        result = entry_point()
+    except SystemExit as exc:
+        return _exit_code(exc.code)
+    return _exit_code(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 cross-platform work under #71 by producing the first self-contained Windows runtime for the authoritative Python implementation.

## Changes

- pin PyInstaller for Windows runtime builds
- add a frozen JL Mixing runtime bootstrap that supports the existing internal `python.exe -m jl_mixing.<module>` launcher contract
- build the runtime in PyInstaller one-folder mode as `runtime\python.exe` plus its private dependencies
- keep API schemas, templates, VERSION, and other application assets external and resolved through `JL_MIXING_HOME`
- add bundled-runtime smoke tests with `PYTHONPATH` removed
- make the Windows installation lifecycle automatically use and verify the bundled runtime when present
- build and test the frozen runtime on the native Windows CI runner

## Compatibility

- end users do not need a separately installed Python interpreter when using the packaged Windows runtime
- public Windows command names and PowerShell shell-integration behavior are unchanged
- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no workspace migration or workflow redesign

The final Windows release ZIP/checksum/inventory and release-workflow publication remain the next packaging slice.

Part of #71.