### PR TITLE
Fix new-client root resolution and refresh v1.5 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ infer API compatibility from the Automation product release number.
 - writable metadata schema: `1.1.0`
 - no v1.0 workspace migration
 
-Existing valid v1.1+ workspaces remain usable. New records identify the current
-application release in `created_with` without changing the metadata schema
-identity.
+v1.5 is compatible with valid v1.1 workspaces and later compatible 1.1.0-schema
+records. New records identify the current application release in `created_with`
+without changing the metadata schema identity.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,168 +1,135 @@
 # JL Mixing Automation
 
-JL Mixing Automation v1.3 creates and manages a consistent filesystem workflow
-for professional mixing projects. It preserves original client files, tracks
-revision approvals, and builds verified final-delivery packages without taking
-ownership of the DAW session itself.
+JL Mixing Automation v1.5 is a cross-platform workflow engine for professional
+mixing projects. It creates consistent workspaces, preserves original client
+files, manages revisions and approval, validates intake, and builds verified
+final-delivery packages.
 
-## v1.3 workflow
+The authoritative v1.5 runtime is Python and is shared across Windows and macOS.
+The Automation API remains version `1.0`, while workspace metadata schemas remain
+version `1.1.0`.
+
+## Workflow
 
 ```text
 new-studio
-  → new-client
-  → new-mix (creates Revision_01)
-  → validate-intake
-  → work in and send the current revision manually
-  → new-revision when another revision is needed
-  → approve-mix
-  → create-delivery
+  -> new-client
+  -> new-mix (creates Revision_01)
+  -> validate-intake
+  -> work in and send the current revision
+  -> new-revision when needed
+  -> approve-mix
+  -> create-delivery
 ```
 
-The default workspace is `~/Music/Mixes/`. Projects have stable paths beneath
+The default workspace is `~/Music/Mixes/`. Projects live directly beneath
 `Clients/<Client>/Projects/<Project>/`; there are no `Active/` or `Completed/`
-directories and no project-completion command.
+directories.
 
-## Requirements
+## Installation
 
-- macOS or Linux
-- Bash 3.2 or newer
-- Python 3.10 or newer
-- `jq`
-- `ffprobe` is optional and preserves the opportunistic intake inspection
-  available in v1.0.4
+### Windows
 
-## Install a release archive
+Download and extract the Windows ZIP, then run the included PowerShell installer:
+
+```powershell
+.\windows\install.ps1
+```
+
+The Windows package includes its private Python runtime. End users do not need to
+install Python, Bash, or jq separately. The default installation is beneath:
+
+```text
+%LOCALAPPDATA%\Programs\JL Mixing\
+```
+
+Open a new PowerShell session after installation so the managed PATH and shell
+integration are active.
+
+### macOS
+
+Download and extract the macOS archive, then run:
 
 ```bash
-cd ~/Downloads
-tar -xzf jl-mixing-1.3.0-macos.tar.gz
-cd jl-mixing-1.3.0
+./macos/install.sh
+```
+
+The macOS package includes its private Python runtime. End users do not need a
+separate Python or jq installation. The default prefix is `~/.local`.
+
+### Linux and source/developer installs
+
+The Linux/source installer remains the compatibility path:
+
+```bash
 ./install.sh
 ```
 
-Use the `linux` archive name on Linux. The default installation is:
+It requires Bash, Python 3.10+ with `venv`, and jq. See
+[`docs/INSTALLATION_GUIDE.md`](docs/INSTALLATION_GUIDE.md) for platform-specific
+details and custom-prefix options.
 
-```text
-Application: ~/.local/share/jl-mixing/
-Commands:    ~/.local/bin/
-```
-
-The installer adds one reversible managed block to `.zshrc` or `.bashrc`. That
-single block adds the command directory to `PATH` and loads the optional shell
-wrappers used by `--cd`. Open a new Terminal tab after installation, or source
-the startup file shown by the installer.
-
-To install without editing shell configuration:
-
-```bash
-./install.sh --no-shell-integration
-```
-
-To install under another prefix:
-
-```bash
-./install.sh --prefix "$HOME/Applications/jl-local"
-```
+`ffprobe`/`ffmpeg` are optional external tools used for enhanced audio intake QC.
+When unavailable, affected checks are reported as skipped rather than silently
+assumed to have passed.
 
 ## Start
 
 ```bash
 new-studio
 new-client acme --name "Acme Records"
-cd "$HOME/Music/Mixes/Clients/Acme Records"
-new-mix "Blue Sky"
+new-mix "Blue Sky" --client acme
 ```
 
-`new-mix --project "Blue Sky"` remains fully supported. When `--artist` is
-omitted, `new-mix` uses the client's artist default and then the client display
-name. Creation commands print a copy-and-paste `Next:` command. When shell
-integration is active, `new-client`, `new-mix`, and `new-revision` can change the
-current Terminal directory with `--cd`; the studio-wide default is configured
-by `new-studio --default-cd`.
+`new-client` can be run from anywhere. Studio-root resolution uses this order:
 
-## Compatibility rule
+1. explicit `--root PATH`
+2. `JL_MIXING_ROOT`
+3. current-directory studio context
+4. the default `~/Music/Mixes` workspace
 
-JL Mixing Automation v1.3 continues using the v1.1 workspace schemas and is
-compatible with valid v1.1 workspaces. Application provenance is independent:
-new records use `created_with: jl-mixing 1.3.0` while the unchanged document
-contract remains `schema_version: 1.1.0`. It does not migrate, restructure, or
-modify v1.0 workspaces. Copy only user-owned material, such as original client
-deliveries or notes, into newly created v1.1/v1.2 projects. Do not copy v1.0
-JSON manifests or complete v1.0 project directories.
+## Automation API
 
-## Automation API discovery
+Machine clients discover the installed provider with:
 
-JL Mixing Studio and other supported machine clients discover the installed
-provider contract through:
-
-```bash
+```text
 jl-mixing system-info --json
 ```
 
-The response reports the Automation API version, application release, workspace
-metadata schema compatibility, implemented capabilities, and installed API
-schema location as separate fields. Clients must use `api_version` and
-`capabilities`; they must not infer API compatibility from the application
-release number.
+API 1.0 advertises capability-backed operations including:
 
-The initial API 1.0 implementation advertises only `system.info`. Existing
-human-facing workflow commands remain supported but are not machine API
-operations until their structured contracts and parity tests are implemented.
-
-## Delivery behavior
-
-`create-delivery` always packages the approved revision. Every selected regular
-file is eligible regardless of extension. Familiar filename phrases are
-classified on a best-effort basis; unmatched files are recorded as
-`unclassified` and are still delivered.
-
-To create a ZIP containing completed delivery notes:
-
-```bash
-create-delivery
-# Edit 05_Final_Delivery/Delivery_Notes.md
-create-delivery --zip --overwrite
+```text
+client.create
+project.create
+project.create.artist
+intake.validate
+intake.validate.report
+revision.create
+revision.create.description
+revision.approve
+delivery.create
+system.info
 ```
 
-`--overwrite` preserves the edited notes when the delivered path set is
-unchanged. A one-step `create-delivery --zip` packages the clean notes template
-because it creates and zips the delivery before the user can edit the file.
+Clients must use the reported `api_version` and `capabilities`; they must not
+infer API compatibility from the Automation product release number.
 
-Generated ZIPs use
-`<project-id>-rev-<NN>-<YYYYMMDDHHMMSS>.zip`, with a zero-padded revision and
-local timestamp.
+## Compatibility
 
-`create-delivery --clean` is intentionally destructive: it replaces every item
-inside the resolved project's `05_Final_Delivery/` directory. Dry-run lists the
-planned deletions before any changes occur.
+- Automation application release: v1.5
+- Automation API: `1.0`
+- readable metadata schemas: `1.1.0`
+- writable metadata schema: `1.1.0`
+- no v1.0 workspace migration
 
