### PR TITLE
Issue #115: Automation API support for editing revision description

### DIFF
--- a/src/jl_mixing/api/revision_update_description.py
+++ b/src/jl_mixing/api/revision_update_description.py
@@ -1,0 +1,156 @@
+"""Automation API 1.0 adapter for revision.update-description."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..context import resolve_project, studio_root
+from ..errors import ArgumentError, ContextError, JLMixingError, ValidationError
+from ..revision_description import (
+    RevisionDescriptionUpdateRequest,
+    update_revision_description,
+)
+from ..versions import api_version
+
+
+@dataclass(frozen=True)
+class RevisionDescriptionApiRequest:
+    project: Path | None = None
+    revision: int | None = None
+    description: str | None = None
+    dry_run: bool = False
+
+
+def _error_envelope(
+    code: str,
+    message: str,
+    exit_code: int,
+    *,
+    status: str = "error",
+) -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "revision.update-description",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [
+            {
+                "code": code,
+                "message": message,
+                "details": {"exit_code": exit_code},
+                "retryable": False,
+            }
+        ],
+    }
+
+
+def execute(request: RevisionDescriptionApiRequest) -> tuple[dict[str, Any], int]:
+    try:
+        project_root = resolve_project(request.project, Path.cwd())
+        if request.revision is None:
+            raise ValidationError("revision number is required.")
+        if request.description is None:
+            raise ValidationError("revision description is required.")
+        result = update_revision_description(
+            RevisionDescriptionUpdateRequest(
+                project_root=project_root,
+                revision=request.revision,
+                description=request.description,
+                dry_run=request.dry_run,
+            )
+        )
+        manifest_path = result.project_root / "00_Admin" / "project-manifest.json"
+        data: dict[str, Any] = {
+            "project": {
+                "id": result.manifest.get("project_id", ""),
+                "path": str(result.project_root),
+            },
+            "manifest_path": str(manifest_path),
+            "revision": {
+                "number": result.revision,
+                "revision_id": result.revision_id,
+                "description": result.description,
+                "previous_description": result.previous_description,
+            },
+            "workspace_path": str(studio_root(result.project_root)),
+            "changed": result.description != result.previous_description,
+        }
+        if request.dry_run:
+            data["would_update"] = [str(manifest_path)]
+        return {
+            "api_version": api_version(),
+            "operation": "revision.update-description",
+            "status": "planned" if request.dry_run else "success",
+            "data": data,
+            "warnings": [],
+            "errors": [],
+        }, 0
+    except ContextError as exc:
+        return _error_envelope(
+            "WORKSPACE_CONTEXT_ERROR", str(exc), exc.exit_code
+        ), exc.exit_code
+    except ValidationError as exc:
+        message = str(exc)
+        code = (
+            "REVISION_NOT_FOUND"
+            if "does not exist" in message.lower()
+            else "VALIDATION_FAILED"
+        )
+        return _error_envelope(
+            code, message, exc.exit_code, status="blocked"
+        ), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope(
+            "INTERNAL_ERROR", str(exc), exc.exit_code
+        ), exc.exit_code
+
+
+def parse_args(args: list[str]) -> RevisionDescriptionApiRequest:
+    project: Path | None = None
+    revision: int | None = None
+    description: str | None = None
+    dry_run = False
+    json_seen = 0
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg in {"--project", "--revision", "--description"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--project":
+                project = Path(value)
+            elif arg == "--revision":
+                try:
+                    revision = int(value)
+                except ValueError as exc:
+                    raise ArgumentError("--revision requires an integer.") from exc
+            else:
+                description = value
+        elif arg == "--dry-run":
+            dry_run = True
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+    if json_seen != 1:
+        raise ArgumentError(
+            "revision update-description requires exactly one --json option."
+        )
+    if revision is None:
+        raise ArgumentError("revision update-description requires --revision.")
+    if description is None:
+        raise ArgumentError("revision update-description requires --description.")
+    return RevisionDescriptionApiRequest(
+        project=project,
+        revision=revision,
+        description=description,
+        dry_run=dry_run,
+    )

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -24,6 +24,11 @@ from .api.revision_approve import parse_args as parse_approval_args
 from .api.revision_create import _error_envelope as revision_error_envelope
 from .api.revision_create import execute as revision_execute
 from .api.revision_create import parse_args as parse_revision_args
+from .api.revision_update_description import (
+    _error_envelope as revision_description_error_envelope,
+)
+from .api.revision_update_description import execute as revision_description_execute
+from .api.revision_update_description import parse_args as parse_revision_description_args
 from .errors import ArgumentError, ValidationError
 from .system_info import document as system_info_document
 
@@ -83,6 +88,30 @@ def main(argv: Sequence[str] | None = None) -> int:
             _emit_json(revision_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
             return exc.exit_code
         payload, status = revision_execute(request)
+        _emit_json(payload)
+        return status
+
+    if len(args) >= 2 and args[0:2] == ["revision", "update-description"]:
+        try:
+            request = parse_revision_description_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(
+                revision_description_error_envelope(
+                    "INVALID_REQUEST", str(exc), exc.exit_code
+                )
+            )
+            return exc.exit_code
+        except ValidationError as exc:
+            _emit_json(
+                revision_description_error_envelope(
+                    "VALIDATION_FAILED",
+                    str(exc),
+                    exc.exit_code,
+                    status="blocked",
+                )
+            )
+            return exc.exit_code
+        payload, status = revision_description_execute(request)
         _emit_json(payload)
         return status
 

--- a/src/jl_mixing/revision_description.py
+++ b/src/jl_mixing/revision_description.py
@@ -1,0 +1,118 @@
+"""Authoritative revision description update service."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .context import resolve_project, studio_root as resolve_studio_root
+from .errors import ValidationError
+from .metadata import now_iso8601
+from .paths import assert_no_symlink_components
+from .revision import _load_manifest, _validate_project_state, _validate_schema
+
+
+@dataclass(frozen=True)
+class RevisionDescriptionUpdateRequest:
+    project_root: Path
+    revision: int
+    description: str
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class RevisionDescriptionUpdateResult:
+    project_root: Path
+    revision: int
+    revision_id: str
+    previous_description: str
+    description: str
+    manifest: dict[str, Any]
+    updated: bool
+
+
+def update_revision_description(
+    request: RevisionDescriptionUpdateRequest,
+) -> RevisionDescriptionUpdateResult:
+    project_root = resolve_project(request.project_root, Path.cwd())
+    studio_root = resolve_studio_root(project_root)
+    assert_no_symlink_components(studio_root, project_root)
+
+    if isinstance(request.revision, bool) or request.revision < 1:
+        raise ValidationError("revision number must be a positive integer.")
+    description = request.description.strip()
+    if not description:
+        raise ValidationError("revision description must not be empty.")
+
+    manifest_path = project_root / "00_Admin" / "project-manifest.json"
+    manifest = _load_manifest(project_root)
+    _validate_project_state(manifest)
+
+    record = next(
+        (
+            item
+            for item in manifest.get("revisions", [])
+            if isinstance(item, dict) and item.get("number") == request.revision
+        ),
+        None,
+    )
+    if record is None:
+        raise ValidationError(f"Revision {request.revision} does not exist.")
+
+    previous_description = record.get("description")
+    if not isinstance(previous_description, str):
+        raise ValidationError(f"Revision {request.revision} has an invalid description.")
+    revision_id = record.get("revision_id")
+    if not isinstance(revision_id, str) or not revision_id:
+        raise ValidationError(f"Revision {request.revision} has an invalid revision ID.")
+
+    updated = deepcopy(manifest)
+    updated_record = next(
+        item for item in updated["revisions"] if item.get("number") == request.revision
+    )
+    updated_record["description"] = description
+    updated["metadata"]["last_modified_at"] = now_iso8601()
+    _validate_project_state(updated)
+    _validate_schema(updated)
+
+    if request.dry_run or description == previous_description:
+        return RevisionDescriptionUpdateResult(
+            project_root=project_root,
+            revision=request.revision,
+            revision_id=revision_id,
+            previous_description=previous_description,
+            description=description,
+            manifest=updated,
+            updated=False,
+        )
+
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{manifest_path.name}.", dir=manifest_path.parent
+    )
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(updated, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_path, manifest_path.stat().st_mode & 0o777)
+        os.replace(temp_path, manifest_path)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+    return RevisionDescriptionUpdateResult(
+        project_root=project_root,
+        revision=request.revision,
+        revision_id=revision_id,
+        previous_description=previous_description,
+        description=description,
+        manifest=updated,
+        updated=True,
+    )

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -18,6 +18,7 @@ _CAPABILITIES = [
     "revision.approve",
     "revision.create",
     "revision.create.description",
+    "revision.update-description",
     "system.info",
 ]
 

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -18,7 +18,7 @@ _CAPABILITIES = [
     "revision.approve",
     "revision.create",
     "revision.create.description",
-    "revision.update-description",
+    "revision.update.description",
     "system.info",
 ]
 

