### PR TITLE
Update Automation user guide for v2.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,12 @@
 
 ## Current user and integration documentation
 
-- [User Guide](USER_GUIDE.md)
+- [v2.1 User Guide](USER_GUIDE.md)
 - [Command Reference](SCRIPT_REFERENCE.md)
 - [Installation Guide](INSTALLATION_GUIDE.md)
 - [Automation API Design](AUTOMATION_API.md)
 - [Automation API Implementation Status](AUTOMATION_API_IMPLEMENTATION.md)
-- [v1.5 Release Notes](RELEASE_NOTES_V1.5.md)
+- [v2.0 Release Notes](RELEASE_NOTES_V2.0.md)
 
 ## Development and architecture
 
@@ -25,8 +25,9 @@
 - [v1.2 Release Notes](RELEASE_NOTES_V1.2.md)
 - [v1.3 Release Notes](RELEASE_NOTES_V1.3.md)
 - [v1.4 Release Notes](RELEASE_NOTES_V1.4.md)
+- [v1.5 Release Notes](RELEASE_NOTES_V1.5.md)
 
-For current behavior, prefer the v1.5 User Guide, Command Reference,
-Installation Guide, API implementation-status document, and v1.5 release notes.
-Older design/scope documents remain available as historical records and should
-not override the current implementation contract.
+For current behavior, prefer the v2.1 User Guide, Command Reference,
+Installation Guide, and API implementation-status document. Release notes remain
+version-specific historical records and should not override the current
+implementation contract.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,4 +1,11 @@
-# JL Mixing Automation v1.5 User Guide
+# JL Mixing Automation v2.1 User Guide
+
+JL Mixing Automation is the workflow engine behind JL Mixing Studio. Most daily
+workflow can be performed from Studio, while the human CLI remains available for
+direct automation use and recovery/administrative workflows.
+
+Automation v2.1 continues using Automation API `1.0` and workspace metadata
+schema `1.1.0`.
 
 ## 1. Create the workspace
 
@@ -10,7 +17,10 @@ The default root is `~/Music/Mixes/`. Use `--default-cd` if creation commands
 should enter newly created directories automatically. `--cd` and `--no-cd`
 override that preference for an individual command.
 
-## 2. Create a client
+After creation, Studio can edit supported Studio defaults through Automation's
+authoritative update capability rather than editing `studio.json` directly.
+
+## 2. Create and maintain clients
 
 ```text
 new-client acme --name "Acme Records"
@@ -27,7 +37,11 @@ A client contains `client.json` and a flattened `Projects/` directory. Audio and
 delivery defaults are inherited from `studio.json` unless overridden. An artist
 default is optional.
 
-## 3. Create a project and Revision 1
+Studio v2.1 can edit supported client metadata through Automation's managed
+client-update operation. Automation remains authoritative for validation,
+conflict checks, and persistence.
+
+## 3. Create and maintain a project
 
 From a client directory or with an explicit client reference:
 
@@ -45,7 +59,10 @@ revision description. Use `--source PATH` to copy an initial client delivery int
 `01_Client_Files/Original_Delivery/`. Source material is copied, never moved or
 modified.
 
-## 4. Validate intake
+Studio v2.1 can edit supported project metadata through Automation's managed
+project-update operation.
+
+## 4. Manage Client Files and validate intake
 
 ```text
 validate-intake
@@ -67,10 +84,35 @@ Unavailable external inspection tools are reported as skipped. JL Mixing does
 not automatically convert, repair, rename, move, or delete original client
 files.
 
-Prepare accepted files manually in `02_Audio_Preparation/Working_Audio/` and
-record engineering decisions in `Preparation_Report.md`.
+### Managed Client Files import
 
-## 5. Work with revisions
+Studio v2.1 can import additional Client Files through Automation's managed
+plan/execute workflow. Before files are copied, Studio shows conflicts and lets
+the user choose Add or Skip per file, or apply Add All / Skip All. Automation
+revalidates the selected plan before execution and preserves path-safety and
+transactional behavior.
+
+Client Files validation findings remain visible on the Client Files screen, but
+they do not by themselves put the overall project into Needs Attention. Project
+validation attention is driven by Audio Prep / Audio Files readiness.
+
+## 5. Prepare working audio
+
+Accepted working files live under:
+
+```text
+02_Audio_Preparation/Working_Audio/
+```
+
+Automation provides structured Audio Prep validation and provenance information
+used by Studio. Studio v2.1 also exposes a managed Audio Prep reset workflow that
+rebuilds the managed working set from the current Client Files source through an
+authoritative Automation plan/execute operation.
+
+Reset is intentionally managed rather than an unrestricted filesystem delete or
+copy operation.
+
+## 6. Work with revisions
 
 Place initial mix prints in:
 