-## Upgrade and uninstall
+Existing valid v1.1+ workspaces remain usable. New records identify the current
+application release in `created_with` without changing the metadata schema
+identity.
 
-Running a newer release's `install.sh` upgrades the application transactionally
-without modifying studio workspaces.
+## Documentation
 
-```bash
-jl-mixing-uninstall
-```
+Start with [`docs/README.md`](docs/README.md), the
+[`User Guide`](docs/USER_GUIDE.md), and the
+[`Installation Guide`](docs/INSTALLATION_GUIDE.md).
 
-Uninstall removes the application, managed launchers, and the exact managed
-shell block. It never removes studio workspaces.
-
-## Developer setup and quality gates
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -r packaging/requirements.txt
-
-make test
-make strict-test
-tools/shellcheck-all
-make release-check
-```
-
-Release archives, checksums, and inventories are written to `dist/` by
-`make release`.
-
-See [docs/README.md](docs/README.md) for the full documentation index and
-[docs/RELEASE_NOTES_V1.3.md](docs/RELEASE_NOTES_V1.3.md) for release highlights.
+JL Mixing Automation is licensed under Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -10,15 +10,27 @@
   manage DAW templates, presets, or project metadata.
 - Original client delivery files are immutable.
 - JSON contains machine-managed state; Markdown contains human documentation.
-- Only the marked automated section in `Intake_Report.md` is rewritten.
+- Only explicitly managed Markdown sections may be rewritten automatically.
 - Client profile snapshots are immutable historical records.
 - Revision status is derived, not stored.
-- `validate-intake` preserves v1.0.4's opportunistic `ffprobe` behavior without
-  expanding audio QC in v1.1.
+- The authoritative v1.5 workflow implementation is cross-platform Python.
+  Platform-specific Bash, PowerShell, installer, and launcher code is thin glue
+  and must not become a second implementation.
+- Automation application versions, Automation API versions, and workspace
+  metadata schema versions are independent contracts.
+- Automation API remains `1.0` for v1.5 and workspace metadata remains `1.1.0`.
+- Machine clients use capability discovery; they do not parse human CLI output
+  or infer compatibility from the Automation product version.
+- `validate-intake` is non-destructive to original delivery files and may perform
+  metadata, decode-integrity, exact duplicate, format, channel, and exact
+  dual-mono checks. Unavailable external tools produce skipped-check reporting.
 - Delivery file eligibility is not restricted by extension.
 - Delivery classification is best-effort; unmatched files are `unclassified`.
 - `create-delivery --clean` explicitly authorizes removal of every item inside
   `05_Final_Delivery/` and remains rollback-capable.
-- Installation, upgrades, shell configuration, and uninstall are transactional.
-- User-facing commands are thin orchestration layers over shared libraries and
-  local helper tools.
+- Installation, upgrades, shell configuration, and uninstall are transactional
+  and preserve user workspaces.
+- Windows and macOS end-user packages carry a private runtime so users do not
+  need a separate Python/Bash/jq runtime installation.
+- Linux/source installation remains a compatibility path and may retain external
+  developer/runtime prerequisites.

--- a/docs/AUTOMATION_API_IMPLEMENTATION.md
+++ b/docs/AUTOMATION_API_IMPLEMENTATION.md
@@ -2,60 +2,87 @@
 
 ## Current implementation
 
-Automation API `1.0` discovery is implemented through:
+JL Mixing Automation v1.5 implements Automation API `1.0` on the same Python
+services used by the human CLI. Discovery is available through:
 
-```bash
+```text
 jl-mixing system-info --json
 ```
 
-The discovery response reports these independently versioned contracts:
+The discovery response reports independently versioned contracts:
 
-- Automation API version from `API_VERSION`;
-- Automation application release from `VERSION`;
-- readable and writable workspace metadata schema versions;
-- implemented machine-facing capabilities; and
-- installed and public API-schema locations.
+- Automation API version from `API_VERSION`
+- Automation application release from `VERSION`
+- readable and writable workspace metadata schema versions
+- implemented machine-facing capabilities
+- installed/public API schema locations
 
-The discovery response is governed by
-`api/schemas/v1.0/system-info.schema.json` and has a reviewed golden example at
-`api/examples/v1.0/success/system-info.json`.
+Workspace metadata remains schema `1.1.0`; application release changes do not
+implicitly change API or metadata-schema versions.
 
-## Distribution contract
+## Advertised capability set
 
-The installer and release archive ship the dispatcher, `API_VERSION`, API
-schemas, and golden examples as one versioned application unit. Installation,
-upgrade, archive-verification, and uninstall tests verify that:
-
-- the public `jl-mixing` launcher is installed and executable;
-- `system-info --json` resolves the installed schema directory;
-- the reported API, application, and metadata-schema versions remain distinct;
-- packaged discovery output validates against the installed schema; and
-- uninstall removes the managed dispatcher without modifying studio workspaces.
-
-## Capability admission rule
-
-`system-info` advertises only capabilities implemented and covered by contract
-tests. The initial capability set is:
+v1.5 advertises:
 
 ```text
+client.create
+delivery.create
+intake.validate
+intake.validate.report
+project.create
+project.create.artist
+revision.approve
+revision.create
+revision.create.description
 system.info
 ```
 
-Existing human-facing commands are not automatically Automation API operations.
-They remain supported, but Studio and other API clients must not treat their
-human-readable output as API `1.0` JSON.
+Each advertised workflow capability is backed by the shared Python service layer
+and structured API adapter rather than by parsing human-readable CLI output.
 
-Workflow capabilities such as `client.create`, `project.create`,
-`intake.validate`, `revision.create`, `revision.approve`, and `delivery.create`
-will be advertised only after their dispatcher routes, response envelopes,
-schemas, golden examples, parity tests, and packaging checks are implemented.
+## Contract artifacts
 
-## Compatibility
+API 1.0 schemas are shipped beneath:
 
-The Automation application version may change without changing `API_VERSION`
-when the published API contract remains backward compatible. Workspace metadata
-schema versions remain independent from both product and API versions.
+```text
+api/schemas/v1.0/
+```
 
-Within API major version 1, clients must ignore unknown optional fields and use
-capability discovery instead of inferring support from the Automation product
-release number.
+Reviewed success/error examples are shipped beneath:
+
+```text
+api/examples/v1.0/
+```
+
+`system-info` reports the installed schema location so offline clients can
+validate provider responses against the exact installed contract.
+
+## Distribution contract
+
+Windows and macOS release packages include the dispatcher, `API_VERSION`, API
+schemas/examples, shared Python services, and private runtime as one application
+unit. Linux/source installation uses the compatibility installer but exposes the
+same API contract.
+
+Release and lifecycle tests verify provider discovery, installed schemas,
+application/API/schema version separation, and workspace preservation during
+install/uninstall operations.
+
+## Compatibility rule
+
+Clients must admit providers based on:
+
+1. compatible `api_version`
+2. required capability names
+3. supported readable/writable metadata schema versions as appropriate
+
+Clients must not require the Automation product release number to match their
+own release number. Within API major version 1, clients should tolerate unknown
+optional response fields and rely on capability discovery for feature admission.
+
+## Human CLI relationship
+
+Human commands and machine operations share authoritative workflow services, but
+their presentation contracts are separate. Human-formatted stdout/stderr must
+not be treated as Automation API JSON unless a documented machine operation
+explicitly defines that output.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -3,66 +3,100 @@
 ## Repository architecture
 
 ```text
-bin/        User-facing Bash commands
-lib/        Shared Bash logic
-schemas/    Strict Draft 2020-12 v1.1 schemas
-templates/  Runtime JSON and Markdown templates
-docs/       User, design, and release documentation
-tests/      Unit, integration, installation, and package tests
-tools/      Python helpers and release utilities
-examples/   Canonical valid v1.1 JSON documents
-packaging/  Runtime dependency metadata
+src/jl_mixing/   Authoritative cross-platform Python services, CLIs, and API adapters
+bin/             Thin POSIX launchers and shell integration
+windows/         Windows packaging/install/shell glue
+macos/           macOS frozen-runtime packaging/install glue
+api/             Automation API 1.0 schemas and examples
+schemas/         Workspace metadata schemas (1.1.0)
+templates/       Runtime JSON and Markdown templates
+docs/            User, architecture, API, and release documentation
+tests/           Python, integration, installation, platform, and package tests
+tools/           Release/build utilities
+packaging/       Runtime/build dependency metadata
 ```
