### PR TITLE
Bundle self-contained macOS runtime for v1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: packaging/requirements.txt
+          cache-dependency-path: |
+            packaging/requirements.txt
+            packaging/macos-build-requirements.txt
 
       - name: Install operating-system dependencies
         shell: bash
@@ -80,6 +82,9 @@ jobs:
           set -euo pipefail
           python -m pip install --upgrade pip
           python -m pip install -r packaging/requirements.txt
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+              python -m pip install -r packaging/macos-build-requirements.txt
+          fi
 
       - name: Verify tag and application version
         shell: bash
@@ -95,6 +100,16 @@ jobs:
               echo "Actual tag:   $RELEASE_TAG" >&2
               exit 1
           fi
+
+      - name: Build self-contained macOS runtime
+        if: runner.os == 'macOS'
+        shell: bash
+        run: bash ./macos/build-runtime.sh
+
+      - name: Run bundled macOS runtime smoke tests
+        if: runner.os == 'macOS'
+        shell: bash
+        run: bash ./tests/macos/test-runtime-bundle.sh
 
       - name: Run release verification
         shell: bash
@@ -124,6 +139,12 @@ jobs:
               fi
               echo "Created: $file"
           done
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+              tar -tzf "$archive" | grep -q "jl-mixing-${version}/runtime/python$" || {
+                  echo "macOS release archive is missing runtime/python." >&2
+                  exit 1
+              }
+          fi
           echo
           ls -lh dist
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,34 +26,19 @@ jobs:
         run: command -v jq >/dev/null 2>&1 || brew install jq
       - name: Install Python validation dependency
         run: python -m pip install -r packaging/requirements.txt
+      - name: Install macOS runtime bundler
+        if: runner.os == 'macOS'
+        run: python -m pip install -r packaging/macos-build-requirements.txt
+      - name: Build self-contained macOS runtime
+        if: runner.os == 'macOS'
+        run: bash ./macos/build-runtime.sh
+      - name: Run bundled macOS runtime smoke tests
+        if: runner.os == 'macOS'
+        run: bash ./tests/macos/test-runtime-bundle.sh
       - name: Run strict Batch 4 tests
         env:
           JL_MIXING_PYTHON: ${{ env.pythonLocation }}/bin/python
         run: make strict-test
-
-  macos-runtime:
-    # Build and exercise the self-contained macOS application runtime.
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install runtime dependencies
-        run: |
-          python -m pip install -r packaging/requirements.txt
-          python -m pip install -r packaging/macos-build-requirements.txt
-      - name: Build self-contained macOS runtime
-        run: bash ./macos/build-runtime.sh
-      - name: Run bundled macOS runtime smoke tests
-        run: bash ./tests/macos/test-runtime-bundle.sh
-      - name: Verify macOS release tarball includes runtime
-        run: |
-          rm -rf dist
-          ./tools/build-release --platform macos --output-dir dist
-          version="$(tr -d '[:space:]' < VERSION)"
-          archive="dist/jl-mixing-${version}-macos.tar.gz"
-          tar -tzf "$archive" | grep -q "jl-mixing-${version}/runtime/python$"
 
   windows-python:
     # Exercise the v1.5 authoritative Python runtime, native command glue,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      # Fetch the exact commit under review.
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -31,6 +30,30 @@ jobs:
         env:
           JL_MIXING_PYTHON: ${{ env.pythonLocation }}/bin/python
         run: make strict-test
+
+  macos-runtime:
+    # Build and exercise the self-contained macOS application runtime.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install -r packaging/requirements.txt
+          python -m pip install -r packaging/macos-build-requirements.txt
+      - name: Build self-contained macOS runtime
+        run: bash ./macos/build-runtime.sh
+      - name: Run bundled macOS runtime smoke tests
+        run: bash ./tests/macos/test-runtime-bundle.sh
+      - name: Verify macOS release tarball includes runtime
+        run: |
+          rm -rf dist
+          ./tools/build-release --platform macos --output-dir dist
+          version="$(tr -d '[:space:]' < VERSION)"
+          archive="dist/jl-mixing-${version}-macos.tar.gz"
+          tar -tzf "$archive" | grep -q "jl-mixing-${version}/runtime/python$"
 
   windows-python:
     # Exercise the v1.5 authoritative Python runtime, native command glue,

--- a/bin/jl-mixing-python-command
+++ b/bin/jl-mixing-python-command
@@ -9,11 +9,14 @@ shift
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="${JL_MIXING_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 python="${JL_MIXING_PYTHON:-}"
+if [ -z "$python" ] && [ -x "$APP_ROOT/runtime/python" ]; then
+    python="$APP_ROOT/runtime/python"
+fi
 if [ -z "$python" ]; then
     python="$(command -v python3 || true)"
 fi
 if [ -z "$python" ]; then
