### PR TITLE
Publish separate Intel and Apple Silicon macOS packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            platform: macos
+          - os: macos-15-intel
+            platform: macos-x86_64
+            architecture: x86_64
+
+          - os: macos-15
+            platform: macos-arm64
+            architecture: arm64
 
           - os: ubuntu-latest
             platform: linux
+            architecture: none
 
     steps:
       - name: Check out release source
@@ -109,6 +115,8 @@ jobs:
       - name: Run bundled macOS runtime smoke tests
         if: runner.os == 'macOS'
         shell: bash
+        env:
+          JL_MIXING_EXPECTED_ARCH: ${{ matrix.architecture }}
         run: bash ./tests/macos/test-runtime-bundle.sh
 
       - name: Run release verification
@@ -122,7 +130,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf dist
-          make release
+          tools/build-release --platform "${{ matrix.platform }}"
 
       - name: Verify generated assets
         shell: bash
@@ -282,9 +290,10 @@ jobs:
           echo "Assets prepared for $RELEASE_TAG:"
           find release-assets -maxdepth 1 -type f -print | sort
           asset_count="$(find release-assets -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
-          # Three platforms, with an archive, checksum, and inventory for each.
-          if [[ "$asset_count" -ne 9 ]]; then
-              echo "Expected 9 release assets; found $asset_count." >&2
+          # Intel macOS, Apple Silicon macOS, Linux, and Windows each publish
+          # an archive, checksum, and inventory.
+          if [[ "$asset_count" -ne 12 ]]; then
+              echo "Expected 12 release assets; found $asset_count." >&2
               exit 1
           fi
 

--- a/packaging/RELEASE_README.md
+++ b/packaging/RELEASE_README.md
@@ -25,7 +25,12 @@ Open a new PowerShell session after installation.
 
 ### macOS
 
-Extract `jl-mixing-<version>-macos.tar.gz`, then run:
+Download the package matching your Mac architecture:
+
+- Intel: `jl-mixing-<version>-macos-x86_64.tar.gz`
+- Apple Silicon: `jl-mixing-<version>-macos-arm64.tar.gz`
+
+After extracting the matching archive, run:
 
 ```bash
 ./macos/install.sh
@@ -35,6 +40,9 @@ The package contains its private runtime. The default prefix is `~/.local`.
 Open a new Terminal tab after installation so managed shell integration is
 active.
 
+To check your Mac architecture, run `uname -m`: `x86_64` means Intel and `arm64`
+means Apple Silicon.
+
 ### Linux/source compatibility path
 
 Extract the Linux archive and run:
@@ -43,7 +51,9 @@ Extract the Linux archive and run:
 ./install.sh
 ```
 
-This path requires Bash, Python 3.10+ with `venv`, and jq.
+This path requires Bash, Python 3.10+ with `venv`, and jq. The top-level
+`./install.sh` also remains available as a compatibility/fallback installation
+path on macOS when the host dependencies are present.
 
 Optional external `ffprobe`/`ffmpeg` tools enable enhanced intake QC. Checks that
 cannot run are reported as skipped.

--- a/tests/macos/test-runtime-bundle.sh
+++ b/tests/macos/test-runtime-bundle.sh
@@ -6,6 +6,18 @@ runtime="$ROOT/runtime/python"
 
 [ -x "$runtime" ] || { echo "[FAIL] bundled macOS runtime exists" >&2; exit 1; }
 
+expected_arch="${JL_MIXING_EXPECTED_ARCH:-$(uname -m)}"
+case "$expected_arch" in
+    x86_64|arm64) ;;
+    *) echo "[FAIL] unsupported expected macOS architecture: $expected_arch" >&2; exit 1 ;;
+esac
+actual_arch="$(lipo -archs "$runtime" 2>/dev/null || true)"
+[ "$actual_arch" = "$expected_arch" ] || {
+    echo "[FAIL] bundled runtime architecture: expected $expected_arch, found ${actual_arch:-unknown}" >&2
+    exit 1
+}
+echo "[PASS] bundled runtime architecture is $expected_arch"
+
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/jl-mixing-macos-runtime.XXXXXX")"
 cleanup() { rm -rf -- "$tmp"; }
 trap cleanup EXIT HUP INT TERM