+
+The authoritative workflow implementation is Python. Platform-specific shell,
+PowerShell, and packaging code must remain thin and must not introduce a second
+workflow implementation.
+
+## Compatibility contracts
+
+Treat these versions independently:
+
+- application release: v1.5.x
+- Automation API: `1.0`
+- workspace metadata schema: `1.1.0`
+
+A product release does not require an API or metadata-schema bump when those
+contracts remain compatible.
 
 ## Coding standards
 
-- Maintain Bash 3.2 compatibility on macOS.
-- Do not rely on empty-array expansion under `set -u`.
-- Quote expansions unless splitting is intentional.
-- Validate external input and reject symlinks at ownership boundaries.
-- Use same-filesystem staging and rollback-capable transactions.
-- Keep user-authored Markdown untouched outside explicitly managed markers.
-- Keep command orchestration in `bin/`; reusable logic belongs in `lib/` or a
-  focused local helper under `tools/`.
+- Keep shared workflow behavior platform-neutral in `src/jl_mixing/`.
+- Preserve human CLI behavior unless a change is explicitly approved.
+- Preserve Automation API 1.0 response/operation contracts.
+- Reject symlinks and unsafe filesystem boundaries where JL Mixing owns data.
+- Use staged/rollback-capable mutation for multi-file operations.
+- Keep user-authored Markdown untouched outside explicitly managed sections.
+- Keep Windows/macOS launchers and installers non-authoritative.
 - Tests must use isolated temporary homes, prefixes, and workspaces.
+- Do not add workspace migration for valid v1.1+ data unless explicitly approved.
 
-## Validation layers
-
-1. JSON syntax
-2. Exact v1.1 schema identity and local Draft 2020-12 schema validation
-3. Cross-document identity and pointer validation
-4. Filesystem boundary and path validation
-
-Schemas are always loaded locally from the installed application. Runtime
-validation uses the private environment created by the installer.
+Legacy Bash remains only where required for Linux/source compatibility or thin
+platform glue; new workflow logic should not be added to the old Bash libraries.
 
 ## Development setup
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -r packaging/requirements.txt
+Use a supported Python 3 environment for service/API tests. Build-time packaging
+requirements are platform-specific:
+
+```text
+packaging/windows-build-requirements.txt
+packaging/macos-build-requirements.txt
 ```
 
-Required developer tools include `jq` and ShellCheck.
+PyInstaller is used to build the private frozen runtimes shipped in Windows and
+macOS release packages.
+
+## Validation layers
+
+1. argument/request validation
+2. JSON syntax and exact schema identity
+3. local Draft 2020-12 schema validation
+4. cross-document identity/pointer validation
+5. filesystem/path ownership validation
+6. staged transaction and post-operation verification
+
+API schemas and workspace schemas are loaded from the installed application; no
+network schema dependency is required at runtime.
 
 ## Quality gates
 
-```bash
-make test
-make strict-test
-tools/shellcheck-all
-make release-check
-```
+Run the repository's Python/unit/integration suites plus platform lifecycle and
+release-package checks. CI currently exercises:
 
-`make strict-test` includes installation and archive lifecycle tests. Tests must
-cover transaction failure and rollback, not only happy paths.
+- core tests and strict/release checks
+- native Windows command/install/package behavior
+- frozen Windows runtime
+- frozen macOS runtime
+- macOS self-contained installation lifecycle
+- release archive/checksum/inventory verification
+
+A release-affecting change should not merge until the applicable CI matrix is
+green.
 
 ## Release process
 
-1. Complete work through feature PRs into `develop/v1.3`.
-2. Run all quality gates from a clean integration branch.
-3. Build and verify the archive with `make release-check`.
-4. Merge `develop/v1.3` to `main` through a protected PR.
-5. Tag the merge commit `v1.3.0` and publish the verified archive, checksum, and
-   v1.3 release notes.
+1. Implement work on a feature/fix/release branch.
+2. Open a PR to `main`; never modify `main` directly.
+3. Run the complete applicable CI matrix and resolve failures on the branch.
+4. Merge the green PR.
+5. Prepare release-version/release-note changes on a dedicated release branch.
+6. Tag the approved merge commit using the release tag expected by the release
+   workflow.
+7. Verify generated macOS, Windows, and Linux assets, checksums, and inventories.
+8. Perform coordinated RC acceptance before publishing a stable release.
+
+For v1.5, Windows and macOS end-user packages must remain self-contained; users
+must not need a separately installed Python, Bash, or jq runtime.

--- a/docs/INSTALLATION_GUIDE.md
+++ b/docs/INSTALLATION_GUIDE.md
@@ -1,100 +1,174 @@
-# JL Mixing Automation v1.3 Installation Guide
+# JL Mixing Automation v1.5 Installation Guide
 
-## Requirements
+JL Mixing Automation v1.5 provides platform-specific packages. Windows and
+macOS packages include the private Python runtime used by Automation; Linux and
+source/developer installs retain the compatibility installer.
 
-- macOS or Linux
-- Bash 3.2 or newer
-- Python 3.10 or newer with `venv`
-- `jq`
-- Network access to install the pinned Python dependency unless the release
-  includes an offline wheelhouse
+## Windows
 
-`ffprobe` is optional and is checked only when `validate-intake` uses it.
+### Requirements
 
-## Standard installation
+- Windows x64
+- PowerShell
 
-Extract the release archive and run:
+No separate Python, Bash, or jq installation is required.
+
+### Install
+
+Extract `jl-mixing-<version>-windows.zip`, open PowerShell in the extracted
+folder, and run:
+
+```powershell
+.\windows\install.ps1
+```
+
+The default prefix is:
+
+```text
+%LOCALAPPDATA%\Programs\JL Mixing
+```
+
+The application is installed beneath `share\jl-mixing`, and public command
+launchers are installed beneath `bin`. The installer manages a PowerShell
+profile block that adds the command directory to PATH and loads the optional
+`--cd` shell integration. Open a new PowerShell session after installation.
+
+To skip profile changes:
+
+```powershell
+.\windows\install.ps1 -NoShellIntegration
+```
+
+To use another prefix:
+
+```powershell
+.\windows\install.ps1 -Prefix "C:\Tools\JL Mixing"
+```
+
+### Uninstall
+
+Run the matching packaged uninstaller with the same prefix when applicable:
+
+```powershell
+.\windows\uninstall.ps1
+```
+
+or:
+
+```powershell
+.\windows\uninstall.ps1 -Prefix "C:\Tools\JL Mixing"
+```
+
+The uninstaller removes only JL Mixing-managed application files, launchers, and
+PowerShell profile integration. Studio workspaces are not modified.
+
+## macOS
+
+### Requirements
+
+The release archive contains its private runtime. A separate Python or jq install
+is not required for the packaged macOS path.
+
+### Install
+
+Extract `jl-mixing-<version>-macos.tar.gz`, then run:
+
+```bash
+./macos/install.sh
+```
+
+The default prefix is `~/.local`:
+
+```text
+Application: ~/.local/share/jl-mixing/
+Commands:    ~/.local/bin/
+```
+
+The installer manages exactly one block in `.zshrc` or `.bashrc` for PATH and
+optional `--cd` integration. Existing content outside that managed block is
+preserved. Open a new Terminal tab after installation.
+
+To skip shell integration:
+
+```bash
+./macos/install.sh --no-shell-integration
+```
+
+To use another prefix:
+
+```bash
+./macos/install.sh --prefix "$HOME/Applications/jl-local"
+```
+
+### Uninstall
+
+From an extracted matching package, run:
+
+```bash
+./macos/uninstall.sh
+```
+
+Use `--prefix PATH` when the application was installed under a custom prefix.
+The uninstaller removes managed application files, launchers, and the managed
+shell block while preserving workspaces and project content.
+
+## Linux and source/developer installation
+
+The compatibility installer remains:
 
 ```bash
 ./install.sh
 ```
 