-    echo "Error: Python 3.10 or newer is required." >&2
+    echo "Error: JL Mixing Python runtime was not found." >&2
     exit 3
 fi
 if [ "${python#*/}" != "$python" ] && [ ! -x "$python" ]; then

--- a/macos/build-runtime.sh
+++ b/macos/build-runtime.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUTPUT_DIR="${1:-$ROOT/runtime}"
+PYTHON="${JL_MIXING_BUILD_PYTHON:-$(command -v python3 || true)}"
+
+[ -n "$PYTHON" ] || { echo "Error: Python 3 is required to build the macOS runtime." >&2; exit 3; }
+"$PYTHON" -c 'import PyInstaller' 2>/dev/null || {
+    echo "Error: PyInstaller is not installed. Install packaging/macos-build-requirements.txt first." >&2
+    exit 3
+}
+
+case "$OUTPUT_DIR" in
+    /*) ;;
+    *) OUTPUT_DIR="$PWD/$OUTPUT_DIR" ;;
+esac
+
+work_root="$(mktemp -d "${TMPDIR:-/tmp}/jl-mixing-pyinstaller.XXXXXX")"
+cleanup() { rm -rf -- "$work_root"; }
+trap cleanup EXIT HUP INT TERM
+
+dist="$work_root/dist"
+work="$work_root/work"
+spec="$work_root/spec"
+mkdir -p "$dist" "$work" "$spec"
+
+"$PYTHON" -m PyInstaller \
+    --noconfirm \
+    --clean \
+    --onedir \
+    --console \
+    --name python \
+    --paths "$ROOT/src" \
+    --distpath "$dist" \
+    --workpath "$work" \
+    --specpath "$spec" \
+    "$ROOT/macos/runtime_bootstrap.py"
+
+built="$dist/python"
+[ -x "$built/python" ] || {
+    echo "Error: PyInstaller output is missing executable python." >&2
+    exit 3
+}
+
+rm -rf -- "$OUTPUT_DIR"
+mkdir -p "$(dirname "$OUTPUT_DIR")"
+mv "$built" "$OUTPUT_DIR"
+
+printf 'Built JL Mixing macOS runtime: %s\n' "$OUTPUT_DIR"

--- a/macos/runtime_bootstrap.py
+++ b/macos/runtime_bootstrap.py
@@ -1,0 +1,71 @@
+"""Frozen macOS runtime bootstrap for JL Mixing Automation.
+
+The public launchers invoke this bundled executable using the same internal
+shape as CPython: ``python -m jl_mixing.<module> ...``. Only JL Mixing command
+modules are accepted; this is an application runtime, not a general-purpose
+Python interpreter.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+
+from jl_mixing import (
+    approve_mix_cli,
+    cli,
+    create_delivery_cli,
+    new_client_cli,
+    new_mix_cli,
+    new_revision_cli,
+    new_studio_cli,
+    validate_intake_cli,
+)
+
+EntryPoint = Callable[[], int | None]
+
+ENTRY_POINTS: dict[str, EntryPoint] = {
+    "jl_mixing.cli": cli.main,
+    "jl_mixing.new_studio_cli": new_studio_cli.main,
+    "jl_mixing.new_client_cli": new_client_cli.main,
+    "jl_mixing.new_mix_cli": new_mix_cli.main,
+    "jl_mixing.validate_intake_cli": validate_intake_cli.main,
+    "jl_mixing.new_revision_cli": new_revision_cli.main,
+    "jl_mixing.approve_mix_cli": approve_mix_cli.main,
+    "jl_mixing.create_delivery_cli": create_delivery_cli.main,
+}
+
+
+def _exit_code(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    print(value, file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if len(sys.argv) < 3 or sys.argv[1] != "-m":
+        print(
+            "Error: JL Mixing bundled runtime requires '-m <jl_mixing module>'.",
+            file=sys.stderr,
+        )
+        return 2
+
+    module_name = sys.argv[2]
+    entry_point = ENTRY_POINTS.get(module_name)
+    if entry_point is None:
+        print(f"Error: unsupported JL Mixing runtime module: {module_name}", file=sys.stderr)
+        return 2
+
+    sys.argv = [module_name, *sys.argv[3:]]
+    try:
+        result = entry_point()
+    except SystemExit as exc:
+        return _exit_code(exc.code)
+    return _exit_code(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/macos-build-requirements.txt
+++ b/packaging/macos-build-requirements.txt
@@ -1,0 +1,1 @@
+pyinstaller==6.21.0

--- a/tests/macos/test-runtime-bundle.sh
+++ b/tests/macos/test-runtime-bundle.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+runtime="$ROOT/runtime/python"
+
+[ -x "$runtime" ] || { echo "[FAIL] bundled macOS runtime exists" >&2; exit 1; }
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/jl-mixing-macos-runtime.XXXXXX")"
+cleanup() { rm -rf -- "$tmp"; }
+trap cleanup EXIT HUP INT TERM
+
+old_pythonpath="${PYTHONPATH-}"
+unset PYTHONPATH
+export JL_MIXING_HOME="$ROOT"
+
+"$runtime" -m jl_mixing.cli system-info --json > "$tmp/system-info.json"
+python3 - "$tmp/system-info.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+obj = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+assert obj['api_version'] == '1.0'
+assert obj['application']['name'] == 'jl-mixing'
+PY
+echo "[PASS] bundled runtime reports API discovery"
+
+"$runtime" -m jl_mixing.new_studio_cli --help > "$tmp/help.txt"
+grep -q '^Usage:' "$tmp/help.txt"
+echo "[PASS] bundled runtime executes human CLI"
+
+if "$runtime" -m jl_mixing.not_a_command >/dev/null 2>&1; then
+    echo "[FAIL] bundled runtime rejects unsupported module" >&2
+    exit 1
+fi
+echo "[PASS] bundled runtime rejects unsupported module"
+
+if [ -n "$old_pythonpath" ]; then export PYTHONPATH="$old_pythonpath"; else unset PYTHONPATH; fi
+
+echo "[OK] macOS bundled runtime"

--- a/tools/build-release
+++ b/tools/build-release
@@ -53,7 +53,6 @@ if [ -z "$platform" ]; then
     esac
 fi
 
-# Use the same exact semantic-version validation as runtime provenance.
 version="$(jl_software_version)" || exit $?
 
 case "$output_dir" in
@@ -71,12 +70,19 @@ package_name="jl-mixing-$version"
 package_root="$work_dir/$package_name"
 mkdir -p "$package_root"
 
-# Runtime directories are copied intact because command-relative paths are part
-# of the installed application contract.
 cp "$ROOT/VERSION" "$ROOT/API_VERSION" "$ROOT/LICENSE" "$ROOT/CHANGELOG.md" \
     "$ROOT/install.sh" "$ROOT/uninstall.sh" "$package_root/"
 cp "$ROOT/packaging/RELEASE_README.md" "$package_root/README.md"
 cp -R "$ROOT/bin" "$ROOT/lib" "$ROOT/src" "$ROOT/api" "$ROOT/schemas" "$ROOT/templates" "$ROOT/docs" "$package_root/"
+
+if [ "$platform" = "macos" ]; then
+    [ -x "$ROOT/runtime/python" ] || {
+        echo "Error: macOS release requires bundled runtime/python. Run macos/build-runtime.sh first." >&2
+        exit 3
+    }
+    cp -R "$ROOT/runtime" "$package_root/"
+fi
+
 mkdir -p "$package_root/tools" "$package_root/packaging"
 cp "$ROOT/tools/validate-json.py" "$ROOT/tools/build-intake-report.py" \
     "$ROOT/tools/project-state.py" "$ROOT/tools/import-project-source.py" \
@@ -91,8 +97,8 @@ chmod +x "$package_root/install.sh" "$package_root/uninstall.sh" "$package_root/
     "$package_root/tools/import-revision-source.py" \
     "$package_root/tools/build-delivery.py" \
     "$package_root/tools/manage-shell-config.py"
+[ "$platform" != "macos" ] || chmod +x "$package_root/runtime/python"
 
-# Record the exact release contents for human review and archive verification.
 (
     cd "$package_root"
     find . -type f -print | sed 's#^./##' | LC_ALL=C sort > RELEASE_MANIFEST.txt


### PR DESCRIPTION
## Summary

Continue JL Mixing Automation v1.5 cross-platform work under #71 by adding a frozen macOS application runtime and including it in the macOS release tarball.

## Changes

- add a macOS JL Mixing runtime bootstrap and PyInstaller one-folder build script
- pin the macOS runtime bundler
- make the POSIX command launcher prefer packaged `runtime/python` while preserving `JL_MIXING_PYTHON` and system-Python development fallbacks
- require the macOS release tarball to include the frozen runtime
- build and smoke-test the bundled runtime in the existing macOS strict CI job
- build and verify the bundled runtime in the official macOS release workflow

## Compatibility

- authoritative workflow code remains the shared `src/jl_mixing` implementation
- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- public command names/options remain unchanged
- Linux packaging behavior remains unchanged

## Follow-up

The current POSIX installer still uses system Python/jq during installation and creates a private venv. Removing those installer-time dependencies and pinning installed macOS launchers directly to the frozen runtime is the next lifecycle slice.

Part of #71.