### PR TITLE
Add v1.5 Windows release package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,9 @@ on:
         required: true
         type: string
 
-# The publish job must be allowed to create a GitHub Release and upload assets.
 permissions:
   contents: write
 
-# For a tag push, github.ref_name contains the tag name.
-# For a manual run, use the tag supplied by the user.
 env:
   RELEASE_TAG: >-
     ${{ github.event_name == 'workflow_dispatch'
@@ -49,17 +46,12 @@ jobs:
             platform: linux
 
     steps:
-      # Check out the exact tagged source being released.
-      #
-      # fetch-depth: 0 ensures tags and complete repository history are
-      # available to release checks that inspect Git metadata.
       - name: Check out release source
         uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
-      # Use a consistent supported Python version on both platforms.
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -67,7 +59,6 @@ jobs:
           cache: "pip"
           cache-dependency-path: packaging/requirements.txt
 
-      # Install the command-line dependencies used by tests and packaging.
       - name: Install operating-system dependencies
         shell: bash
         run: |
@@ -83,27 +74,21 @@ jobs:
               exit 1
           fi
 
-      # Install the pinned JSON Schema validator used by strict tests.
       - name: Install Python dependencies
         shell: bash
         run: |
           set -euo pipefail
-
           python -m pip install --upgrade pip
           python -m pip install -r packaging/requirements.txt
 
-      # Prevent publishing a tag whose name disagrees with VERSION.
       - name: Verify tag and application version
         shell: bash
         run: |
           set -euo pipefail
-
           version="$(tr -d '[:space:]' < VERSION)"
           expected_tag="v${version}"
-
           echo "Release tag: $RELEASE_TAG"
           echo "VERSION:     $version"
-
           if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
               echo "Tag/version mismatch." >&2
               echo "Expected tag: $expected_tag" >&2
@@ -111,47 +96,37 @@ jobs:
               exit 1
           fi
 
-      # Run the complete release gate before producing an official package.
       - name: Run release verification
         shell: bash
         run: |
           set -euo pipefail
           make release-check
 
-      # Build the actual end-user archive, checksum, and inventory.
       - name: Build release package
         shell: bash
         run: |
           set -euo pipefail
-
           rm -rf dist
           make release
 
-      # Confirm that the expected platform-specific outputs were generated.
       - name: Verify generated assets
         shell: bash
         run: |
           set -euo pipefail
-
           version="$(tr -d '[:space:]' < VERSION)"
           archive="dist/jl-mixing-${version}-${{ matrix.platform }}.tar.gz"
           checksum="${archive}.sha256"
           inventory="${archive}.inventory.txt"
-
           for file in "$archive" "$checksum" "$inventory"; do
               if [[ ! -f "$file" ]]; then
                   echo "Missing release asset: $file" >&2
                   exit 1
               fi
-
               echo "Created: $file"
           done
-
           echo
           ls -lh dist
 
-      # Workflow artifacts transfer the platform packages to the publish job.
-      # These are temporary Actions artifacts, not yet GitHub Release assets.
       - name: Upload platform release assets
         uses: actions/upload-artifact@v4
         with:
@@ -163,10 +138,106 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  build-windows:
+    name: Build windows package
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            packaging/requirements.txt
+            packaging/windows-build-requirements.txt
+
+      - name: Install Python dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r packaging/requirements.txt
+          python -m pip install -r packaging/windows-build-requirements.txt
+
+      - name: Verify tag and application version
+        shell: pwsh
+        run: |
+          $version = (Get-Content -LiteralPath VERSION -Raw).Trim()
+          $expectedTag = "v$version"
+          Write-Output "Release tag: $env:RELEASE_TAG"
+          Write-Output "VERSION:     $version"
+          if ($env:RELEASE_TAG -ne $expectedTag) {
+              throw "Tag/version mismatch. Expected $expectedTag; actual $env:RELEASE_TAG"
+          }
+
+      - name: Run Python runtime tests
+        shell: pwsh
+        env:
+          PYTHONPATH: ${{ github.workspace }}\src
+        run: python -m unittest discover -s tests/python -p "test_*.py"
+
+      - name: Run native Windows command tests
+        shell: pwsh
+        run: ./tests/windows/test-command-surface.ps1
+
+      - name: Build self-contained Windows runtime
+        shell: pwsh
+        run: ./windows/build-runtime.ps1
+
+      - name: Run bundled runtime smoke tests
+        shell: pwsh
+        run: ./tests/windows/test-runtime-bundle.ps1
+
+      - name: Run Windows installation lifecycle tests
+        shell: pwsh
+        run: ./tests/windows/test-installation.ps1
+
+      - name: Build and verify Windows release package
+        shell: pwsh
+        run: ./tests/windows/test-release-package.ps1
+
+      - name: Build official Windows release assets
+        shell: pwsh
+        run: |
+          Remove-Item -LiteralPath dist -Recurse -Force -ErrorAction SilentlyContinue
+          ./windows/build-release.ps1 -OutputDir dist
+
+      - name: Verify generated assets
+        shell: pwsh
+        run: |
+          $version = (Get-Content -LiteralPath VERSION -Raw).Trim()
+          $archive = "dist\jl-mixing-$version-windows.zip"
+          $checksum = "$archive.sha256"
+          $inventory = "$archive.inventory.txt"
+          foreach ($file in @($archive, $checksum, $inventory)) {
+              if (-not (Test-Path -LiteralPath $file -PathType Leaf)) {
+                  throw "Missing release asset: $file"
+              }
+              Write-Output "Created: $file"
+          }
+          Get-ChildItem -LiteralPath dist
+
+      - name: Upload Windows release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows
+          path: |
+            dist/jl-mixing-*-windows.zip
+            dist/jl-mixing-*-windows.zip.sha256
+            dist/jl-mixing-*-windows.zip.inventory.txt
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: Publish GitHub release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, build-windows]
 
     steps:
       - name: Check out release notes
@@ -176,8 +247,6 @@ jobs:
           sparse-checkout: docs/RELEASE_NOTES_V1.4.md
           sparse-checkout-cone-mode: false
 
-      # Download and merge the macOS and Linux workflow artifacts into one
-      # directory. Their platform-specific filenames prevent collisions.
       - name: Download release assets
         uses: actions/download-artifact@v4
         with:
@@ -189,23 +258,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
           echo "Assets prepared for $RELEASE_TAG:"
           find release-assets -maxdepth 1 -type f -print | sort
-
-          asset_count="$(
-              find release-assets -maxdepth 1 -type f | wc -l | tr -d '[:space:]'
-          )"
-
-          # Two platforms, with an archive, checksum, and inventory for each.
-          if [[ "$asset_count" -ne 6 ]]; then
-              echo "Expected 6 release assets; found $asset_count." >&2
+          asset_count="$(find release-assets -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          # Three platforms, with an archive, checksum, and inventory for each.
+          if [[ "$asset_count" -ne 9 ]]; then
+              echo "Expected 9 release assets; found $asset_count." >&2
               exit 1
           fi
 