-Default locations:
+Requirements for this path are:
+
+- Bash 3.2 or newer
+- Python 3.10 or newer with `venv`
+- jq
+
+The default prefix is `~/.local`. `--prefix` and `--no-shell-integration` remain
+available. This installer may create a private virtual environment and therefore
+is distinct from the frozen runtime included in Windows/macOS release packages.
+
+## Optional intake-QC tools
+
+`ffprobe` and `ffmpeg` enable enhanced audio intake checks such as metadata
+inspection and full-file decode verification. When an external check is not
+available, `validate-intake` reports it as skipped rather than treating it as a
+pass.
+
+## Verify an installation
+
+After opening a new shell, run:
 
 ```text
-~/.local/share/jl-mixing/
-~/.local/bin/
-```
-
-The installer builds and verifies the complete application in a staging area,
-then commits the application, launchers, and shell configuration together. A
-failed install restores the previous working version.
-
-## Automatic shell configuration
-
-By default, the installer detects bash or zsh and manages exactly one block in
-`.bashrc` or `.zshrc`:
-
-```text
-# >>> JL Mixing managed configuration >>>
-...
-# <<< JL Mixing managed configuration <<<
-```
-
-The block adds the single installed `bin` directory to `PATH` and sources the
-wrapper integration used by `--cd`. Existing startup-file content outside the
-block is preserved byte-for-byte. Open a new Terminal tab after installation.
-
-To avoid startup-file modification:
-
-```bash
-./install.sh --no-shell-integration
-```
-
-The commands still work; automatic directory changes fall back to a quoted
-copy-and-paste `cd` command.
-
-## Custom prefix
-
-```bash
-./install.sh --prefix "$HOME/Applications/jl-local"
-```
-
-The environment variable `JL_MIXING_INSTALL_PREFIX` is also supported, but an
-explicit `--prefix` takes precedence.
-
-## Verify the installed Automation API
-
-After installation, machine-readable discovery is available through:
-
-```bash
 jl-mixing system-info --json
 ```
 
-The installed application includes `API_VERSION` and the matching schemas and
-examples under `~/.local/share/jl-mixing/api/` (or the selected prefix). The
-reported `schemas.installed_path` identifies the exact offline schema directory.
+The response reports:
 
-## Upgrade
+- Automation API version (`1.0`)
+- installed application version
+- readable and writable metadata schemas (`1.1.0`)
+- implemented API capabilities
+- installed API schema location
 
-Extract the newer release and run its installer with the same prefix. Reinstall
-is idempotent: the single managed shell block is replaced in place and the
-active application is not changed until the staged version passes verification.
-Studio workspaces are never modified.
+You can also verify the human command surface with:
 
-## Uninstall
-
-```bash
-jl-mixing-uninstall
+```text
+new-client --help
+new-mix --help
+validate-intake --help
 ```
 
-The uninstaller removes managed application files, launchers, and the exact
-managed shell block as one rollback-capable transaction. Studio workspaces,
-audio, and project data are never removed. Open a new Terminal tab afterward to
-clear already-loaded shell functions and PATH entries.
+## Upgrade/reinstall behavior
 
-## Fresh workspace requirement
+Reinstall using the newer package for the same platform and prefix. Installers
+stage and validate managed application state before replacing the prior install.
+User workspaces are outside the application prefix and are not migrated or
+removed during install, reinstall, or uninstall.
 
-v1.3 supports valid v1.1 workspaces. Installation or upgrade does not migrate
-v1.0 workspaces. Use a separate root when retaining a v1.0 workspace for
-reference.
+## Workspace compatibility
+
+v1.5 continues to read and write metadata schema `1.1.0`. Existing valid v1.1+
+workspaces remain usable. v1.0 workspace contents are not migrated.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 - [v1.1 Release Notes](RELEASE_NOTES_V1.1.md)
 - [v1.2 Release Notes](RELEASE_NOTES_V1.2.md)
 - [v1.3 Release Notes](RELEASE_NOTES_V1.3.md)
+- [v1.4 Release Notes](RELEASE_NOTES_V1.4.md)
 
 For current behavior, prefer the v1.5 User Guide, Command Reference,
 Installation Guide, API implementation-status document, and v1.5 release notes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,31 @@
 # Documentation Index
 
+## Current user and integration documentation
+
 - [User Guide](USER_GUIDE.md)
 - [Command Reference](SCRIPT_REFERENCE.md)
 - [Installation Guide](INSTALLATION_GUIDE.md)
 - [Automation API Design](AUTOMATION_API.md)
 - [Automation API Implementation Status](AUTOMATION_API_IMPLEMENTATION.md)
+- [v1.5 Release Notes](RELEASE_NOTES_V1.5.md)
+
+## Development and architecture
+
 - [Automation Roadmap](ROADMAP.md)
-- [v1.1 Design Summary](DESIGN_SPECIFICATION_V1.md)
 - [Developer Guide](DEVELOPER_GUIDE.md)
 - [Architecture Decisions](ARCHITECTURE_DECISIONS.md)
+- [Project Maintenance](PROJECT_MAINTENANCE.md)
+
+## Historical release/design material
+
+- [v1.1 Design Summary](DESIGN_SPECIFICATION_V1.md)
 - [v1.1 Scope Summary](SCOPE_FREEZE_V1.md)
 - [v1.2 Scope Freeze](SCOPE_FREEZE_V1.2.md)
 - [v1.1 Release Notes](RELEASE_NOTES_V1.1.md)
 - [v1.2 Release Notes](RELEASE_NOTES_V1.2.md)
 - [v1.3 Release Notes](RELEASE_NOTES_V1.3.md)
-- [Project Maintenance](PROJECT_MAINTENANCE.md)
 
-Historical v1.1 design artifacts remain available; `SCOPE_FREEZE_V1.2.md`
-defines the approved v1.2 implementation boundary. The Automation API design
-and implementation-status documents govern the machine-facing contract.
+For current behavior, prefer the v1.5 User Guide, Command Reference,
+Installation Guide, API implementation-status document, and v1.5 release notes.
+Older design/scope documents remain available as historical records and should
+not override the current implementation contract.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,43 +1,73 @@
 # JL Mixing Automation Roadmap
 
-**Status:** Proposed for review
+**Status:** Living, version-agnostic backlog guidance
 
 ## Product role
 
-JL Mixing Automation is the stable workflow engine and CLI for the JL Mixing ecosystem. It owns project structure, metadata validation, lifecycle rules, filesystem mutation, delivery behavior, and the public machine-readable Automation API.
+JL Mixing Automation is the stable workflow engine and CLI for the JL Mixing
+ecosystem. It owns project structure, metadata validation, lifecycle rules,
+filesystem mutation, delivery behavior, and the public machine-readable
+Automation API.
 
 ## Versioning
 
-The Automation application version, Automation API version, and metadata schema version are independent. Application releases may retain the same API and schema versions when their contracts do not change.
+The Automation application version, Automation API version, and metadata schema
+version are independent. Application releases may retain the same API and schema
+versions when those contracts do not change.
 
-## Near-term priorities
+The current v1.5 line uses:
 
-1. Preserve the released v1.3.0 CLI behavior and v1.1.0 metadata schemas.
-2. Define Automation API 1.0 without changing existing human-oriented CLI behavior.
-3. Add machine-readable compatibility discovery.
-4. Add consistent JSON envelopes, operation identifiers, errors, warnings, and result semantics for Studio-supported operations.
-5. Add contract fixtures and tests that Studio can validate against.
+- Automation API `1.0`
+- workspace metadata schema `1.1.0`
+- one authoritative cross-platform Python implementation
 
-## Candidate API 1.x capabilities
+## Current release priority
 
-These are candidates, not committed release scope:
+Complete v1.5 cross-platform acceptance on macOS and Windows while preserving
+existing CLI/API/workspace compatibility. RC findings should be fixed before the
+stable release when they materially affect supported behavior.
 
-- system and capability discovery;
-- structured dry-run plans;
-- structured results for existing workflow commands;
-- project, client, revision, and delivery inspection;
-- structured validation findings;
-- project health checks;
-- batch operations where transaction and partial-failure semantics are explicitly designed.
+## Future-feature policy
+
+Future work is maintained as a version-agnostic backlog until a specific release
+scope is explicitly approved. Do not assign proposed features to product versions
+merely because they are discussed or captured as issues.
+
+Candidate areas include:
+
+- delivery-workflow usability and note-preservation semantics
+- native one-click Windows/macOS installers
+- project archive/restore design
+- additional intake-QC capabilities
+- structured inspection/health operations
+- batch operations with explicitly designed transaction semantics
+
+GitHub issues are the source of truth for the detailed design and readiness of
+these items.
 
 ## Metadata policy
 
-Metadata changes are the slowest-moving track. Add persisted fields only when the information must travel with the workspace and be understood by Automation, Studio, or another supported client. UI preferences, recent items, favorites, search history, and rebuildable indexes do not belong in project schemas.
+Metadata changes are the slowest-moving track. Add persisted fields only when the
+information must travel with the workspace and be understood by Automation,
+Studio, or another supported client. UI preferences, recent items, favorites,
+search history, and rebuildable indexes do not belong in project schemas.
+
+## API policy
+
+Automation API capabilities are advertised only when the structured operation,
+response envelope, schema/examples, parity tests, and packaging/install behavior
+are implemented. Machine clients use capability discovery instead of product
+version matching.
 
 ## Release admission rule
 
-A feature is assigned to an Automation release only after its behavior, API impact, schema impact, compatibility requirements, tests, and Studio dependency are approved. Cross-repository features use linked issues rather than a single mixed implementation issue.
+A feature is assigned to an Automation release only after its behavior, API
+impact, schema impact, compatibility requirements, tests, and Studio dependency
+are reviewed and explicitly approved. Cross-repository features use linked issues
+rather than a single mixed implementation issue.
 
 ## Non-goals
 
-Automation does not own desktop presentation, local UI preferences, general-purpose indexing, cloud collaboration, accounting, CRM, or DAW session processing.
+Automation does not own desktop presentation, local UI preferences,
+general-purpose indexing, cloud collaboration, accounting, CRM, or DAW session
+processing.

--- a/docs/SCRIPT_REFERENCE.md
+++ b/docs/SCRIPT_REFERENCE.md
@@ -1,7 +1,7 @@
-# JL Mixing Automation v1.3 Command Reference
+# JL Mixing Automation v1.5 Command Reference
 
-Every command supports `-h` and `--help`. Mutating commands validate governing
-JSON and filesystem boundaries before committing changes.
+Every human-facing command supports `-h` and `--help`. Mutating commands validate
+workspace metadata and filesystem boundaries before committing changes.
 
 ## `jl-mixing`
 
@@ -11,15 +11,11 @@ jl-mixing --help
 ```
 
 `jl-mixing` is the canonical machine-facing Automation API dispatcher.
