### PR TITLE
Automation v2.1: add studio.update capability

### DIFF
--- a/api/examples/v1.0/blocked/studio-update.json
+++ b/api/examples/v1.0/blocked/studio-update.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "1.0",
+  "operation": "studio.update",
+  "status": "blocked",
+  "data": {},
+  "warnings": [],
+  "errors": [
+    {
+      "code": "VALIDATION_FAILED",
+      "message": "Unsupported expected sample rate: 12345",
+      "details": {"exit_code": 5},
+      "retryable": false
+    }
+  ]
+}

--- a/api/examples/v1.0/error/studio-update.json
+++ b/api/examples/v1.0/error/studio-update.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "1.0",
+  "operation": "studio.update",
+  "status": "error",
+  "data": {},
+  "warnings": [],
+  "errors": [
+    {
+      "code": "FILESYSTEM_ERROR",
+      "message": "Studio configuration could not be written.",
+      "details": {"exit_code": 1},
+      "retryable": false
+    }
+  ]
+}

--- a/api/examples/v1.0/planned/studio-update.json
+++ b/api/examples/v1.0/planned/studio-update.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "1.0",
+  "operation": "studio.update",
+  "status": "planned",
+  "data": {
+    "studio": {"id": "mixing-studio", "path": "/Users/example/Music/Mixes", "configuration_path": "/Users/example/Music/Mixes/Studio/studio.json"},
+    "changed_fields": ["studio_name"],
+    "editable": {"studio_name": "Planned Studio", "mix_engineer": "Mix Engineer", "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"}, "delivery": {"method": "Cloud transfer", "requested_deliverables": ["main_mix", "instrumental"]}},
+    "last_modified_at": "2030-01-01T12:00:00Z",
+    "changed": true,
+    "would_update": ["/Users/example/Music/Mixes/Studio/studio.json"]
+  },
+  "warnings": [],
+  "errors": []
+}

--- a/api/examples/v1.0/success/studio-update.json
+++ b/api/examples/v1.0/success/studio-update.json
@@ -1,0 +1,23 @@
+{
+  "api_version": "1.0",
+  "operation": "studio.update",
+  "status": "success",
+  "data": {
+    "studio": {
+      "id": "mixing-studio",
+      "path": "/Users/example/Music/Mixes",
+      "configuration_path": "/Users/example/Music/Mixes/Studio/studio.json"
+    },
+    "changed_fields": ["studio_name", "defaults.audio.sample_rate"],
+    "editable": {
+      "studio_name": "JL Mixing Studio",
+      "mix_engineer": "Mix Engineer",
+      "audio": {"sample_rate": 96000, "bit_depth": 24, "file_format": "WAV"},
+      "delivery": {"method": "Cloud transfer", "requested_deliverables": ["main_mix", "instrumental"]}
+    },
+    "last_modified_at": "2030-01-01T13:00:00Z",
+    "changed": true
+  },
+  "warnings": [],
+  "errors": []
+}

--- a/api/schemas/v1.0/operations/studio-update.schema.json
+++ b/api/schemas/v1.0/operations/studio-update.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jlaudio.github.io/jl-mixing/api/v1.0/schemas/operations/studio-update.schema.json",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["api_version", "operation", "status", "data", "warnings", "errors"],
+  "properties": {
+    "api_version": {"const": "1.0"},
+    "operation": {"const": "studio.update"},
+    "status": {"enum": ["success", "planned", "blocked", "error"]},
+    "data": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "studio": {
+          "type": "object",
+          "required": ["id", "path", "configuration_path"],
+          "properties": {
+            "id": {"type": "string"},
+            "path": {"type": "string", "minLength": 1},
+            "configuration_path": {"type": "string", "minLength": 1}
+          }
+        },
+        "changed_fields": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "editable": {"type": "object"},
+        "last_modified_at": {"type": "string"},
+        "changed": {"type": "boolean"},
+        "would_update": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "warnings": {"type": "array"},
+    "errors": {"type": "array"}
+  }
+}

