### PR TITLE
Automation v2.1: integrate approved branding assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# JL Mixing Automation
+<p align="left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jl-aspect-works/jl-brand/main/jl-mixing-automation-dark-product.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/jl-aspect-works/jl-brand/main/jl-mixing-automation-light-product.png">
+    <img alt="JL Mixing Automation by JL Aspect Works" width="420" src="https://raw.githubusercontent.com/jl-aspect-works/jl-brand/main/jl-mixing-automation-light-product.png">
+  </picture>
+</p>
 
 JL Mixing Automation v2.0 is the cross-platform workflow engine behind JL Mixing Studio. It creates consistent workspaces, preserves original client files, validates intake, manages revisions/approval, exposes the Automation API used by Studio, and builds verified final-delivery packages.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
     <img alt="JL Mixing Automation by JL Aspect Works" width="420" src="https://raw.githubusercontent.com/jl-aspect-works/jl-brand/main/jl-mixing-automation-light-product.png">
   </picture>
 </p>
-
 JL Mixing Automation v2.0 is the cross-platform workflow engine behind JL Mixing Studio. It creates consistent workspaces, preserves original client files, validates intake, manages revisions/approval, exposes the Automation API used by Studio, and builds verified final-delivery packages.
 
 The authoritative runtime is Python and is shared across Windows and macOS. Automation API remains version `1.0`, while workspace metadata schemas remain version `1.1.0`.


### PR DESCRIPTION
## Summary
- updates the GitHub README to use the approved JL Mixing Automation light/dark product logos from `jl-brand/main`
- keeps the product logo left-aligned at 420px and uses it in place of the duplicate H1 heading
- preserves normal CLI/API behavior unchanged

## Scope decision
For v2.1, Automation branding is limited to the GitHub README product logo. No runtime, installer, package, or CLI branding changes are included.

## Testing
README-only branding change; normal Automation CI should remain behaviorally unchanged.

Closes #129

Related: jl-aspect-works/jl-mixing-studio#252