-`system-info --json` writes exactly one JSON discovery object to standard output
-and reports the Automation API version, application release, metadata schema
-compatibility, implemented capabilities, and installed API schema location.
+`system-info --json` reports the Automation API version, application release,
+metadata schema compatibility, capabilities, and installed API schema location.
 
-API clients must use the reported `api_version` and `capabilities`. They must not
-infer compatibility from the Automation application release. The initial API
-1.0 capability set contains only `system.info`; existing human-facing commands
-remain outside the machine API until their structured operation contracts are
-implemented.
+API clients must use `api_version` and `capabilities`, not the application
+release number, to determine compatibility.
 
 ## `new-studio`
 
@@ -30,8 +26,7 @@ new-studio [--root PATH] [--name NAME] [--engineer NAME]
            [--default-cd|--no-default-cd] [--dry-run]
 ```
 
-Creates a new, previously nonexistent workspace. No DAW directories or DAW
-metadata are created.
+Creates a new workspace. The default root is `~/Music/Mixes/`.
 
 ## `new-client`
 
@@ -39,10 +34,20 @@ metadata are created.
 new-client CLIENT_ID [--name NAME] [--artist NAME]
            [--sample-rate HZ] [--bit-depth BITS]
            [--file-format WAV|AIFF] [--delivery-method TEXT]
-           [--deliverables LIST] [--cd|--no-cd] [--dry-run]
+           [--deliverables LIST] [--root PATH]
+           [--cd|--no-cd] [--dry-run]
 ```
 
 Creates `Clients/<Readable Name>/client.json` and `Projects/`.
+
+Studio-root resolution order is:
+
+1. explicit `--root PATH`
+2. `JL_MIXING_ROOT`
+3. current-directory studio context
+4. default `~/Music/Mixes` workspace
+
+This allows studio-level client creation from an unrelated working directory.
 
 ## `new-mix`
 
@@ -59,14 +64,9 @@ Options include:
   --description TEXT   --source PATH    --cd|--no-cd  --dry-run
 ```
 
-Exactly one project name is required. The positional form may appear before or
-after other valid options. Supplying both forms or additional positional
-arguments is rejected before filesystem mutation.
-
-Creates the complete flattened project tree, strict project manifest, immutable
-client-profile snapshot, and unapproved `Revision_01/Revision_Notes.md` in one
-atomic transaction. When `--artist` is omitted, artist precedence is client
-artist default, then client display name.
+Creates the complete project tree, project manifest, client-profile snapshot,
+and unapproved Revision 1 transactionally. Artist precedence is explicit
+`--artist`, client artist default, then client display name.
 
 ## `validate-intake`
 
@@ -77,8 +77,13 @@ validate-intake [--project PATH] [--source PATH]
                 [--no-duplicate-check] [--dry-run]
 ```
 
-Preserves v1.0.4 intake behavior while writing the clearer v1.1-schema managed
-report. `--no-duplicate-check` skips duplicate-basename detection only.
+Validation is read-only with respect to original client files. The managed report
+can include metadata, decode-integrity results, exact SHA-256 duplicates,
+project-format mismatches, channel counts, exact dual-mono warnings, unsupported
+or unreadable files, skipped checks, and preparation recommendations.
+
+`ffprobe` and `ffmpeg` are used when available for enhanced checks. Missing
+external inspection tools produce explicit skipped-check reporting.
 
 ## `new-revision`
 
@@ -88,8 +93,7 @@ new-revision [--project PATH] [--description TEXT]
 ```
 
 Creates the next contiguous `Revision_NN/` directory and advances
-`state.current_revision` transactionally. For v1.2-created projects, the first
-call creates Revision 2. Existing valid zero-revision projects remain supported.
+`state.current_revision` transactionally.
 
 ## `approve-mix`
 
@@ -98,8 +102,8 @@ approve-mix [--project PATH] [--revision NUMBER]
             [--approved-by NAME] [--date TIMESTAMP] [--dry-run]
 ```
 
-Approves the current revision by default. Approval may move to any existing
-revision. Approval does not modify revision files or final-delivery content.
+Approves the current revision by default. Approval may move to another existing
+revision and does not modify revision files or final-delivery content.
 
 ## `create-delivery`
 