--- a/src/jl_mixing/api/studio_update.py
+++ b/src/jl_mixing/api/studio_update.py
@@ -1,0 +1,125 @@
+"""Automation API 1.0 adapter for studio.update."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..context import studio_root
+from ..errors import ArgumentError, ContextError, JLMixingError, UnsafeOperationError, ValidationError
+from ..studio_update import StudioUpdateRequest, update_studio
+from ..versions import api_version
+
+
+@dataclass(frozen=True)
+class StudioUpdateApiRequest:
+    studio: Path | None = None
+    studio_name: str | None = None
+    mix_engineer: str | None = None
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    file_format: str | None = None
+    delivery_method: str | None = None
+    requested_deliverables: tuple[str, ...] | None = None
+    dry_run: bool = False
+
+
+def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    return {
+        "api_version": api_version(),
+        "operation": "studio.update",
+        "status": status,
+        "data": {},
+        "warnings": [],
+        "errors": [{"code": code, "message": message, "details": {"exit_code": exit_code}, "retryable": False}],
+    }
+
+
+def execute(request: StudioUpdateApiRequest) -> tuple[dict[str, Any], int]:
+    try:
+        root = studio_root(request.studio or Path.cwd())
+        result = update_studio(StudioUpdateRequest(
+            studio_root=root,
+            studio_name=request.studio_name,
+            mix_engineer=request.mix_engineer,
+            sample_rate=request.sample_rate,
+            bit_depth=request.bit_depth,
+            file_format=request.file_format,
+            delivery_method=request.delivery_method,
+            requested_deliverables=request.requested_deliverables,
+            dry_run=request.dry_run,
+        ))
+        doc = result.document
+        data: dict[str, Any] = {
+            "studio": {"id": doc["studio_id"], "path": str(result.studio_root), "configuration_path": str(result.studio_config)},
+            "changed_fields": list(result.changed_fields),
+            "editable": {
+                "studio_name": doc["studio_name"],
+                "mix_engineer": doc["defaults"]["mix_engineer"],
+                "audio": doc["defaults"]["audio"],
+                "delivery": doc["defaults"]["delivery"],
+            },
+            "last_modified_at": doc["metadata"]["last_modified_at"],
+            "changed": bool(result.changed_fields),
+        }
+        if request.dry_run:
+            data["would_update"] = [str(result.studio_config)] if result.changed_fields else []
+        return {
+            "api_version": api_version(),
+            "operation": "studio.update",
+            "status": "planned" if request.dry_run else "success",
+            "data": data,
+            "warnings": [],
+            "errors": [],
+        }, 0
+    except ContextError as exc:
+        return _error_envelope("WORKSPACE_CONTEXT_ERROR", str(exc), exc.exit_code), exc.exit_code
+    except UnsafeOperationError as exc:
+        return _error_envelope("UNSAFE_OPERATION", str(exc), exc.exit_code, status="blocked"), exc.exit_code
+    except ValidationError as exc:
+        return _error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"), exc.exit_code
+    except JLMixingError as exc:
+        return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+    except OSError as exc:
+        return _error_envelope("FILESYSTEM_ERROR", str(exc), 7), 7
+
+
+def parse_args(args: list[str]) -> StudioUpdateApiRequest:
+    values: dict[str, Any] = {"dry_run": False}
+    json_seen = 0
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--json":
+            json_seen += 1
+        elif arg == "--dry-run":
+            values["dry_run"] = True
+        elif arg in {"--studio", "--name", "--engineer", "--sample-rate", "--bit-depth", "--file-format", "--delivery-method", "--deliverables"}:
+            index += 1
+            if index >= len(args):
+                raise ArgumentError(f"{arg} requires a value.")
+            value = args[index]
+            if arg == "--studio": values["studio"] = Path(value)
+            elif arg == "--name": values["studio_name"] = value
+            elif arg == "--engineer": values["mix_engineer"] = value
+            elif arg == "--sample-rate":
+                try: values["sample_rate"] = int(value)
+                except ValueError as exc: raise ArgumentError("--sample-rate requires an integer.") from exc
+            elif arg == "--bit-depth":
+                try: values["bit_depth"] = int(value)
+                except ValueError as exc: raise ArgumentError("--bit-depth requires an integer.") from exc
+            elif arg == "--file-format": values["file_format"] = value
+            elif arg == "--delivery-method": values["delivery_method"] = value
+            else: values["requested_deliverables"] = tuple(part.strip() for part in value.split(","))
+        elif arg.startswith("-"):
+            raise ArgumentError(f"Unknown option: {arg}")
+        else:
+            raise ArgumentError(f"Unexpected positional argument: {arg}")
+        index += 1
+    if json_seen != 1:
+        raise ArgumentError("studio update requires exactly one --json option.")
+    editable_keys = {"studio_name", "mix_engineer", "sample_rate", "bit_depth", "file_format", "delivery_method", "requested_deliverables"}
+    if not any(key in values for key in editable_keys):
+        raise ArgumentError("studio update requires at least one editable field.")
+    return StudioUpdateApiRequest(**values)

--- a/src/jl_mixing/api/studio_update.py
+++ b/src/jl_mixing/api/studio_update.py
@@ -32,27 +32,40 @@ def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "e
         "status": status,
         "data": {},
         "warnings": [],
-        "errors": [{"code": code, "message": message, "details": {"exit_code": exit_code}, "retryable": False}],
+        "errors": [
+            {
+                "code": code,
+                "message": message,
+                "details": {"exit_code": exit_code},
+                "retryable": False,
+            }
+        ],
     }
 
 
 def execute(request: StudioUpdateApiRequest) -> tuple[dict[str, Any], int]:
     try:
         root = studio_root(request.studio or Path.cwd())
-        result = update_studio(StudioUpdateRequest(
-            studio_root=root,
-            studio_name=request.studio_name,
-            mix_engineer=request.mix_engineer,
-            sample_rate=request.sample_rate,
-            bit_depth=request.bit_depth,
-            file_format=request.file_format,
-            delivery_method=request.delivery_method,
-            requested_deliverables=request.requested_deliverables,
-            dry_run=request.dry_run,
-        ))
+        result = update_studio(
+            StudioUpdateRequest(
+                studio_root=root,
+                studio_name=request.studio_name,
+                mix_engineer=request.mix_engineer,
+                sample_rate=request.sample_rate,
+                bit_depth=request.bit_depth,
+                file_format=request.file_format,
+                delivery_method=request.delivery_method,
+                requested_deliverables=request.requested_deliverables,
+                dry_run=request.dry_run,
+            )
+        )
         doc = result.document
         data: dict[str, Any] = {
-            "studio": {"id": doc["studio_id"], "path": str(result.studio_root), "configuration_path": str(result.studio_config)},
+            "studio": {
+                "id": doc["studio_id"],
+                "path": str(result.studio_root),
+                "configuration_path": str(result.studio_config),
+            },
             "changed_fields": list(result.changed_fields),
             "editable": {
                 "studio_name": doc["studio_name"],
@@ -82,7 +95,7 @@ def execute(request: StudioUpdateApiRequest) -> tuple[dict[str, Any], int]:
     except JLMixingError as exc:
         return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
     except OSError as exc:
-        return _error_envelope("FILESYSTEM_ERROR", str(exc), 7), 7
+        return _error_envelope("FILESYSTEM_ERROR", str(exc), 1), 1
 
 
 def parse_args(args: list[str]) -> StudioUpdateApiRequest:
@@ -95,23 +108,42 @@ def parse_args(args: list[str]) -> StudioUpdateApiRequest:
             json_seen += 1
         elif arg == "--dry-run":
             values["dry_run"] = True
-        elif arg in {"--studio", "--name", "--engineer", "--sample-rate", "--bit-depth", "--file-format", "--delivery-method", "--deliverables"}:
+        elif arg in {
+            "--studio",
+            "--name",
+            "--engineer",
+            "--sample-rate",
+            "--bit-depth",
+            "--file-format",
+            "--delivery-method",
+            "--deliverables",
+        }:
             index += 1
             if index >= len(args):
                 raise ArgumentError(f"{arg} requires a value.")
             value = args[index]
-            if arg == "--studio": values["studio"] = Path(value)
-            elif arg == "--name": values["studio_name"] = value
-            elif arg == "--engineer": values["mix_engineer"] = value
+            if arg == "--studio":
+                values["studio"] = Path(value)
+            elif arg == "--name":
+                values["studio_name"] = value
+            elif arg == "--engineer":
+                values["mix_engineer"] = value
             elif arg == "--sample-rate":
-                try: values["sample_rate"] = int(value)
-                except ValueError as exc: raise ArgumentError("--sample-rate requires an integer.") from exc
+                try:
+                    values["sample_rate"] = int(value)
+                except ValueError as exc:
+                    raise ArgumentError("--sample-rate requires an integer.") from exc
             elif arg == "--bit-depth":
-                try: values["bit_depth"] = int(value)
-                except ValueError as exc: raise ArgumentError("--bit-depth requires an integer.") from exc
-            elif arg == "--file-format": values["file_format"] = value
-            elif arg == "--delivery-method": values["delivery_method"] = value
-            else: values["requested_deliverables"] = tuple(part.strip() for part in value.split(","))
+                try:
+                    values["bit_depth"] = int(value)
+                except ValueError as exc:
+                    raise ArgumentError("--bit-depth requires an integer.") from exc
+            elif arg == "--file-format":
+                values["file_format"] = value
+            elif arg == "--delivery-method":
+                values["delivery_method"] = value
+            else:
+                values["requested_deliverables"] = tuple(part.strip() for part in value.split(","))
         elif arg.startswith("-"):
             raise ArgumentError(f"Unknown option: {arg}")
         else:
@@ -119,7 +151,15 @@ def parse_args(args: list[str]) -> StudioUpdateApiRequest:
         index += 1
     if json_seen != 1:
         raise ArgumentError("studio update requires exactly one --json option.")
-    editable_keys = {"studio_name", "mix_engineer", "sample_rate", "bit_depth", "file_format", "delivery_method", "requested_deliverables"}
+    editable_keys = {
+        "studio_name",
+        "mix_engineer",
+        "sample_rate",
+        "bit_depth",
+        "file_format",
+        "delivery_method",
+        "requested_deliverables",
+    }
     if not any(key in values for key in editable_keys):
         raise ArgumentError("studio update requires at least one editable field.")
     return StudioUpdateApiRequest(**values)

--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -29,11 +29,12 @@ from .api.revision_approve import parse_args as parse_approval_args
 from .api.revision_create import _error_envelope as revision_error_envelope
 from .api.revision_create import execute as revision_execute
 from .api.revision_create import parse_args as parse_revision_args
-from .api.revision_update_description import (
-    _error_envelope as revision_description_error_envelope,
-)
+from .api.revision_update_description import _error_envelope as revision_description_error_envelope
 from .api.revision_update_description import execute as revision_description_execute
 from .api.revision_update_description import parse_args as parse_revision_description_args
+from .api.studio_update import _error_envelope as studio_update_error_envelope
+from .api.studio_update import execute as studio_update_execute
+from .api.studio_update import parse_args as parse_studio_update_args
 from .errors import ArgumentError, ValidationError
 from .system_info import document as system_info_document
 
@@ -56,6 +57,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             return EXIT_CONFIG
         _emit_json(payload)
         return 0
+
+    if len(args) >= 2 and args[0:2] == ["studio", "update"]:
+        try:
+            request = parse_studio_update_args(args[2:])
+        except ArgumentError as exc:
+            _emit_json(studio_update_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
+            return exc.exit_code
+        except ValidationError as exc:
+            _emit_json(studio_update_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
+            return exc.exit_code
+        payload, status = studio_update_execute(request)
+        _emit_json(payload)
+        return status
 
     if len(args) >= 2 and args[0:2] == ["client", "create"]:
         try:
@@ -100,21 +114,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             request = parse_revision_description_args(args[2:])
         except ArgumentError as exc:
-            _emit_json(
-                revision_description_error_envelope(
-                    "INVALID_REQUEST", str(exc), exc.exit_code
-                )
-            )
+            _emit_json(revision_description_error_envelope("INVALID_REQUEST", str(exc), exc.exit_code))
             return exc.exit_code
         except ValidationError as exc:
-            _emit_json(
-                revision_description_error_envelope(
-                    "VALIDATION_FAILED",
-                    str(exc),
-                    exc.exit_code,
-                    status="blocked",
-                )
-            )
+            _emit_json(revision_description_error_envelope("VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"))
             return exc.exit_code
         payload, status = revision_description_execute(request)
         _emit_json(payload)

--- a/src/jl_mixing/studio_update.py
+++ b/src/jl_mixing/studio_update.py
@@ -1,0 +1,148 @@
+"""Authoritative studio configuration update service."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from .errors import ContextError, ValidationError
+from .metadata import touch_document, validate_v11, write_json_document
+from .validation import require_bit_depth, require_file_format, require_sample_rate
+from .versions import application_root
+
+_ALLOWED_DELIVERABLES = {
+    "main_mix",
+    "instrumental",
+    "acapella",
+    "tv_mix",
+    "performance_mix",
+    "stems",
+    "master",
+}
+
+
+@dataclass(frozen=True)
+class StudioUpdateRequest:
+    studio_root: Path
+    studio_name: str | None = None
+    mix_engineer: str | None = None
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    file_format: str | None = None
+    delivery_method: str | None = None
+    requested_deliverables: tuple[str, ...] | None = None
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class StudioUpdateResult:
+    studio_root: Path
+    studio_config: Path
+    document: dict[str, Any]
+    changed_fields: tuple[str, ...]
+    previous_last_modified_at: str
+    committed: bool
+
+
+def _schema() -> dict[str, Any]:
+    schema_path = application_root() / "schemas" / "studio.schema.json"
+    try:
+        return json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContextError(f"Required studio schema is unreadable: {schema_path}") from exc
+
+
+def _validate_document(document: dict[str, Any]) -> None:
+    validate_v11(document.get("metadata"), "mixing-studio", mutability="mutable")
+    try:
+        jsonschema.Draft202012Validator(_schema()).validate(document)
+    except jsonschema.ValidationError as exc:
+        raise ValidationError(f"Studio configuration failed schema validation: {exc.message}") from exc
+
+
+def _read_config(path: Path) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ContextError(f"Studio configuration not found or unsafe: {path}")
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Invalid studio configuration: {path}") from exc
+    if not isinstance(document, dict):
+        raise ValidationError(f"Invalid studio configuration object: {path}")
+    _validate_document(document)
+    return document
+
+
+def _validated_deliverables(values: tuple[str, ...]) -> list[str]:
+    if not values:
+        raise ValidationError("requested deliverables must contain at least one value.")
+    normalized = [value.strip() for value in values]
+    if any(not value for value in normalized):
+        raise ValidationError("requested deliverables must not contain empty values.")
+    if len(set(normalized)) != len(normalized):
+        raise ValidationError("requested deliverables must not contain duplicates.")
+    unsupported = [value for value in normalized if value not in _ALLOWED_DELIVERABLES]
+    if unsupported:
+        raise ValidationError(f"Unsupported requested deliverable: {unsupported[0]}")
+    return normalized
+
+
+def update_studio(request: StudioUpdateRequest) -> StudioUpdateResult:
+    root = request.studio_root.resolve()
+    config = root / "Studio" / "studio.json"
+    original = _read_config(config)
+    updated = deepcopy(original)
+    changed: list[str] = []
+
+    def assign(path: tuple[str, ...], value: object, label: str) -> None:
+        current: Any = updated
+        for key in path[:-1]:
+            current = current[key]
+        key = path[-1]
+        if current[key] != value:
+            current[key] = value
+            changed.append(label)
+
+    if request.studio_name is not None:
+        name = request.studio_name.strip()
+        if not name:
+            raise ValidationError("studio name must not be empty.")
+        assign(("studio_name",), name, "studio_name")
+    if request.mix_engineer is not None:
+        assign(("defaults", "mix_engineer"), request.mix_engineer.strip(), "defaults.mix_engineer")
+    if request.sample_rate is not None:
+        assign(("defaults", "audio", "sample_rate"), require_sample_rate(request.sample_rate), "defaults.audio.sample_rate")
+    if request.bit_depth is not None:
+        assign(("defaults", "audio", "bit_depth"), require_bit_depth(request.bit_depth), "defaults.audio.bit_depth")
+    if request.file_format is not None:
+        assign(("defaults", "audio", "file_format"), require_file_format(request.file_format), "defaults.audio.file_format")
+    if request.delivery_method is not None:
+        method = request.delivery_method.strip()
+        if not method:
+            raise ValidationError("delivery method must not be empty.")
+        assign(("defaults", "delivery", "method"), method, "defaults.delivery.method")
+    if request.requested_deliverables is not None:
+        assign(
+            ("defaults", "delivery", "requested_deliverables"),
+            _validated_deliverables(request.requested_deliverables),
+            "defaults.delivery.requested_deliverables",
+        )
+
+    previous_modified = str(original["metadata"]["last_modified_at"])
+    if changed:
+        updated = touch_document(updated)
+    _validate_document(updated)
+
+    if request.dry_run or not changed:
+        return StudioUpdateResult(root, config, updated, tuple(changed), previous_modified, False)
+
+    write_json_document(config, updated)
+    committed = _read_config(config)
+    if committed != updated:
+        raise ValidationError("Committed studio configuration did not verify after update.")
+    return StudioUpdateResult(root, config, committed, tuple(changed), previous_modified, True)

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -22,6 +22,7 @@ _CAPABILITIES = [
     "revision.create",
     "revision.create.description",
     "revision.update.description",
+    "studio.update",
     "system.info",
 ]
 