-      # Supplying --repo tells the GitHub CLI exactly which repository owns the
-      # release. A new release uses the reviewed v1.4 notes checked out above.
-      # If a prior attempt already created the release, upload replaces assets.
       - name: Create or update GitHub release
         shell: bash
         env:
@@ -213,32 +274,20 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-
           tag="$RELEASE_TAG"
-
           shopt -s nullglob
           assets=(release-assets/*)
-
           if [[ "${#assets[@]}" -eq 0 ]]; then
               echo "No release assets were downloaded." >&2
               exit 1
           fi
-
-          if gh release view "$tag" \
-              --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
               echo "Release $tag already exists."
               echo "Uploading and replacing its custom assets."
-
-              gh release upload "$tag" \
-                  "${assets[@]}" \
-                  --repo "$GITHUB_REPOSITORY" \
-                  --clobber
+              gh release upload "$tag" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
           else
               echo "Creating release $tag."
-
-              gh release create "$tag" \
-                  "${assets[@]}" \
+              gh release create "$tag" "${assets[@]}" \
                   --repo "$GITHUB_REPOSITORY" \
                   --verify-tag \
                   --title "JL Mixing Automation ${tag#v}" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
   windows-python:
     # Exercise the v1.5 authoritative Python runtime, native command glue,
-    # self-contained runtime bundle, and installer on Windows.
+    # self-contained runtime bundle, installer, and release ZIP on Windows.
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,3 +61,6 @@ jobs:
       - name: Run Windows installation lifecycle tests
         shell: pwsh
         run: ./tests/windows/test-installation.ps1
+      - name: Run Windows release package lifecycle tests
+        shell: pwsh
+        run: ./tests/windows/test-release-package.ps1

--- a/tests/windows/test-release-package.ps1
+++ b/tests/windows/test-release-package.ps1
@@ -1,0 +1,63 @@
+$ErrorActionPreference = 'Stop'
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw "[FAIL] $Message" }
+    Write-Output "[PASS] $Message"
+}
+
+$root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+$pwsh = (Get-Command pwsh.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+$version = (Get-Content -LiteralPath (Join-Path $root 'VERSION') -Raw).Trim()
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("jl-mixing-windows-release-test-{0}" -f [Guid]::NewGuid().ToString('N'))
+$dist = Join-Path $tempRoot 'dist'
+$extract = Join-Path $tempRoot 'extract'
+$prefix = Join-Path $tempRoot 'prefix'
+$profile = Join-Path $tempRoot 'profile\Microsoft.PowerShell_profile.ps1'
+$archive = Join-Path $dist "jl-mixing-$version-windows.zip"
+$checksum = "$archive.sha256"
+$inventory = "$archive.inventory.txt"
+$packageRoot = Join-Path $extract "jl-mixing-$version"
+$originalProfile = $env:JL_MIXING_TEST_PROFILE
+
+try {
+    New-Item -ItemType Directory -Force -Path $dist, $extract, (Split-Path -Parent $profile) | Out-Null
+    Set-Content -LiteralPath $profile -Value "# package test profile`r`n" -NoNewline -Encoding utf8
+    $env:JL_MIXING_TEST_PROFILE = $profile
+
+    & $pwsh -NoProfile -File (Join-Path $root 'windows\build-release.ps1') -OutputDir $dist | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'Windows release builder succeeds'
+    Assert-True (Test-Path -LiteralPath $archive -PathType Leaf) 'Windows release ZIP exists'
+    Assert-True (Test-Path -LiteralPath $checksum -PathType Leaf) 'Windows release checksum exists'
+    Assert-True (Test-Path -LiteralPath $inventory -PathType Leaf) 'Windows release inventory exists'
+
+    $expectedHash = ((Get-Content -LiteralPath $checksum -Raw).Trim() -split '\s+')[0]
+    $actualHash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+    Assert-True ($expectedHash -eq $actualHash) 'Windows release checksum verifies'
+
+    Expand-Archive -LiteralPath $archive -DestinationPath $extract
+    Assert-True (Test-Path -LiteralPath (Join-Path $packageRoot 'runtime\python.exe') -PathType Leaf) 'extracted package contains bundled runtime'
+    Assert-True (Test-Path -LiteralPath (Join-Path $packageRoot 'windows\install.ps1') -PathType Leaf) 'extracted package contains Windows installer'
+    Assert-True (Test-Path -LiteralPath (Join-Path $packageRoot 'RELEASE_MANIFEST.txt') -PathType Leaf) 'extracted package contains release manifest'
+
+    & $pwsh -NoProfile -File (Join-Path $packageRoot 'windows\install.ps1') -Prefix $prefix | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'extracted Windows release installs'
+
+    $installedCommand = Join-Path $prefix 'bin\jl-mixing.cmd'
+    $systemInfoText = & $installedCommand system-info --json | Out-String
+    Assert-True ($LASTEXITCODE -eq 0) 'installed release command runs through bundled runtime'
+    $systemInfo = $systemInfoText | ConvertFrom-Json
+    Assert-True ($systemInfo.api_version -eq '1.0') 'installed release reports API 1.0'
+    Assert-True ($systemInfo.application.version -eq $version) 'installed release reports package VERSION'
+
+    & $pwsh -NoProfile -File (Join-Path $prefix 'share\jl-mixing\windows\uninstall.ps1') -Prefix $prefix | Out-Null
+    Assert-True ($LASTEXITCODE -eq 0) 'extracted Windows release uninstalls'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $prefix 'share\jl-mixing'))) 'release uninstall removes installed application'
+    Assert-True ((Get-Content -LiteralPath $profile -Raw) -match '# package test profile') 'release lifecycle preserves profile content'
+
+    $global:LASTEXITCODE = 0
+    Write-Output '[OK] Windows release package lifecycle'
+} finally {
+    if ($null -eq $originalProfile) { Remove-Item Env:JL_MIXING_TEST_PROFILE -ErrorAction SilentlyContinue } else { $env:JL_MIXING_TEST_PROFILE = $originalProfile }
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/windows/build-release.ps1
+++ b/windows/build-release.ps1
@@ -1,0 +1,89 @@
+[CmdletBinding()]
+param(
+    [string]$OutputDir = 'dist'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail([string]$Message, [int]$Code = 1) {
+    [Console]::Error.WriteLine("Error: $Message")
+    exit $Code
+}
+
+$root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$output = if ([IO.Path]::IsPathRooted($OutputDir)) {
+    [IO.Path]::GetFullPath($OutputDir)
+} else {
+    [IO.Path]::GetFullPath((Join-Path (Get-Location) $OutputDir))
+}
+
+$versionPath = Join-Path $root 'VERSION'
+if (-not (Test-Path -LiteralPath $versionPath -PathType Leaf)) { Fail 'VERSION is missing.' 3 }
+$version = (Get-Content -LiteralPath $versionPath -Raw).Trim()
+if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+    Fail "invalid VERSION: $version" 3
+}
+
+$runtime = Join-Path $root 'runtime\python.exe'
+if (-not (Test-Path -LiteralPath $runtime -PathType Leaf)) {
+    Fail 'runtime\python.exe is missing; run windows\build-runtime.ps1 first.' 3
+}
+
+$packageName = "jl-mixing-$version"
+$archive = Join-Path $output "$packageName-windows.zip"
+$checksum = "$archive.sha256"
+$inventory = "$archive.inventory.txt"
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("jl-mixing-release-{0}" -f [Guid]::NewGuid().ToString('N'))
+$packageRoot = Join-Path $tempRoot $packageName
+
+try {
+    New-Item -ItemType Directory -Force -Path $output, $packageRoot | Out-Null
+
+    foreach ($file in @('VERSION','API_VERSION','LICENSE','CHANGELOG.md')) {
+        $source = Join-Path $root $file
+        if (-not (Test-Path -LiteralPath $source -PathType Leaf)) { Fail "release source is missing $file" 3 }
+        Copy-Item -LiteralPath $source -Destination $packageRoot
+    }
+    Copy-Item -LiteralPath (Join-Path $root 'packaging\RELEASE_README.md') -Destination (Join-Path $packageRoot 'README.md')
+
+    foreach ($directory in @('src','api','schemas','templates','docs','windows','runtime')) {
+        $source = Join-Path $root $directory
+        if (-not (Test-Path -LiteralPath $source -PathType Container)) { Fail "release source is missing $directory" 3 }
+        Copy-Item -LiteralPath $source -Destination (Join-Path $packageRoot $directory) -Recurse
+    }
+
+    $manifestEntries = Get-ChildItem -LiteralPath $packageRoot -File -Recurse |
+        ForEach-Object {
+            [IO.Path]::GetRelativePath($packageRoot, $_.FullName).Replace('\','/')
+        } |
+        Sort-Object -CaseSensitive
+    $manifestEntries | Set-Content -LiteralPath (Join-Path $packageRoot 'RELEASE_MANIFEST.txt') -Encoding utf8
+
+    Remove-Item -LiteralPath $archive, $checksum, $inventory -Force -ErrorAction SilentlyContinue
+    Compress-Archive -LiteralPath $packageRoot -DestinationPath $archive -CompressionLevel Optimal
+
+    $hash = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+    "$hash  $([IO.Path]::GetFileName($archive))" | Set-Content -LiteralPath $checksum -Encoding ascii
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [IO.Compression.ZipFile]::OpenRead($archive)
+    try {
+        $entries = $zip.Entries | ForEach-Object { $_.FullName } | Sort-Object -CaseSensitive
+        $entries | Set-Content -LiteralPath $inventory -Encoding utf8
+    } finally {
+        $zip.Dispose()
+    }
+
+    if (-not (Select-String -LiteralPath $inventory -SimpleMatch "$packageName/runtime/python.exe" -Quiet)) {
+        Fail 'release archive inventory does not contain runtime/python.exe.' 3
+    }
+    if (-not (Select-String -LiteralPath $inventory -SimpleMatch "$packageName/windows/install.ps1" -Quiet)) {
+        Fail 'release archive inventory does not contain windows/install.ps1.' 3
+    }
+
+    Write-Output "Created release archive: $archive"
+    Write-Output "Checksum: $checksum"
+    Write-Output "Inventory: $inventory"
+} finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Complete the Windows artifact path for JL Mixing Automation v1.5 under #71 by adding a self-contained Windows ZIP package, checksum/inventory verification, package lifecycle testing, and official Release-workflow publication.

## Changes

- add `windows/build-release.ps1` to assemble the application, Windows installer/launchers, and bundled `runtime\python.exe` into `jl-mixing-<version>-windows.zip`
- generate SHA-256 and ZIP inventory assets alongside the archive
- add a Windows release-package lifecycle test that builds, verifies, extracts, installs, runs API discovery through the bundled runtime, and uninstalls the package
- run the Windows release-package lifecycle in normal native Windows CI
- add a separate `build-windows` job to the official Release workflow
- upload Windows ZIP/checksum/inventory assets and require nine total assets across macOS, Linux, and Windows before publication

## Compatibility

- public command names and Automation API 1.0 remain unchanged
- workspace metadata schema remains 1.1.0
- no workspace migration or workflow redesign
- existing macOS/Linux tarball builders remain unchanged

Release notes/version promotion remain separate final v1.5 release-preparation work.

Part of #71.