--- a/tests/python/test_revision_description_api.py
+++ b/tests/python/test_revision_description_api.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jl_mixing.project import ProjectCreateRequest, create_project
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_workspace(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio",
+            "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing 1.5.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "api-studio",
+        "studio_name": "API Studio",
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "API Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+        "cli": {"change_directory_after_create": True},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    client = root / "Clients" / "API Client"
+    (client / "Projects").mkdir(parents=True)
+    client_doc = {
+        "metadata": {
+            "schema": "mixing-client",
+            "schema_version": "1.1.0",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "created_with": "jl-mixing 1.5.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "client_id": "api-client",
+        "client_name": "API Client",
+        "defaults": {
+            "artist": "API Artist",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud", "requested_deliverables": ["main_mix"]},
+        },
+    }
+    (client / "client.json").write_text(json.dumps(client_doc), encoding="utf-8")
+    return create_project(
+        ProjectCreateRequest(client, "API Song", change_directory=False)
+    ).project_root
+
+
+def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class RevisionDescriptionApiTests(unittest.TestCase):
+    def test_updates_only_structured_description_and_preserves_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_workspace(Path(tmp))
+            notes = project / "04_Revisions" / "Revision_01" / "Revision_Notes.md"
+            notes_before = notes.read_text(encoding="utf-8")
+
+            proc = run_cli(
+                project,
+                "revision",
+                "update-description",
+                "--revision",
+                "1",
+                "--description",
+                "Brighter vocal balance",
+                "--json",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "revision.update-description")
+            self.assertEqual(payload["status"], "success")
+            self.assertEqual(
+                payload["data"]["revision"]["description"], "Brighter vocal balance"
+            )
+            self.assertTrue(payload["data"]["changed"])
+
+            manifest = json.loads(
+                (project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["revisions"][0]["description"], "Brighter vocal balance")
+            self.assertEqual(notes.read_text(encoding="utf-8"), notes_before)
+
+    def test_dry_run_does_not_mutate_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_workspace(Path(tmp))
+            manifest_path = project / "00_Admin" / "project-manifest.json"
+            before = manifest_path.read_bytes()
+            proc = run_cli(
+                project,
+                "revision",
+                "update-description",
+                "--revision",
+                "1",
+                "--description",
+                "Dry-run description",
+                "--dry-run",
+                "--json",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["data"]["would_update"], [str(manifest_path.resolve())])
+            self.assertEqual(manifest_path.read_bytes(), before)
+
+    def test_nonexistent_revision_is_machine_readable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_workspace(Path(tmp))
+            proc = run_cli(
+                project,
+                "revision",
+                "update-description",
+                "--revision",
+                "99",
+                "--description",
+                "Missing",
+                "--json",
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["errors"][0]["code"], "REVISION_NOT_FOUND")
+
+    def test_requires_revision_description_and_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_workspace(Path(tmp))
+            proc = run_cli(
+                project,
+                "revision",
+                "update-description",
+                "--revision",
+                "1",
+                "--json",
+            )
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(json.loads(proc.stdout)["errors"][0]["code"], "INVALID_REQUEST")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -43,6 +43,7 @@ class SystemInfoTests(unittest.TestCase):
                 "revision.approve",
                 "revision.create",
                 "revision.create.description",
+                "revision.update.description",
                 "system.info",
             ],
         )

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -47,7 +47,7 @@ assert document["capabilities"] == [
     "revision.approve",
     "revision.create",
     "revision.create.description",
-    "revision.update-description",
+    "revision.update.description",
     "system.info",
 ]
 assert Path(document["schemas"]["installed_path"]).resolve() == (

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -47,6 +47,7 @@ assert document["capabilities"] == [
     "revision.approve",
     "revision.create",
     "revision.create.description",
+    "revision.update-description",
     "system.info",
 ]
 assert Path(document["schemas"]["installed_path"]).resolve() == (


### PR DESCRIPTION
## Summary
Adds the Automation-owned API 1.0 operation required by Studio Revisions #189 to edit an existing revision's structured description safely.

### Included
- `revision update-description --revision N --description TEXT --json`
- optional `--project` and `--dry-run`
- capability `revision.update-description`
- schema-validated, atomic manifest replacement
- updates only the targeted revision description and project `last_modified_at`
- preserves revision identity/status/timestamps and `Revision_Notes.md`
- machine-readable `REVISION_NOT_FOUND` / validation errors
- focused API tests for mutation, dry-run, invalid target, and request validation

### Ownership boundary
This operation deliberately does not edit `Revision_Notes.md`; freeform Revision Notes remain separate from authoritative structured revision metadata.

Closes #115