@@ -110,20 +114,47 @@ create-delivery [--project PATH] [--include PATTERN]
 ```
 
 Packages the approved revision, verifies copied bytes with SHA-256, writes the
-strict delivery manifest, and updates `state.delivered_revision` as one
-rollback-capable transaction.
+delivery manifest, and updates `state.delivered_revision` transactionally.
 
-To create a ZIP with completed notes, run `create-delivery`, edit
-`05_Final_Delivery/Delivery_Notes.md`, then run
-`create-delivery --zip --overwrite`. `--overwrite` requires an unchanged
-delivered path set. `--clean` replaces all contents of `05_Final_Delivery/`, not
-only files listed by a prior manifest.
+For a ZIP containing edited delivery notes:
 
-`--zip` creates
-`<project-id>-rev-<NN>-<YYYYMMDDHHMMSS>.zip`, using the delivered revision and
-a local creation timestamp.
+```text
+create-delivery
+edit 05_Final_Delivery/Delivery_Notes.md
+create-delivery --zip --overwrite
+```
 
-## Removed v1.0 interface
+`--overwrite` requires an unchanged delivered path set. `--clean` replaces all
+contents inside `05_Final_Delivery/`; review `--dry-run --clean` before using it.
 
-v1.3 retains the v1.1 removal of the project-completion command. Known v1.0
-flags are rejected with specific diagnostics rather than silently ignored.
+Generated ZIPs use:
+
+```text
+<project-id>-rev-<NN>-<YYYYMMDDHHMMSS>.zip
+```
+
+## Automation API 1.0 capabilities
+
+v1.5 advertises these capability names through `system-info`:
+
+```text
+client.create
+delivery.create
+intake.validate
+intake.validate.report
+project.create
+project.create.artist
+revision.approve
+revision.create
+revision.create.description
+system.info
+```
+
+The API schemas under `api/schemas/v1.0/` govern machine request/response
+contracts. Human CLI output is not a machine API contract.
+
+## Removed legacy interface
+
+v1.5 retains the v1.1 removal of the project-completion command and other retired
+v1.0 options. Known removed flags are rejected with explicit diagnostics rather
+than silently ignored.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,8 +1,8 @@
-# JL Mixing Automation v1.3 User Guide
+# JL Mixing Automation v1.5 User Guide
 
 ## 1. Create the workspace
 
-```bash
+```text
 new-studio
 ```
 
@@ -12,9 +12,16 @@ override that preference for an individual command.
 
 ## 2. Create a client
 
-```bash
+```text
 new-client acme --name "Acme Records"
 ```
+
+`new-client` may be run from anywhere. Studio-root resolution uses:
+
+1. `--root PATH`
+2. `JL_MIXING_ROOT`
+3. current-directory studio context
+4. `~/Music/Mixes`
 
 A client contains `client.json` and a flattened `Projects/` directory. Audio and
 delivery defaults are inherited from `studio.json` unless overridden. An artist
@@ -22,144 +29,137 @@ default is optional.
 
 ## 3. Create a project and Revision 1
 
-From the client directory:
+From a client directory or with an explicit client reference:
 
-```bash
+```text
 new-mix "Blue Sky"
+new-mix "Blue Sky" --client acme
 ```
 
-The equivalent explicit form remains supported:
+The equivalent `--project "Blue Sky"` form remains supported. When `--artist`
+is omitted, the project uses the nonempty `client.defaults.artist` value and
+then the client's display name.
 
-```bash
-new-mix --project "Blue Sky"
-```
-
-When `--artist` is omitted, the project uses the nonempty
-`client.defaults.artist` value and then the client's display name. An explicit
-nonempty `--artist` overrides both; an explicit empty value is rejected.
-
-`new-mix` creates `04_Revisions/Revision_01/Revision_Notes.md` with the
-description `Initial mix`. The new project starts in the existing `In progress`
-state with Revision 1 unapproved.
-
-Use `--source PATH` to copy an initial delivery into
-`01_Client_Files/Original_Delivery/`. The source is copied, never moved or
-modified. It is not copied into Revision 1. The project is created directly
-beneath the client's `Projects/` directory and keeps the same path for its
-entire lifetime.
+`new-mix` creates `04_Revisions/Revision_01/Revision_Notes.md` with the initial
+revision description. Use `--source PATH` to copy an initial client delivery into
+`01_Client_Files/Original_Delivery/`. Source material is copied, never moved or
+modified.
 
 ## 4. Validate intake
 
-```bash
+```text
 validate-intake
 ```
 
-The command recursively inventories the original delivery, preserves v1.0.4's
-recognized-extension and duplicate-basename behavior, and uses `ffprobe`
-opportunistically when available. It updates only the managed section in
-`00_Admin/Intake_Report.md`; text outside the markers is preserved.
+Validation is non-destructive to `01_Client_Files/Original_Delivery/`. The
+managed intake report can include:
+
+- file inventory and channel counts
+- project-format mismatches
+- exact SHA-256 duplicate detection
+- corrupt/unreadable-file findings
+- `ffprobe` metadata inspection when available
+- full-file decode integrity checks through `ffmpeg` when available
+- exact dual-mono warnings for stereo files with identical channels
+- skipped checks and preparation recommendations
+
+Unavailable external inspection tools are reported as skipped. JL Mixing does
+not automatically convert, repair, rename, move, or delete original client
+files.
 
 Prepare accepted files manually in `02_Audio_Preparation/Working_Audio/` and
 record engineering decisions in `Preparation_Report.md`.
 
 ## 5. Work with revisions
 
-Place the initial mix prints directly in:
+Place initial mix prints in:
 
 ```text
 04_Revisions/Revision_01/
 ```
 
-Send those files to the client using the studio's normal review process. When a
-later revision is needed, run:
+When another revision is needed:
 
-```bash
+```text
 new-revision --description "Client notes addressed"
 ```
 
 Use `--source FILE_OR_DIRECTORY` to copy immediate mix-print files into the new
-`Revision_NN/` directory. Files can also be placed there manually after
-creation. JL Mixing does not add a separate review-packaging command.
+revision directory. JL Mixing does not add a separate review-package lifecycle.
 
 ## 6. Record approval
 
-```bash
+```text
 approve-mix
 ```
 
 The current revision is approved by default. An older existing revision can be
 selected explicitly:
 
-```bash
+```text
 approve-mix --revision 2 --approved-by "Client"
 ```
 
-Approval updates project metadata only. It does not copy files or alter the
+Approval updates project metadata only. It does not alter revision files or an
 existing final-delivery package.
 
 ## 7. Create final delivery
 
-```bash
+```text
 create-delivery
 ```
 
-The command always packages the approved revision. It considers every immediate
-regular file except `Revision_Notes.md`; there is no extension allowlist.
-`--include`, `--exclude`, and `--working-prefix` control selection.
+The command packages the approved revision, considering immediate regular files
+except `Revision_Notes.md`. `--include`, `--exclude`, and `--working-prefix`
+control selection. Copied files are SHA-256 verified and recorded in the delivery
+manifest.
 
-Recognized naming phrases are classified on a best-effort basis. Unmatched files
-use `unclassified` and remain valid deliverables. Only files recognized as stems
-are placed beneath `05_Final_Delivery/Stems/`.
+### ZIP workflow
 
-Each copied file is verified by comparing source and staged SHA-256 values. The
-final manifest records the destination-relative path, classification, size, and
-SHA-256.
+To include edited delivery notes in a ZIP:
 
-### Create a ZIP with completed delivery notes
-
-Use this two-step workflow:
-
-```bash
+```text
 create-delivery
 # Edit 05_Final_Delivery/Delivery_Notes.md
 create-delivery --zip --overwrite
 ```
 
-The first command creates an editable delivery folder. The second rebuilds the
-same delivery and creates a ZIP containing the edited `Delivery_Notes.md`.
-
-ZIP filenames identify the delivered revision and creation time:
+Generated ZIP names use:
 
 ```text
 <project-id>-rev-<NN>-<YYYYMMDDHHMMSS>.zip
 ```
 
-The revision is zero-padded and the timestamp uses the computer's local timezone. For example:
-`blue-sky-rev-01-20260724153045.zip`. Each generated archive has a unique,
-traceable name; earlier generated archives are not nested inside later ones.
-
-`--overwrite` requires the delivered path set to remain unchanged. File contents
-may change, but adding, removing, or renaming delivered paths causes overwrite
-to fail. A one-step `create-delivery --zip` contains the clean notes template
-because the ZIP is created before the user has an opportunity to edit it.
-
 ### Replacing a delivery
 
