### PR TITLE
Issue #116: Expose Audio Prep validation and exact-content provenance

### DIFF
--- a/api/schemas/v1.0/operations/intake-validate.schema.json
+++ b/api/schemas/v1.0/operations/intake-validate.schema.json
@@ -40,33 +40,42 @@
         },
         "files": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": true,
-            "required": ["relative_path", "is_audio", "status", "cache_state", "findings"],
-            "properties": {
-              "relative_path": {"type": "string", "minLength": 1},
-              "is_audio": {"type": "boolean"},
-              "status": {"enum": ["valid", "needs_attention", "blocked", "info", "not_applicable"]},
-              "cache_state": {"enum": ["validated", "reused"]},
-              "sha256": {"type": ["string", "null"]},
-              "metadata": {"type": ["object", "null"]},
-              "decode_ok": {"type": ["boolean", "null"]},
-              "dual_mono": {"type": ["boolean", "null"]},
-              "findings": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": ["code", "severity", "message"],
-                  "properties": {
-                    "code": {"type": "string", "minLength": 1},
-                    "severity": {"enum": ["critical", "warning", "info"]},
-                    "message": {"type": "string", "minLength": 1},
-                    "expected": {},
-                    "actual": {},
-                    "related_paths": {"type": "array", "items": {"type": "string", "minLength": 1}}
+          "items": {"$ref": "#/$defs/validationFile"}
+        },
+        "audio_prep": {
+          "type": "object",
+          "required": ["working_path", "validation_cache_path", "summary", "files"],
+          "properties": {
+            "working_path": {"type": "string", "minLength": 1},
+            "validation_cache_path": {"type": "string", "minLength": 1},
+            "summary": {
+              "type": "object",
+              "required": ["files_discovered", "blocking_errors", "warnings", "ffprobe_available", "ffmpeg_available", "cache_reused", "files_validated"],
+              "properties": {
+                "files_discovered": {"type": "integer", "minimum": 0},
+                "blocking_errors": {"type": "integer", "minimum": 0},
+                "warnings": {"type": "integer", "minimum": 0},
+                "ffprobe_available": {"type": ["boolean", "null"]},
+                "ffmpeg_available": {"type": ["boolean", "null"]},
+                "cache_reused": {"type": "integer", "minimum": 0},
+                "files_validated": {"type": "integer", "minimum": 0}
+              }
+            },
+            "files": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {"$ref": "#/$defs/validationFile"},
+                  {
+                    "type": "object",
+                    "required": ["original_delivery_relative_path", "original_filename", "provenance_state"],
+                    "properties": {
+                      "original_delivery_relative_path": {"type": ["string", "null"]},
+                      "original_filename": {"type": ["string", "null"]},
+                      "provenance_state": {"enum": ["exact_content", "ambiguous", "unavailable"]}
+                    }
                   }
-                }
+                ]
               }
             }
           }
@@ -76,5 +85,37 @@
     },
     "warnings": {"type": "array"},
     "errors": {"type": "array"}