@@ -85,9 +127,19 @@ new-revision --description "Client notes addressed"
 ```
 
 Use `--source FILE_OR_DIRECTORY` to copy immediate mix-print files into the new
-revision directory. JL Mixing does not add a separate review-package lifecycle.
+revision directory.
 
-## 6. Record approval
+### Close and reopen revisions
+
+Studio v2.1 adds reversible Close/Reopen controls backed by Automation. Use
+Close when a revision was created by mistake, abandoned, or should no longer be
+treated as the active/current revision. Closing does not delete revision files or
+history. Reopen restores the revision to the normal workflow when needed.
+
+This avoids destructive revision deletion while allowing project health to
+reflect the revision that is actually being worked on.
+
+## 7. Approve and unapprove a revision
 
 ```text
 approve-mix
@@ -103,7 +155,11 @@ approve-mix --revision 2 --approved-by "Client"
 Approval updates project metadata only. It does not alter revision files or an
 existing final-delivery package.
 
-## 7. Create final delivery
+Studio v2.1 can also Unapprove an approved revision through Automation. This is
+a reversible metadata operation and does not remove revision files or delivery
+history.
+
+## 8. Create final delivery
 
 ```text
 create-delivery
@@ -143,13 +199,13 @@ to remain unchanged.
 create-delivery --clean
 ```
 
-`--clean` replaces every file and directory inside the project's
-`05_Final_Delivery/`. Review `create-delivery --dry-run --clean` before using it.
-Current v1.5 behavior may regenerate delivery-note templates during a clean
-rebuild; delivery-note preservation semantics are tracked for a future workflow
-revision.
+`--clean` replaces generated Delivery contents according to the managed delivery
+plan. Review `create-delivery --dry-run --clean` before using it.
 
-## 8. Machine/API integration
+Studio uses Automation's managed Delivery status and reconciliation operations to
+show whether a package is current, stale, missing, or ready to build.
+
+## 9. Studio / Automation API integration
 
 JL Mixing Studio and other machine clients discover Automation with:
 
@@ -157,9 +213,22 @@ JL Mixing Studio and other machine clients discover Automation with:
 jl-mixing system-info --json
 ```
 
-Automation API `1.0` exposes capability-backed client, project, intake,
-revision/approval, delivery, and system-info operations. Machine clients should
-use API capabilities instead of parsing human CLI output.
+Automation API `1.0` uses additive capability discovery. Studio v2.1 relies on
+capability-backed operations for:
+
+- Studio, client, and project metadata updates
+- cached structured intake validation
+- managed Client Files import, including selected-file execution
+- Audio Prep validation, provenance, and managed reset
+- revision creation and description updates
+- revision Close/Reopen
+- approval and Unapprove
+- Delivery status, reconciliation, package creation, and managed cleanup
+- system/version/capability discovery
+
+Machine clients must use the reported `api_version` and `capabilities` rather
+than parsing human CLI output or assuming compatibility from the product release
+number.
 
 ## Directory layout
 
@@ -183,6 +252,7 @@ boundary but does not interpret or manage native DAW project files.
 
 ## Compatibility
 
-v1.5 continues using metadata schema `1.1.0` and supports valid v1.1+
-workspaces. It does not migrate v1.0 workspaces. Application, Automation API,
-and metadata schema versions are independent contracts.
+Automation v2.1 continues using metadata schema `1.1.0` and Automation API
+`1.0`. Existing valid v1.1+ workspaces remain compatible; no workspace migration
+is introduced by v2.1. Application release, Automation API, and metadata schema
+versions remain independent contracts.


### PR DESCRIPTION
## Summary
- refreshes the Automation User Guide from v1.5 to the v2.1 workflow
- documents Studio-facing metadata editing, managed Client Files import / Audio Prep reset, revision Close/Reopen and Unapprove behavior, and current Delivery/API integration
- updates the documentation index so it no longer points users to the v1.5 guide
- preserves Automation API 1.0 and metadata schema 1.1.0 compatibility guidance

Documentation-only release-preparation change.