--- a/tools/build-release
+++ b/tools/build-release
@@ -11,7 +11,7 @@ Usage: tools/build-release [options]
 
 Options:
   --output-dir PATH  Destination directory (default: dist)
-  --platform NAME    Package label (default: detected macos or linux)
+  --platform NAME    Package label (default: detected macos-<arch> or linux)
   -h, --help         Show this help
 USAGE
 }
@@ -47,7 +47,13 @@ done
 
 if [ -z "$platform" ]; then
     case "$(uname -s)" in
-        Darwin) platform="macos" ;;
+        Darwin)
+            case "$(uname -m)" in
+                x86_64) platform="macos-x86_64" ;;
+                arm64) platform="macos-arm64" ;;
+                *) echo "Error: unsupported macOS architecture: $(uname -m)" >&2; exit 3 ;;
+            esac
+            ;;
         Linux) platform="linux" ;;
         *) echo "Error: unsupported release platform: $(uname -s)" >&2; exit 3 ;;
     esac
@@ -75,13 +81,15 @@ cp "$ROOT/VERSION" "$ROOT/API_VERSION" "$ROOT/LICENSE" "$ROOT/CHANGELOG.md" \
 cp "$ROOT/packaging/RELEASE_README.md" "$package_root/README.md"
 cp -R "$ROOT/bin" "$ROOT/lib" "$ROOT/src" "$ROOT/api" "$ROOT/schemas" "$ROOT/templates" "$ROOT/docs" "$package_root/"
 
-if [ "$platform" = "macos" ]; then
-    [ -x "$ROOT/runtime/python" ] || {
-        echo "Error: macOS release requires bundled runtime/python. Run macos/build-runtime.sh first." >&2
-        exit 3
-    }
-    cp -R "$ROOT/runtime" "$ROOT/macos" "$package_root/"
-fi
+case "$platform" in
+    macos|macos-*)
+        [ -x "$ROOT/runtime/python" ] || {
+            echo "Error: macOS release requires bundled runtime/python. Run macos/build-runtime.sh first." >&2
+            exit 3
+        }
+        cp -R "$ROOT/runtime" "$ROOT/macos" "$package_root/"
+        ;;
+esac
 
 mkdir -p "$package_root/tools" "$package_root/packaging"
 cp "$ROOT/tools/validate-json.py" "$ROOT/tools/build-intake-report.py" \
@@ -97,9 +105,11 @@ chmod +x "$package_root/install.sh" "$package_root/uninstall.sh" "$package_root/
     "$package_root/tools/import-revision-source.py" \
     "$package_root/tools/build-delivery.py" \
     "$package_root/tools/manage-shell-config.py"
-if [ "$platform" = "macos" ]; then
-    chmod +x "$package_root/runtime/python" "$package_root/macos/install.sh" "$package_root/macos/uninstall.sh"
-fi
+case "$platform" in
+    macos|macos-*)
+        chmod +x "$package_root/runtime/python" "$package_root/macos/install.sh" "$package_root/macos/uninstall.sh"
+        ;;
+esac
 
 (
     cd "$package_root"


### PR DESCRIPTION
## Summary

Fixes #109 by making JL Mixing Automation macOS release packages architecture-specific.

## Changes

- build Intel macOS packages on `macos-15-intel`
- build Apple Silicon macOS packages on `macos-15`
- publish `macos-x86_64` and `macos-arm64` archive names
- verify the bundled PyInstaller runtime architecture with `lipo` before release
- keep Linux and Windows packaging behavior unchanged
- document the correct macOS package selection and retain top-level `./install.sh` as a compatibility/fallback path
- update release asset count from 9 to 12

## Compatibility

No Automation API, CLI behavior, metadata schema, or workspace behavior changes. Automation API remains `1.0`; metadata schema remains `1.1.0`.

## Release plan

After this PR passes CI and merges, prepare `v1.5.1-rc.1` to exercise the actual tag-triggered release workflow on both macOS architectures before stable `v1.5.1`.