### PR TITLE
Automation v2.1: selected-file managed import execution

### DIFF
--- a/src/jl_mixing/api/managed_client_files.py
+++ b/src/jl_mixing/api/managed_client_files.py
@@ -20,6 +20,7 @@ class ImportRequest:
     sources: tuple[Path, ...]
     plan_id: str | None = None
     decisions: dict[str, str] | None = None
+    selected_relative_paths: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,23 @@ def _error(operation: str, code: str, message: str, exit_code: int, *, status: s
 
 def _project_data(root: Path) -> dict[str, str]:
     return {"path": str(root), "workspace_path": str(studio_root(root))}
+
+
+def _selected_import_plan(plan: dict[str, Any], selected_relative_paths: tuple[str, ...] | None) -> dict[str, Any]:
+    if selected_relative_paths is None:
+        return plan
+    selected = set(selected_relative_paths)
+    if not selected:
+        raise ValidationError("Import execute requires at least one selected relative path.")
+    available = {item["relative_path"] for item in plan["files"]}
+    unknown = selected - available
+    if unknown:
+        raise ValidationError(f"Selected import path is not part of the plan: {sorted(unknown)[0]}")
+    return {
+        **plan,
+        "files": [item for item in plan["files"] if item["relative_path"] in selected],
+        "items": [item for item in plan["items"] if item["source_relative_path"] in selected],
+    }
 
 
 def execute_import_plan(request: ImportRequest) -> tuple[dict[str, Any], int]:
@@ -63,11 +81,12 @@ def execute_import(request: ImportRequest) -> tuple[dict[str, Any], int]:
         if not request.plan_id:
             raise ValidationError("Import execute requires --plan-id.")
         root = resolve_project(request.project, Path.cwd())
-        plan = plan_import(root, request.source_kind, request.sources)
-        if plan["plan_id"] != request.plan_id:
+        full_plan = plan_import(root, request.source_kind, request.sources)
+        if full_plan["plan_id"] != request.plan_id:
             raise ValidationError("Import plan is stale; run import-plan again.")
+        plan = _selected_import_plan(full_plan, request.selected_relative_paths)
         result = execute_plan(root, plan, request.decisions or {})
-        return _envelope(operation, "success", {"project": _project_data(root), "plan_id": plan["plan_id"], "result": result}), 0
+        return _envelope(operation, "success", {"project": _project_data(root), "plan_id": full_plan["plan_id"], "result": result}), 0
     except ContextError as exc: return _error(operation, "PROJECT_NOT_FOUND", str(exc), exc.exit_code), exc.exit_code
     except UnsafeOperationError as exc: return _error(operation, "UNSAFE_OPERATION", str(exc), exc.exit_code, status="blocked"), exc.exit_code
     except ValidationError as exc: return _error(operation, "VALIDATION_FAILED", str(exc), exc.exit_code, status="blocked"), exc.exit_code
@@ -124,11 +143,12 @@ def _parse_decisions(raw: str) -> dict[str, str]:
 
 def parse_import_args(args: list[str], *, execute: bool) -> ImportRequest:
     project: Path | None = None; source_kind: str | None = None; sources: list[Path] = []
-    plan_id: str | None = None; decisions: dict[str, str] | None = None; json_seen = 0; index = 0
+    plan_id: str | None = None; decisions: dict[str, str] | None = None; selected_relative_paths: list[str] = []
+    json_seen = 0; index = 0
     while index < len(args):
         arg = args[index]
         if arg == "--json": json_seen += 1
-        elif arg in {"--project", "--source-kind", "--source", "--plan-id", "--decisions-json"}:
+        elif arg in {"--project", "--source-kind", "--source", "--plan-id", "--decisions-json", "--include-relative-path"}:
             index += 1
             if index >= len(args): raise ArgumentError(f"{arg} requires a value.")
             value = args[index]
@@ -136,15 +156,16 @@ def parse_import_args(args: list[str], *, execute: bool) -> ImportRequest:
             elif arg == "--source-kind": source_kind = value
             elif arg == "--source": sources.append(Path(value))
             elif arg == "--plan-id": plan_id = value
+            elif arg == "--include-relative-path": selected_relative_paths.append(value)
             else: decisions = _parse_decisions(value)
         else: raise ArgumentError(f"Unknown option: {arg}")
         index += 1
     if json_seen != 1: raise ArgumentError("managed import requires exactly one --json option.")
     if source_kind not in {"zip", "folder", "files"}: raise ArgumentError("--source-kind must be zip, folder, or files.")
     if not sources: raise ArgumentError("At least one --source is required.")
-    if not execute and (plan_id is not None or decisions is not None): raise ArgumentError("import-plan does not accept execute-only options.")
+    if not execute and (plan_id is not None or decisions is not None or selected_relative_paths): raise ArgumentError("import-plan does not accept execute-only options.")
     if execute and plan_id is None: raise ArgumentError("import-execute requires --plan-id.")
-    return ImportRequest(project, source_kind, tuple(sources), plan_id, decisions)
+    return ImportRequest(project, source_kind, tuple(sources), plan_id, decisions, tuple(selected_relative_paths) if selected_relative_paths else None)
 
 
 def parse_reset_args(args: list[str], *, execute: bool) -> ResetRequest:

--- a/tests/python/test_managed_client_files_api.py
+++ b/tests/python/test_managed_client_files_api.py
@@ -53,6 +53,54 @@ class ManagedClientFilesApiTests(unittest.TestCase):
             self.assertEqual((project / "01_Client_Files" / "Original_Delivery" / "Stems" / "bass.wav").read_bytes(), b"bass")
             self.assertEqual((project / "02_Audio_Preparation" / "Working_Audio" / "mix.wav").read_bytes(), b"mix")
 
+    def test_folder_execute_can_select_only_part_of_the_immutable_plan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); project = fixture(root / "studio")
+            source = root / "delivery"; (source / "Stems").mkdir(parents=True)
+            (source / "mix.wav").write_bytes(b"mix")
+            (source / "Stems" / "bass.wav").write_bytes(b"bass")
+            planned = run(project, "client-files", "import-plan", "--json", "--source-kind", "folder", "--source", str(source))
+            plan = json.loads(planned.stdout)["data"]["plan"]
+            executed = run(
+                project,
+                "client-files", "import-execute", "--json", "--source-kind", "folder", "--source", str(source),
+                "--plan-id", plan["plan_id"], "--include-relative-path", "Stems/bass.wav",
+            )
+            self.assertEqual(executed.returncode, 0, executed.stdout + executed.stderr)
+            self.assertEqual((project / "01_Client_Files" / "Original_Delivery" / "Stems" / "bass.wav").read_bytes(), b"bass")
+            self.assertEqual((project / "02_Audio_Preparation" / "Working_Audio" / "Stems" / "bass.wav").read_bytes(), b"bass")
+            self.assertFalse((project / "01_Client_Files" / "Original_Delivery" / "mix.wav").exists())
+            self.assertFalse((project / "02_Audio_Preparation" / "Working_Audio" / "mix.wav").exists())
+
+    def test_selection_rejects_unknown_paths_and_ignores_deselected_conflicts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); project = fixture(root / "studio")
+            source = root / "delivery"; source.mkdir()
+            (source / "keep.wav").write_bytes(b"keep")
+            (source / "conflict.wav").write_bytes(b"new")
+            existing = project / "01_Client_Files" / "Original_Delivery" / "conflict.wav"
+            existing.write_bytes(b"old")
+            planned = run(project, "client-files", "import-plan", "--json", "--source-kind", "folder", "--source", str(source))
+            plan = json.loads(planned.stdout)["data"]["plan"]
+
+            unknown = run(
+                project,
+                "client-files", "import-execute", "--json", "--source-kind", "folder", "--source", str(source),
+                "--plan-id", plan["plan_id"], "--include-relative-path", "missing.wav",
+            )
+            self.assertEqual(unknown.returncode, 5)
+            self.assertIn("Selected import path is not part of the plan", unknown.stdout)
+
+            executed = run(
+                project,
+                "client-files", "import-execute", "--json", "--source-kind", "folder", "--source", str(source),
+                "--plan-id", plan["plan_id"], "--include-relative-path", "keep.wav",
+            )
+            self.assertEqual(executed.returncode, 0, executed.stdout + executed.stderr)
+            self.assertEqual(existing.read_bytes(), b"old")
+            self.assertEqual((project / "01_Client_Files" / "Original_Delivery" / "keep.wav").read_bytes(), b"keep")
+            self.assertEqual((project / "02_Audio_Preparation" / "Working_Audio" / "keep.wav").read_bytes(), b"keep")
+
     def test_conflicts_require_decisions_and_skip_couples_audio_operation(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp); project = fixture(root / "studio")


### PR DESCRIPTION
## Summary
- extends `client.files.import.execute` with optional repeated `--include-relative-path` selection
- validates selected source-relative paths against the already verified immutable import plan
- filters execution to selected plan files/items before invoking the existing transactional executor
- preserves full-plan behavior when selection is omitted
- requires conflict decisions only for selected files because deselected plan items are excluded before conflict validation
- keeps original plan-ID/stale-plan, destination-state, path-safety, rollback, provenance, and cache invalidation behavior intact
- adds coverage for partial folder-plan execution, unknown selection rejection, deselected conflicts, and backward-compatible full-plan execution

Closes #140
Supports jl-aspect-works/jl-mixing-studio#269