--- a/tests/python/test_studio_update_api.py
+++ b/tests/python/test_studio_update_api.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+
+def write_studio(root: Path) -> Path:
+    (root / "Studio").mkdir(parents=True)
+    (root / "Clients").mkdir()
+    studio = {
+        "metadata": {
+            "schema": "mixing-studio",
+            "schema_version": "1.1.0",
+            "document_id": "44444444-4444-4444-4444-444444444444",
+            "created_with": "jl-mixing 2.0.0",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "studio_id": "api-studio",
+        "studio_name": "API Studio",
+        "root_path": str(root),
+        "defaults": {
+            "mix_engineer": "Engineer",
+            "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+            "delivery": {"method": "Cloud transfer", "requested_deliverables": ["main_mix", "instrumental"]},
+        },
+        "cli": {"change_directory_after_create": False},
+    }
+    (root / "Studio" / "studio.json").write_text(json.dumps(studio), encoding="utf-8")
+    return root
+
+
+def run_cli(cwd: Path, *args: str, fail_at: str | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    if fail_at:
+        env["JL_MIXING_FAIL_AT"] = fail_at
+    return subprocess.run(
+        [sys.executable, "-m", "jl_mixing.cli", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class StudioUpdateApiTests(unittest.TestCase):
+    def test_updates_only_editable_fields_and_preserves_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = write_studio(Path(tmp))
+            path = root / "Studio" / "studio.json"
+            before = json.loads(path.read_text(encoding="utf-8"))
+            proc = run_cli(
+                root, "studio", "update", "--json",
+                "--name", "Renamed Studio",
+                "--engineer", "New Engineer",
+                "--sample-rate", "96000",
+                "--bit-depth", "32",
+                "--file-format", "aiff",
+                "--delivery-method", "Secure upload",
+                "--deliverables", "main_mix,stems",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "studio.update")
+            self.assertEqual(payload["status"], "success")
+            after = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(after["studio_id"], before["studio_id"])
+            self.assertEqual(after["root_path"], before["root_path"])
+            self.assertEqual(after["cli"], before["cli"])
+            for key in ("schema", "schema_version", "document_id", "created_with", "created_at"):
+                self.assertEqual(after["metadata"][key], before["metadata"][key])
+            self.assertNotEqual(after["metadata"]["last_modified_at"], before["metadata"]["last_modified_at"])
+            self.assertEqual(after["studio_name"], "Renamed Studio")
+            self.assertEqual(after["defaults"]["audio"], {"sample_rate": 96000, "bit_depth": 32, "file_format": "AIFF"})
+            self.assertEqual(after["defaults"]["delivery"]["requested_deliverables"], ["main_mix", "stems"])
+
+    def test_dry_run_validates_without_writing_or_touching_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = write_studio(Path(tmp))
+            path = root / "Studio" / "studio.json"
+            before = path.read_text(encoding="utf-8")
+            proc = run_cli(root, "studio", "update", "--json", "--name", "Planned Name", "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["data"]["editable"]["studio_name"], "Planned Name")
+            self.assertEqual(path.read_text(encoding="utf-8"), before)
+
+    def test_invalid_value_is_blocked_and_original_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = write_studio(Path(tmp))
+            path = root / "Studio" / "studio.json"
+            before = path.read_bytes()
+            proc = run_cli(root, "studio", "update", "--json", "--sample-rate", "12345")
+            self.assertEqual(proc.returncode, 5)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "blocked")
+            self.assertEqual(payload["errors"][0]["code"], "VALIDATION_FAILED")
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_transaction_failure_rolls_back_original_document(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = write_studio(Path(tmp))
+            path = root / "Studio" / "studio.json"
+            before = path.read_bytes()
+            proc = run_cli(root, "studio", "update", "--json", "--name", "Should Roll Back", fail_at="after-file-replacement")
+            self.assertNotEqual(proc.returncode, 0)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "error")
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_requires_at_least_one_editable_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = write_studio(Path(tmp))
+            proc = run_cli(root, "studio", "update", "--json")
+            self.assertEqual(proc.returncode, 2)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["errors"][0]["code"], "INVALID_REQUEST")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -47,6 +47,7 @@ class SystemInfoTests(unittest.TestCase):
                 "revision.create",
                 "revision.create.description",
                 "revision.update.description",
+                "studio.update",
                 "system.info",
             ],
         )

--- a/tests/unit/test-api-studio-update.sh
+++ b/tests/unit/test-api-studio-update.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/tests/test-helper.sh"
+require_test_command python3
+
+tmp="$(new_test_dir)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+studio="$tmp/Studio Root"
+mkdir -p "$studio/Studio" "$studio/Clients"
+
+python3 - "$studio" <<'PY_FIXTURE'
+import json
+from pathlib import Path
+import sys
+root = Path(sys.argv[1]).resolve()
+doc = {
+    "metadata": {
+        "schema": "mixing-studio", "schema_version": "1.1.0",
+        "document_id": "44444444-4444-4444-4444-444444444444",
+        "created_with": "jl-mixing 2.0.0",
+        "created_at": "2030-01-01T12:00:00Z", "last_modified_at": "2030-01-01T12:00:00Z"
+    },
+    "studio_id": "api-studio", "studio_name": "API Studio", "root_path": str(root),
+    "defaults": {
+        "mix_engineer": "Engineer",
+        "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+        "delivery": {"method": "Cloud transfer", "requested_deliverables": ["main_mix", "instrumental"]}
+    },
+    "cli": {"change_directory_after_create": False}
+}
+(root / "Studio" / "studio.json").write_text(json.dumps(doc) + "\n", encoding="utf-8")
+PY_FIXTURE
+
+config="$studio/Studio/studio.json"
+cp "$config" "$tmp/original.json"
+
+(
+    cd "$studio"
+    "$ROOT/bin/jl-mixing" studio update --json --name "Planned Studio" --dry-run >"$tmp/planned.json" 2>"$tmp/planned.err"
+)
+assert_eq "" "$(cat "$tmp/planned.err")" "studio.update dry-run keeps stderr empty"
+assert_eq "$(cat "$tmp/original.json")" "$(cat "$config")" "studio.update dry-run is non-mutating"
+assert_success "studio.update planned response matches schema" \
+    python3 "$ROOT/tools/validate-json.py" --strict \
+        --schema "$ROOT/api/schemas/v1.0/operations/studio-update.schema.json" \
+        --document "$tmp/planned.json"
+
+(
+    cd "$studio"
+    "$ROOT/bin/jl-mixing" studio update --json \
+        --name "Renamed Studio" --engineer "New Engineer" \
+        --sample-rate 96000 --bit-depth 32 --file-format aiff \
+        --delivery-method "Secure upload" --deliverables main_mix,stems \
+        >"$tmp/success.json" 2>"$tmp/success.err"
+)
+assert_eq "" "$(cat "$tmp/success.err")" "studio.update success keeps stderr empty"
+python3 - "$config" <<'PY_ASSERT'
+import json, sys
+from pathlib import Path
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["studio_id"] == "api-studio"
+assert doc["studio_name"] == "Renamed Studio"
+assert doc["defaults"]["audio"] == {"sample_rate": 96000, "bit_depth": 32, "file_format": "AIFF"}
+assert doc["defaults"]["delivery"]["requested_deliverables"] == ["main_mix", "stems"]
+assert doc["cli"] == {"change_directory_after_create": False}
+assert doc["metadata"]["document_id"] == "44444444-4444-4444-4444-444444444444"
+PY_ASSERT
+pass "studio.update commits editable values without changing identity"
+assert_success "studio.update success response matches schema" \
+    python3 "$ROOT/tools/validate-json.py" --strict \
+        --schema "$ROOT/api/schemas/v1.0/operations/studio-update.schema.json" \
+        --document "$tmp/success.json"
+
+cp "$config" "$tmp/before-invalid.json"
+set +e
+(
+    cd "$studio"
+    "$ROOT/bin/jl-mixing" studio update --json --sample-rate 12345 >"$tmp/blocked.json" 2>"$tmp/blocked.err"
+)
+status=$?
+set -e
+assert_eq "5" "$status" "studio.update invalid value preserves validation exit code"
+assert_eq "" "$(cat "$tmp/blocked.err")" "studio.update blocked response keeps stderr empty"
+assert_eq "$(cat "$tmp/before-invalid.json")" "$(cat "$config")" "studio.update blocked update preserves original document"
+assert_success "studio.update blocked response matches schema" \
+    python3 "$ROOT/tools/validate-json.py" --strict \
+        --schema "$ROOT/api/schemas/v1.0/operations/studio-update.schema.json" \
+        --document "$tmp/blocked.json"
+
+cp "$config" "$tmp/before-failure.json"
+set +e
+(
+    cd "$studio"
+    JL_MIXING_FAIL_AT=after-file-replacement "$ROOT/bin/jl-mixing" studio update --json --name "Rollback" >"$tmp/error.json" 2>"$tmp/error.err"
+)
+status=$?
+set -e
+assert_failure "studio.update injected transaction failure returns non-zero" test "$status" -eq 0
+assert_eq "$(cat "$tmp/before-failure.json")" "$(cat "$config")" "studio.update transaction failure rolls back original document"
+assert_success "studio.update error response matches schema" \
+    python3 "$ROOT/tools/validate-json.py" --strict \
+        --schema "$ROOT/api/schemas/v1.0/operations/studio-update.schema.json" \
+        --document "$tmp/error.json"
+
+echo "[OK] Automation API studio.update ($TEST_COUNT assertions)"

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -51,6 +51,7 @@ assert document["capabilities"] == [
     "revision.create",
     "revision.create.description",
     "revision.update.description",
+    "studio.update",
     "system.info",
 ]
 assert Path(document["schemas"]["installed_path"]).resolve() == (


### PR DESCRIPTION
## Summary
- adds authoritative `studio.update` mutation service
- exposes `jl-mixing studio update ... --json` through API 1.0
- enforces the locked Studio editable allowlist
- preserves Studio identity/root/metadata creation identity/CLI preferences
- validates resulting `studio.json` against the current Studio schema before commit
- atomically replaces and re-verifies the committed Studio document
- supports `--dry-run` planning without touching timestamps/files
- advertises `studio.update` through `system-info`
- adds API schema/examples and cross-platform Python API tests

## Editable fields
- `studio_name`
- `defaults.mix_engineer`
- `defaults.audio.sample_rate`
- `defaults.audio.bit_depth`
- `defaults.audio.file_format`
- `defaults.delivery.method`
- `defaults.delivery.requested_deliverables`

Closes #126