-```bash
+```text
 create-delivery --overwrite
 ```
 
-`--overwrite` is for same-shape replacement and preserves unrelated content.
-It fails if old tracked files would become stale.
+`--overwrite` is for same-shape replacement and requires the delivered path set
+to remain unchanged.
 
-```bash
+```text
 create-delivery --clean
 ```
 
-`--clean` is intentionally destructive. It replaces **every file and directory**
-inside the project's `05_Final_Delivery/`, including untracked and user-added
-content. Preserve edited notes before using it. Use `--dry-run --clean` to review
-the exact deletion plan first.
+`--clean` replaces every file and directory inside the project's
+`05_Final_Delivery/`. Review `create-delivery --dry-run --clean` before using it.
+Current v1.5 behavior may regenerate delivery-note templates during a clean
+rebuild; delivery-note preservation semantics are tracked for a future workflow
+revision.
+
+## 8. Machine/API integration
+
+JL Mixing Studio and other machine clients discover Automation with:
+
+```text
+jl-mixing system-info --json
+```
+
+Automation API `1.0` exposes capability-backed client, project, intake,
+revision/approval, delivery, and system-info operations. Machine clients should
+use API capabilities instead of parsing human CLI output.
 
 ## Directory layout
 
@@ -179,10 +179,10 @@ the exact deletion plan first.
 ```
 
 `03_DAW_Project/` is opaque user/DAW-owned content. JL Mixing creates the
-boundary but does not interpret, clean, or manage native DAW project files.
+boundary but does not interpret or manage native DAW project files.
 
-## v1.0 compatibility
+## Compatibility
 
-v1.2 continues using v1.1 workspace schemas and supports valid v1.1 workspaces.
-It does not migrate v1.0 workspaces. Commands stop before modifying a workspace
-that uses a v1.0 schema or recognizable v1.0 layout.
+v1.5 continues using metadata schema `1.1.0` and supports valid v1.1+
+workspaces. It does not migrate v1.0 workspaces. Application, Automation API,
+and metadata schema versions are independent contracts.

--- a/packaging/RELEASE_README.md
+++ b/packaging/RELEASE_README.md
@@ -1,51 +1,71 @@
-# JL Mixing Automation v1.3
+# JL Mixing Automation v1.5
 
-JL Mixing Automation creates repeatable professional mixing project workspaces,
-tracks revision approval, and builds SHA-256-verified final-delivery packages.
-
-## Requirements
-
-- Bash 3.2 or newer
-- Python 3.10 or newer
-- `jq`
-- Optional: `ffprobe` for enhanced intake reporting
+JL Mixing Automation creates repeatable mixing-project workspaces, manages
+revision approval, validates intake, and builds SHA-256-verified final-delivery
+packages.
 
 ## Install
+
+### Windows
+
+Extract `jl-mixing-<version>-windows.zip`, then run:
+
+```powershell
+.\windows\install.ps1
+```
+
+The package contains its private runtime. No separate Python, Bash, or jq install
+is required. The default prefix is:
+
+```text
+%LOCALAPPDATA%\Programs\JL Mixing
+```
+
+Open a new PowerShell session after installation.
+
+### macOS
+
+Extract `jl-mixing-<version>-macos.tar.gz`, then run:
+
+```bash
+./macos/install.sh
+```
+
+The package contains its private runtime. The default prefix is `~/.local`.
+Open a new Terminal tab after installation so managed shell integration is
+active.
+
+### Linux/source compatibility path
+
+Extract the Linux archive and run:
 
 ```bash
 ./install.sh
 ```
 
-Default locations:
+This path requires Bash, Python 3.10+ with `venv`, and jq.
 
-```text
-Application: ~/.local/share/jl-mixing/
-Commands:    ~/.local/bin/
-```
-
-The installer configures one managed `.zshrc` or `.bashrc` block so no separate
-PATH or wrapper setup is required. Open a new Terminal tab after installation.
-Use `./install.sh --no-shell-integration` to opt out of startup-file changes.
+Optional external `ffprobe`/`ffmpeg` tools enable enhanced intake QC. Checks that
+cannot run are reported as skipped.
 
 ## Start
 
-```bash
+```text
 new-studio
+new-client acme --name "Acme Records"
+new-mix "Blue Sky" --client acme
 ```
 
-The default workspace is `~/Music/Mixes/`. v1.3 supports valid v1.1 workspaces
-and does not migrate v1.0 workspaces. New records retain the v1.1.0 metadata
-schema while recording the v1.3 application release in `created_with`.
+The default workspace is `~/Music/Mixes/`. `new-client` can run outside a studio
+context; root resolution is `--root`, then `JL_MIXING_ROOT`, then current studio
+context, then the default workspace.
 
 ## Workflow
 
 ```text
-new-studio → new-client → new-mix (creates Revision_01) → validate-intake
-→ manual mix/review → approve-mix → create-delivery
+new-studio -> new-client -> new-mix -> validate-intake
+-> manual mix/review -> new-revision as needed -> approve-mix -> create-delivery
 ```
-
-Use `new-revision` for later revisions. `new-mix PROJECT_NAME` and
-`new-mix --project PROJECT_NAME` are both supported.
 
 For a ZIP with completed delivery notes:
 
@@ -55,33 +75,38 @@ edit 05_Final_Delivery/Delivery_Notes.md
 create-delivery --zip --overwrite
 ```
 
-Generated ZIPs use
-`<project-id>-rev-<NN>-<YYYYMMDDHHMMSS>.zip`, with a zero-padded revision and
-local timestamp.
+Generated ZIPs use `<project-id>-rev-<NN>-<YYYYMMDDHHMMSS>.zip`.
+`create-delivery --clean` replaces all contents inside the selected project's
+`05_Final_Delivery/` directory; use its dry-run mode before destructive cleanup.
 
-`create-delivery --clean` deletes and replaces all contents inside the selected
-project's `05_Final_Delivery/` directory.
+## Automation API
 
-## Automation API discovery
+Machine clients use:
 
-Supported machine clients use:
-
-```bash
+```text
 jl-mixing system-info --json
 ```
 
-The JSON response reports the independent Automation API version, application
-release, metadata schema compatibility, implemented capabilities, and bundled
-schema path. API compatibility must be determined from `api_version` and
-`capabilities`, not from the application release number.
+Automation API `1.0` reports the application version, readable/writable metadata
+schema versions, installed schema path, and supported capabilities. Application,
+API, and metadata schema versions are independent contracts.
 
-## Upgrade and uninstall
+## Compatibility
 
-Run the new release's `install.sh` to upgrade transactionally. Workspaces are
-not modified.
+- Automation API: `1.0`
+- metadata schema: `1.1.0`
+- valid v1.1+ workspaces remain supported
+- no v1.0 workspace migration
 
-```bash
-jl-mixing-uninstall
-```
+## Uninstall
+
+Windows: run the included `windows\uninstall.ps1` from the package/application
+installation path as documented in the Installation Guide.
+
+macOS: run the packaged `macos/uninstall.sh` or installed managed uninstaller as
+documented for the selected prefix.
+
+Uninstall removes JL Mixing-managed application files and shell integration but
+preserves user workspaces and project content.
 
 See `docs/USER_GUIDE.md` and `docs/INSTALLATION_GUIDE.md` for complete details.

--- a/src/jl_mixing/new_client_cli.py
+++ b/src/jl_mixing/new_client_cli.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 from .client import ClientCreateRequest, create_client
 from .context import studio_root
-from .errors import ArgumentError, JLMixingError, ValidationError
+from .errors import ArgumentError, ContextError, JLMixingError, ValidationError
 
