### PR TITLE
Issue #117: cover delivery package failure safety

### DIFF
--- a/tests/python/test_delivery_management.py
+++ b/tests/python/test_delivery_management.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from jl_mixing.delivery import DeliveryCreateRequest, create_delivery
 from jl_mixing.delivery_management import (
@@ -11,7 +12,7 @@ from jl_mixing.delivery_management import (
     delete_generated_package,
     inspect_delivery,
 )
-from jl_mixing.errors import UnsafeOperationError
+from jl_mixing.errors import ContextError, UnsafeOperationError
 from test_delivery_service import write_project
 
 
@@ -81,6 +82,30 @@ class DeliveryManagementTests(unittest.TestCase):
             self.assertEqual(result["delivery"]["package_state"], "none")
             with self.assertRaises(UnsafeOperationError):
                 delete_generated_package(DeliveryDeletePackageRequest(project, "Delivery Song Main Mix.wav"))
+
+    def test_failed_package_delete_preserves_existing_delivery_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            created = create_delivery(DeliveryCreateRequest(project, make_zip=True))
+            self.assertIsNotNone(created.zip_name)
+            delivery = project / "05_Final_Delivery"
+            archive = delivery / str(created.zip_name)
+            manifest = delivery / "delivery-manifest.json"
+            manifest_before = manifest.read_bytes()
+            status_before = inspect_delivery(DeliveryStatusRequest(project))
+            self.assertEqual(status_before["state"], "ready")
+            self.assertEqual(status_before["package_state"], "current")
+
+            with patch.object(Path, "unlink", side_effect=OSError("simulated package delete failure")):
+                with self.assertRaises(ContextError):
+                    delete_generated_package(DeliveryDeletePackageRequest(project, str(created.zip_name)))
+
+            self.assertTrue(archive.is_file())
+            self.assertEqual(manifest.read_bytes(), manifest_before)
+            status_after = inspect_delivery(DeliveryStatusRequest(project))
+            self.assertEqual(status_after["state"], "ready")
+            self.assertEqual(status_after["package_state"], "current")
+            self.assertEqual(status_after["current_package"]["name"], created.zip_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Final safety regression coverage for #117 after the managed delivery status/package reconciliation slice merged in PR #122.

Adds focused failure-injection coverage proving that if generated-package deletion fails with an I/O error:
- the existing package remains present;
- the delivery manifest remains byte-for-byte unchanged;
- authoritative delivery readiness remains `ready`;
- package state remains `current`;
- the current package identity remains unchanged.

No production delivery behavior changes are introduced. This PR closes the remaining explicit #117 acceptance gap around failed mutations preserving authoritative delivery state.

Closes #117 when accepted.