+  },
+  "$defs": {
+    "validationFile": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["relative_path", "is_audio", "status", "cache_state", "findings"],
+      "properties": {
+        "relative_path": {"type": "string", "minLength": 1},
+        "is_audio": {"type": "boolean"},
+        "status": {"enum": ["valid", "needs_attention", "blocked", "info", "not_applicable"]},
+        "cache_state": {"enum": ["validated", "reused"]},
+        "sha256": {"type": ["string", "null"]},
+        "metadata": {"type": ["object", "null"]},
+        "decode_ok": {"type": ["boolean", "null"]},
+        "dual_mono": {"type": ["boolean", "null"]},
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["code", "severity", "message"],
+            "properties": {
+              "code": {"type": "string", "minLength": 1},
+              "severity": {"enum": ["critical", "warning", "info"]},
+              "message": {"type": "string", "minLength": 1},
+              "expected": {},
+              "actual": {},
+              "related_paths": {"type": "array", "items": {"type": "string", "minLength": 1}}
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/docs/API_INTAKE_VALIDATE.md
+++ b/docs/API_INTAKE_VALIDATE.md
@@ -16,6 +16,8 @@ Consumers should discover support through `system-info --json` rather than by ma
 - `intake.validate.report` — durable managed intake report
 - `intake.validate.incremental` — unchanged files may reuse authoritative cached inspection results
 - `intake.validate.structured` — structured per-file validation records are returned in `data.files`
+- `audio-prep.validation.structured` — structured validation for `02_Audio_Preparation/Working_Audio` is returned in `data.audio_prep`
+- `audio-prep.provenance.exact-content` — an Audio Prep file may identify its Original Delivery source when one unique exact SHA-256 content match exists
 
 ## Request options
 
@@ -42,7 +44,7 @@ A cached record is reused only when:
 
 New, changed, or context-invalidated files receive the full authoritative checks. This avoids unnecessary repeated full-file decode/hash I/O while not relying on timestamps alone.
 
-`--dry-run` never creates or updates the cache.
+Audio Prep uses the same validation implementation with its own `00_Admin/audio-prep-validation-cache.json`, so Working_Audio changes do not invalidate the Original Delivery cache. `--dry-run` never creates or updates either cache.
 
 ## Results
 
@@ -56,7 +58,7 @@ A completed scan returns project, manifest, report, workspace, source, and valid
 - `cache_reused`
 - `files_validated`
 
-`data.files` contains one record per discovered file. Useful fields include:
+`data.files` contains one record per discovered Original Delivery file. Useful fields include:
 
 - `relative_path`
 - `is_audio`
@@ -70,13 +72,31 @@ A completed scan returns project, manifest, report, workspace, source, and valid
 
 Each finding has a stable `code`, `severity`, and `message`, with `expected` / `actual` or `related_paths` where relevant. Current finding codes include sample-rate, bit-depth and file-format mismatches, unreadable/decode-integrity failures, exact duplicate relationships, and exact dual-mono information.
 
+## Audio Prep status and provenance
+
+When `audio-prep.validation.structured` is advertised, `data.audio_prep` describes the current `02_Audio_Preparation/Working_Audio` tree. It has its own `working_path`, `validation_cache_path`, `summary`, and `files` collection. Audio Prep validation uses the same project sample-rate, bit-depth, and expected-format policy as Original Delivery.
+
+Audio Prep findings do **not** change the top-level `intake.validate` status or exit code. The top-level result remains the intake/Original Delivery contract; Studio consumes `data.audio_prep.summary` and each Audio Prep file's own `status` separately.
+
+Each `data.audio_prep.files` record adds:
+
+- `original_delivery_relative_path`
+- `original_filename`
+- `provenance_state`: `exact_content`, `ambiguous`, or `unavailable`
+
+For this first #116 integration slice, provenance is reported only when the Working_Audio file's SHA-256 has one unique exact-content match among Original Delivery files. This is authoritative for an unchanged copy and remains valid if that copy was renamed. If multiple Original Delivery files have the same content, Automation returns `ambiguous` and leaves the source fields null. If no exact match exists, it returns `unavailable`; Automation does not guess from filenames or directory layout.
+
+Converted/repaired files will require durable provenance recorded by the future mutation portion of #116. This additive read-side contract deliberately does not infer that relationship before those operations exist.
+
+An absent or empty Working_Audio directory is represented as an empty Audio Prep result rather than a validation failure.
+
 ## Human-report compatibility
 
 Normal validation continues to update only the managed section of `00_Admin/Intake_Report.md`; Original Delivery remains immutable. Existing human-facing report contracts such as duplicate-basename reporting and established diagnostic wording are preserved. Exact SHA-256 duplicate relationships are additive and are also exposed through structured file findings.
 
-Dry-run returns `status: planned`, does not update the report or cache, and includes `would_update` for the report path only.
+Dry-run returns `status: planned`, does not update the report or caches, and includes `would_update` for the report path only.
 
-A completed scan with blocking findings returns process exit code `5`, `status: blocked`, and machine code `INTAKE_BLOCKING_FINDINGS`. The report is still updated in normal mode, matching `validate-intake` behavior.
+A completed intake scan with blocking findings returns process exit code `5`, `status: blocked`, and machine code `INTAKE_BLOCKING_FINDINGS`. The report is still updated in normal mode, matching `validate-intake` behavior. Audio Prep blocking findings do not alter this top-level intake outcome.
 
 Request/context failures retain the existing exit-code contract and map to stable API machine codes such as `INVALID_REQUEST`, `PROJECT_NOT_FOUND`, `SOURCE_NOT_FOUND`, `WORKSPACE_CONTEXT_ERROR`, `VALIDATION_FAILED`, and `UNSAFE_OPERATION`.
 

--- a/docs/API_INTAKE_VALIDATE.md
+++ b/docs/API_INTAKE_VALIDATE.md
@@ -16,8 +16,8 @@ Consumers should discover support through `system-info --json` rather than by ma
 - `intake.validate.report` — durable managed intake report
 - `intake.validate.incremental` — unchanged files may reuse authoritative cached inspection results
 - `intake.validate.structured` — structured per-file validation records are returned in `data.files`
-- `audio-prep.validation.structured` — structured validation for `02_Audio_Preparation/Working_Audio` is returned in `data.audio_prep`
-- `audio-prep.provenance.exact-content` — an Audio Prep file may identify its Original Delivery source when one unique exact SHA-256 content match exists
+- `audio.prep.validation.structured` — structured validation for `02_Audio_Preparation/Working_Audio` is returned in `data.audio_prep`
+- `audio.prep.provenance.sha256` — an Audio Prep file may identify its Original Delivery source when one unique exact SHA-256 content match exists
 
 ## Request options
 
@@ -74,7 +74,7 @@ Each finding has a stable `code`, `severity`, and `message`, with `expected` / `
 
 ## Audio Prep status and provenance
 
-When `audio-prep.validation.structured` is advertised, `data.audio_prep` describes the current `02_Audio_Preparation/Working_Audio` tree. It has its own `working_path`, `validation_cache_path`, `summary`, and `files` collection. Audio Prep validation uses the same project sample-rate, bit-depth, and expected-format policy as Original Delivery.
+When `audio.prep.validation.structured` is advertised, `data.audio_prep` describes the current `02_Audio_Preparation/Working_Audio` tree. It has its own `working_path`, `validation_cache_path`, `summary`, and `files` collection. Audio Prep validation uses the same project sample-rate, bit-depth, and expected-format policy as Original Delivery.
 
 Audio Prep findings do **not** change the top-level `intake.validate` status or exit code. The top-level result remains the intake/Original Delivery contract; Studio consumes `data.audio_prep.summary` and each Audio Prep file's own `status` separately.
 

--- a/src/jl_mixing/api/intake_validate.py
+++ b/src/jl_mixing/api/intake_validate.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ..audio_prep_status import build_audio_prep_status
 from ..context import resolve_project
 from ..errors import ArgumentError, ContextError, JLMixingError, ValidationError
 from ..intake_incremental import validate_intake_incremental
@@ -86,6 +87,14 @@ def execute(request: IntakeRequest) -> tuple[dict[str, Any], int]:
             cache_path=cache_path,
             update_cache=not request.dry_run,
         )
+        audio_prep = build_audio_prep_status(
+            project,
+            original_files=result.files,
+            expected_sample_rate=sample_rate,
+            expected_bit_depth=bit_depth,
+            expected_format=expected_format,
+            update_cache=not request.dry_run,
+        )
         if request.dry_run:
             report_markdown = result.report_markdown
         else:
@@ -115,6 +124,7 @@ def execute(request: IntakeRequest) -> tuple[dict[str, Any], int]:
                 "files_validated": result.files_validated,
             },
             "files": list(result.files),
+            "audio_prep": audio_prep,
         }
         if request.dry_run:
             data["would_update"] = [str(report_path)]

--- a/src/jl_mixing/audio_prep_status.py
+++ b/src/jl_mixing/audio_prep_status.py
@@ -1,0 +1,125 @@
+"""Read-side Audio Prep status built from authoritative validation facts.
+
+This module intentionally does not perform repair/conversion. It validates the
+managed Working_Audio tree against project audio policy and reports provenance
+only when an unchanged working file has one unique exact-content match in
+Original Delivery. Future Audio Prep mutation operations can add durable
+provenance for converted/repaired outputs without changing this response shape.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .intake_incremental import validate_intake_incremental
+
+_AUDIO_PREP_CACHE_NAME = "audio-prep-validation-cache.json"
+
+
+def _summary(result: Any) -> dict[str, Any]:
+    return {
+        "files_discovered": result.files_discovered,
+        "blocking_errors": result.blocking_errors,
+        "warnings": result.warnings,
+        "ffprobe_available": result.ffprobe_available,
+        "ffmpeg_available": result.ffmpeg_available,
+        "cache_reused": result.cache_reused,
+        "files_validated": result.files_validated,
+    }
+
+
+def _originals_by_hash(original_files: tuple[dict[str, Any], ...] | list[dict[str, Any]]) -> dict[str, list[str]]:
+    by_hash: dict[str, list[str]] = {}
+    for record in original_files:
+        sha256 = record.get("sha256")
+        relative_path = record.get("relative_path")
+        if isinstance(sha256, str) and sha256 and isinstance(relative_path, str) and relative_path:
+            by_hash.setdefault(sha256, []).append(relative_path)
+    return by_hash
+
+
+def _with_provenance(record: dict[str, Any], originals: dict[str, list[str]]) -> dict[str, Any]:
+    enriched = dict(record)
+    sha256 = record.get("sha256")
+    matches = originals.get(sha256, []) if isinstance(sha256, str) and sha256 else []
+    if len(matches) == 1:
+        original_path = matches[0]
+        enriched["original_delivery_relative_path"] = original_path
+        enriched["original_filename"] = Path(original_path).name
+        enriched["provenance_state"] = "exact_content"
+    elif len(matches) > 1:
+        enriched["original_delivery_relative_path"] = None
+        enriched["original_filename"] = None
+        enriched["provenance_state"] = "ambiguous"
+    else:
+        enriched["original_delivery_relative_path"] = None
+        enriched["original_filename"] = None
+        enriched["provenance_state"] = "unavailable"
+    return enriched
+
+
+def build_audio_prep_status(
+    project: Path,
+    *,
+    original_files: tuple[dict[str, Any], ...] | list[dict[str, Any]],
+    expected_sample_rate: int,
+    expected_bit_depth: int,
+    expected_format: str | None,
+    update_cache: bool,
+) -> dict[str, Any]:
+    working_path = project / "02_Audio_Preparation" / "Working_Audio"
+    cache_path = project / "00_Admin" / _AUDIO_PREP_CACHE_NAME
+
+    # Project creation guarantees this directory, but older/incomplete projects
+    # should degrade to an empty workspace rather than making intake validation
+    # fail for an unrelated reason.
+    if not working_path.is_dir() or working_path.is_symlink():
+        return {
+            "working_path": str(working_path),
+            "validation_cache_path": str(cache_path),
+            "summary": {
+                "files_discovered": 0,
+                "blocking_errors": 0,
+                "warnings": 0,
+                "ffprobe_available": None,
+                "ffmpeg_available": None,
+                "cache_reused": 0,
+                "files_validated": 0,
+            },
+            "files": [],
+        }
+
+    has_files = any(path.is_file() and not path.is_symlink() for path in working_path.rglob("*"))
+    if not has_files:
+        return {
+            "working_path": str(working_path.resolve()),
+            "validation_cache_path": str(cache_path.resolve()),
+            "summary": {
+                "files_discovered": 0,
+                "blocking_errors": 0,
+                "warnings": 0,
+                "ffprobe_available": None,
+                "ffmpeg_available": None,
+                "cache_reused": 0,
+                "files_validated": 0,
+            },
+            "files": [],
+        }
+
+    result = validate_intake_incremental(
+        working_path.resolve(),
+        expected_sample_rate=expected_sample_rate,
+        expected_bit_depth=expected_bit_depth,
+        expected_format=expected_format,
+        duplicate_check=False,
+        cache_path=cache_path,
+        update_cache=update_cache,
+    )
+    originals = _originals_by_hash(original_files)
+    return {
+        "working_path": str(working_path.resolve()),
+        "validation_cache_path": str(cache_path.resolve()),
+        "summary": _summary(result),
+        "files": [_with_provenance(record, originals) for record in result.files],
+    }

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from .versions import api_version, application_version, schema_root
 
 _CAPABILITIES = [
-    "audio-prep.provenance.exact-content",
-    "audio-prep.validation.structured",
+    "audio.prep.provenance.sha256",
+    "audio.prep.validation.structured",
     "client.create",
     "delivery.create",
     "intake.validate",

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from .versions import api_version, application_version, schema_root
 
 _CAPABILITIES = [
+    "audio-prep.provenance.exact-content",
+    "audio-prep.validation.structured",
     "client.create",
     "delivery.create",
     "intake.validate",

--- a/tests/python/test_intake_api.py
+++ b/tests/python/test_intake_api.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
+import wave
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -37,6 +39,15 @@ def write_project(root: Path) -> Path:
         encoding="utf-8",
     )
     return project
+
+
+def write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as audio:
+        audio.setnchannels(2)
+        audio.setsampwidth(3)
+        audio.setframerate(48000)
+        audio.writeframes(b"\0" * (480 * 2 * 3))
 
 
 def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
@@ -109,19 +120,21 @@ class IntakeApiTests(unittest.TestCase):
             project = write_project(Path(tmp))
             original = project / "01_Client_Files" / "Original_Delivery"
             working = project / "02_Audio_Preparation" / "Working_Audio"
+            source_file = original / "Original Name.wav"
+            working_file = working / "Renamed Working Copy.wav"
+            write_wav(source_file)
             working.mkdir(parents=True)
-            (original / "Original Name.txt").write_text("same content\n", encoding="utf-8")
-            (working / "Renamed Working Copy.txt").write_text("same content\n", encoding="utf-8")
+            shutil.copyfile(source_file, working_file)
 
             proc = run_cli("intake", "validate", "--json", "--project", str(project))
             self.assertEqual(proc.returncode, 0, proc.stderr)
             payload = json.loads(proc.stdout)
             audio_prep = payload["data"]["audio_prep"]
             self.assertEqual(audio_prep["summary"]["files_discovered"], 1)
-            self.assertEqual(audio_prep["files"][0]["relative_path"], "Renamed Working Copy.txt")
-            self.assertEqual(audio_prep["files"][0]["status"], "not_applicable")
-            self.assertEqual(audio_prep["files"][0]["original_filename"], "Original Name.txt")
-            self.assertEqual(audio_prep["files"][0]["original_delivery_relative_path"], "Original Name.txt")
+            self.assertEqual(audio_prep["files"][0]["relative_path"], "Renamed Working Copy.wav")
+            self.assertIn(audio_prep["files"][0]["status"], {"valid", "needs_attention", "info"})
+            self.assertEqual(audio_prep["files"][0]["original_filename"], "Original Name.wav")
+            self.assertEqual(audio_prep["files"][0]["original_delivery_relative_path"], "Original Name.wav")
             self.assertEqual(audio_prep["files"][0]["provenance_state"], "exact_content")
             self.assertTrue((project / "00_Admin" / "audio-prep-validation-cache.json").is_file())
 
@@ -130,10 +143,13 @@ class IntakeApiTests(unittest.TestCase):
             project = write_project(Path(tmp))
             original = project / "01_Client_Files" / "Original_Delivery"
             working = project / "02_Audio_Preparation" / "Working_Audio"
+            first = original / "First.wav"
+            second = original / "Second.wav"
+            working_file = working / "Working.wav"
+            write_wav(first)
+            shutil.copyfile(first, second)
             working.mkdir(parents=True)
-            (original / "First.txt").write_text("duplicate\n", encoding="utf-8")
-            (original / "Second.txt").write_text("duplicate\n", encoding="utf-8")
-            (working / "Working.txt").write_text("duplicate\n", encoding="utf-8")
+            shutil.copyfile(first, working_file)
 
             proc = run_cli("intake", "validate", "--json", "--project", str(project))
             self.assertEqual(proc.returncode, 0, proc.stderr)

--- a/tests/python/test_intake_api.py
+++ b/tests/python/test_intake_api.py
@@ -75,6 +75,7 @@ class IntakeApiTests(unittest.TestCase):
             self.assertIn("Notes.txt", payload["data"]["report_markdown"])
             self.assertEqual(payload["data"]["validation_cache_path"], str(cache.resolve()))
             self.assertEqual(payload["data"]["would_update"], [str(report.resolve())])
+            self.assertEqual(payload["data"]["audio_prep"]["files"], [])
             self.assertEqual(report.read_bytes(), before)
             self.assertFalse(cache.exists())
 
@@ -102,6 +103,45 @@ class IntakeApiTests(unittest.TestCase):
             second_payload = json.loads(second.stdout)
             self.assertEqual(second_payload["data"]["summary"]["cache_reused"], 1)
             self.assertEqual(second_payload["data"]["summary"]["files_validated"], 0)
+
+    def test_audio_prep_reports_validation_and_unique_exact_content_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            original = project / "01_Client_Files" / "Original_Delivery"
+            working = project / "02_Audio_Preparation" / "Working_Audio"
+            working.mkdir(parents=True)
+            (original / "Original Name.txt").write_text("same content\n", encoding="utf-8")
+            (working / "Renamed Working Copy.txt").write_text("same content\n", encoding="utf-8")
+
+            proc = run_cli("intake", "validate", "--json", "--project", str(project))
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            audio_prep = payload["data"]["audio_prep"]
+            self.assertEqual(audio_prep["summary"]["files_discovered"], 1)
+            self.assertEqual(audio_prep["files"][0]["relative_path"], "Renamed Working Copy.txt")
+            self.assertEqual(audio_prep["files"][0]["status"], "not_applicable")
+            self.assertEqual(audio_prep["files"][0]["original_filename"], "Original Name.txt")
+            self.assertEqual(audio_prep["files"][0]["original_delivery_relative_path"], "Original Name.txt")
+            self.assertEqual(audio_prep["files"][0]["provenance_state"], "exact_content")
+            self.assertTrue((project / "00_Admin" / "audio-prep-validation-cache.json").is_file())
+
+    def test_audio_prep_ambiguous_exact_content_does_not_guess_original(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            original = project / "01_Client_Files" / "Original_Delivery"
+            working = project / "02_Audio_Preparation" / "Working_Audio"
+            working.mkdir(parents=True)
+            (original / "First.txt").write_text("duplicate\n", encoding="utf-8")
+            (original / "Second.txt").write_text("duplicate\n", encoding="utf-8")
+            (working / "Working.txt").write_text("duplicate\n", encoding="utf-8")
+
+            proc = run_cli("intake", "validate", "--json", "--project", str(project))
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            record = payload["data"]["audio_prep"]["files"][0]
+            self.assertIsNone(record["original_filename"])
+            self.assertIsNone(record["original_delivery_relative_path"])
+            self.assertEqual(record["provenance_state"], "ambiguous")
 
     def test_empty_source_returns_blocked_contract_and_updates_report(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -30,6 +30,8 @@ class SystemInfoTests(unittest.TestCase):
         self.assertEqual(
             info["capabilities"],
             [
+                "audio-prep.provenance.exact-content",
+                "audio-prep.validation.structured",
                 "client.create",
                 "delivery.create",
                 "intake.validate",

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -30,8 +30,8 @@ class SystemInfoTests(unittest.TestCase):
         self.assertEqual(
             info["capabilities"],
             [
-                "audio-prep.provenance.exact-content",
-                "audio-prep.validation.structured",
+                "audio.prep.provenance.sha256",
+                "audio.prep.validation.structured",
                 "client.create",
                 "delivery.create",
                 "intake.validate",

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -34,8 +34,8 @@ assert document["metadata"] == {
     "writable_schema_version": "1.1.0",
 }
 assert document["capabilities"] == [
-    "audio-prep.provenance.exact-content",
-    "audio-prep.validation.structured",
+    "audio.prep.provenance.sha256",
+    "audio.prep.validation.structured",
     "client.create",
     "delivery.create",
     "intake.validate",

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -34,6 +34,8 @@ assert document["metadata"] == {
     "writable_schema_version": "1.1.0",
 }
 assert document["capabilities"] == [
+    "audio-prep.provenance.exact-content",
+    "audio-prep.validation.structured",
     "client.create",
     "delivery.create",
     "intake.validate",


### PR DESCRIPTION
Implements the first bounded #116 integration slice needed by Studio Audio Prep without pulling repair/conversion mutations into scope.

Adds a capability-gated `data.audio_prep` section to the existing Automation API 1.0 `intake.validate` response. Working_Audio is validated through the same authoritative incremental validator using a separate `00_Admin/audio-prep-validation-cache.json`, so Studio can show real per-file validation status without affecting the top-level intake outcome.

Adds exact-content provenance for existing unchanged working copies: when a Working_Audio file SHA-256 has one unique match in Original Delivery, the response includes `original_delivery_relative_path`, `original_filename`, and `provenance_state: exact_content`. Duplicate-content ambiguity returns null source fields with `provenance_state: ambiguous`; no match returns `unavailable`. No filename/path inference is used.

Discovery adds:
- `audio.prep.validation.structured`
- `audio.prep.provenance.sha256`

The published intake response schema and API documentation are updated, with tests covering empty/missing Working_Audio, unique exact-content provenance, ambiguous provenance, separate cache behavior, and the strict capability list.

Important boundary: transformed repair/convert outputs still require durable provenance written by the future mutation portion of #116. This PR does not implement Fix/Convert and does not change Original Delivery.

Part of #116; does not close the full issue.