-_USAGE = """Usage: new-client CLIENT_ID [options]\n\nOptions:\n  --name NAME             Display name (default: title-cased client ID)\n  --artist NAME           Default artist or program name\n  --sample-rate HZ        Default project sample rate\n  --bit-depth BITS        Default project bit depth\n  --file-format FORMAT    Default project format: WAV or AIFF\n  --delivery-method TEXT  Default delivery method\n  --deliverables LIST     Comma-separated requested deliverables\n  --cd                    Enter the new client directory after creation\n  --no-cd                 Remain in the current directory after creation\n  --dry-run               Show the planned client without creating it\n  -h, --help              Show this help\n"""
+_USAGE = """Usage: new-client CLIENT_ID [options]\n\nOptions:\n  --name NAME             Display name (default: title-cased client ID)\n  --artist NAME           Default artist or program name\n  --sample-rate HZ        Default project sample rate\n  --bit-depth BITS        Default project bit depth\n  --file-format FORMAT    Default project format: WAV or AIFF\n  --delivery-method TEXT  Default delivery method\n  --deliverables LIST     Comma-separated requested deliverables\n  --root PATH             Studio root to target explicitly\n  --cd                    Enter the new client directory after creation\n  --no-cd                 Remain in the current directory after creation\n  --dry-run               Show the planned client without creating it\n  -h, --help              Show this help\n"""
 
 
 def _removed_option(name: str) -> ArgumentError:
@@ -36,6 +36,20 @@ def _parse_deliverables(value: str) -> list[str]:
     return values
 
 
+def _resolve_studio_root(explicit_root: str | None) -> Path:
+    if explicit_root:
+        return studio_root(Path(explicit_root).expanduser())
+
+    configured_root = os.environ.get("JL_MIXING_ROOT")
+    if configured_root:
+        return studio_root(Path(configured_root).expanduser())
+
+    try:
+        return studio_root(Path.cwd())
+    except ContextError:
+        return studio_root(Path.home() / "Music" / "Mixes")
+
+
 def _parse(args: list[str]) -> tuple[ClientCreateRequest | None, bool]:
     if not args:
         raise ArgumentError("client ID must not be empty.")
@@ -53,6 +67,7 @@ def _parse(args: list[str]) -> tuple[ClientCreateRequest | None, bool]:
         "file_format": None,
         "delivery_method": None,
         "deliverables": None,
+        "root": None,
     }
     cd_value: bool | None = None
     cd_seen = False
@@ -73,7 +88,16 @@ def _parse(args: list[str]) -> tuple[ClientCreateRequest | None, bool]:
             cd_value = False
         elif arg == "--dry-run":
             dry_run = True
-        elif arg in {"--name", "--artist", "--sample-rate", "--bit-depth", "--file-format", "--delivery-method", "--deliverables"}:
+        elif arg in {
+            "--name",
+            "--artist",
+            "--sample-rate",
+            "--bit-depth",
+            "--file-format",
+            "--delivery-method",
+            "--deliverables",
+            "--root",
+        }:
             index += 1
             if index >= len(args):
                 raise ArgumentError(f"{arg} requires a value.")
@@ -96,8 +120,10 @@ def _parse(args: list[str]) -> tuple[ClientCreateRequest | None, bool]:
                 values["file_format"] = value
             elif arg == "--delivery-method":
                 values["delivery_method"] = value
-            else:
+            elif arg == "--deliverables":
                 values["deliverables"] = _parse_deliverables(value)
+            else:
+                values["root"] = value
         elif arg.startswith("-"):
             raise ArgumentError(f"Unknown option: {arg}")
         else:
@@ -109,8 +135,8 @@ def _parse(args: list[str]) -> tuple[ClientCreateRequest | None, bool]:
     if dry_run and (cd_seen or no_cd_seen):
         raise ArgumentError("--cd and --no-cd cannot be used with --dry-run.")
 
-    configured_root = os.environ.get("JL_MIXING_ROOT")
-    root = studio_root(Path(configured_root) if configured_root else Path.cwd())
+    root_value = values["root"] if isinstance(values["root"], str) else None
+    root = _resolve_studio_root(root_value)
     return (
         ClientCreateRequest(
             studio_root=root,

--- a/tests/python/test_new_client_cli.py
+++ b/tests/python/test_new_client_cli.py
@@ -43,6 +43,7 @@ def make_studio(root: Path, *, auto_cd: bool = False) -> None:
 def run_cli(cwd: Path, *args: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(SRC)
+    env.pop("JL_MIXING_ROOT", None)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -61,6 +62,7 @@ class NewClientCliTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertIn("Usage: new-client CLIENT_ID [options]", proc.stdout)
         self.assertIn("--delivery-method TEXT", proc.stdout)
+        self.assertIn("--root PATH", proc.stdout)
         self.assertIn("--cd", proc.stdout)
 
     def test_dry_run_inherits_defaults_without_mutation(self) -> None:
@@ -99,6 +101,72 @@ class NewClientCliTests(unittest.TestCase):
             self.assertEqual(doc["defaults"]["delivery"]["requested_deliverables"], ["main_mix", "stems"])
             self.assertTrue((studio / "Clients" / "API Client" / "Projects").is_dir())
             self.assertIn("Client created successfully.", proc.stdout)
+
+    def test_default_workspace_is_used_outside_studio_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            home = base / "home"
+            default_studio = home / "Music" / "Mixes"
+            unrelated = base / "downloads"
+            unrelated.mkdir()
+            make_studio(default_studio)
+            proc = run_cli(
+                unrelated,
+                "default-client",
+                "--name", "Default Client",
+                extra_env={"HOME": str(home), "USERPROFILE": str(home)},
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertTrue((default_studio / "Clients" / "Default Client" / "client.json").is_file())
+
+    def test_explicit_root_takes_precedence_over_environment_and_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            explicit = base / "explicit"
+            configured = base / "configured"
+            context = base / "context"
+            make_studio(explicit)
+            make_studio(configured)
+            make_studio(context)
+            proc = run_cli(
+                context,
+                "precedence-client",
+                "--name", "Precedence Client",
+                "--root", str(explicit),
+                extra_env={"JL_MIXING_ROOT": str(configured)},
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertTrue((explicit / "Clients" / "Precedence Client" / "client.json").is_file())
+            self.assertFalse((configured / "Clients" / "Precedence Client").exists())
+            self.assertFalse((context / "Clients" / "Precedence Client").exists())
+
+    def test_environment_root_takes_precedence_over_current_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            configured = base / "configured"
+            context = base / "context"
+            make_studio(configured)
+            make_studio(context)
+            proc = run_cli(
+                context,
+                "environment-client",
+                "--name", "Environment Client",
+                extra_env={"JL_MIXING_ROOT": str(configured)},
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertTrue((configured / "Clients" / "Environment Client" / "client.json").is_file())
+            self.assertFalse((context / "Clients" / "Environment Client").exists())
+
+    def test_invalid_explicit_root_fails_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            valid_studio = base / "studio"
+            invalid_root = base / "missing"
+            make_studio(valid_studio)
+            proc = run_cli(valid_studio, "blocked-client", "--root", str(invalid_root))
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("No context marker", proc.stderr)
+            self.assertFalse((valid_studio / "Clients" / "Blocked Client").exists())
 
     def test_cd_result_file_receives_created_directory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Complete the remaining v1.5 RC1 Automation cleanup by fixing #103 and bringing current documentation forward to the cross-platform v1.5 implementation.

## Changes

- add `new-client --root PATH`
- resolve studio root in the approved precedence: explicit `--root`, `JL_MIXING_ROOT`, current studio context, default `~/Music/Mixes`
- add regression coverage for default-root fallback, precedence, and invalid-root no-mutation behavior
- refresh README and packaged release README for Windows/macOS self-contained packages and Linux/source compatibility path
- refresh installation, user, command, API implementation, developer, architecture, roadmap, and documentation-index material for v1.5
- document the current Automation API 1.0 capability set and metadata schema 1.1.0 compatibility

## Compatibility

- Automation API remains 1.0
- workspace metadata schema remains 1.1.0
- no workspace migration
- existing in-context `new-client` behavior remains valid
- root resolution behavior is platform-neutral

Closes #103.