### PR TITLE
Drive Automation releases from VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,55 @@
-# Build and publish JL Mixing Automation release packages.
-#
-# Normal use:
-#   Push an annotated tag such as v2.1.0-rc.1.
-#
-# Recovery use:
-#   Run this workflow manually and enter an existing tag, such as v2.1.0-rc.1.
-#   This is useful when package builds succeeded but the publish job failed.
-
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
-
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Existing release tag to build and publish, such as v2.1.0-rc.1"
-        required: true
-        type: string
 
 permissions:
-  contents: write
+  contents: read
 
-env:
-  RELEASE_TAG: >-
-    ${{ github.event_name == 'workflow_dispatch'
-        && inputs.tag
-        || github.ref_name }}
+concurrency:
+  group: release-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main" || {
+            echo "Normal releases must be dispatched from main; got $GITHUB_REF" >&2
+            exit 1
+          }
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - id: version
+        name: Read VERSION
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(tr -d '[:space:]' < VERSION)"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
+            echo "Invalid VERSION: $version" >&2
+            exit 1
+          }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+      - name: Run release verification
+        shell: bash
+        run: make release-check
+
   build:
     name: Build ${{ matrix.platform }} package
+    needs: validate
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -42,22 +57,18 @@ jobs:
           - os: macos-15-intel
             platform: macos-x86_64
             architecture: x86_64
-
           - os: macos-15
             platform: macos-arm64
             architecture: arm64
-
           - os: ubuntu-latest
             platform: linux
             architecture: none
-
     steps:
       - name: Check out release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -66,12 +77,10 @@ jobs:
           cache-dependency-path: |
             packaging/requirements.txt
             packaging/macos-build-requirements.txt
-
       - name: Install operating-system dependencies
         shell: bash
         run: |
           set -euo pipefail
-
           if [[ "$RUNNER_OS" == "macOS" ]]; then
               brew install jq shellcheck
           elif [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -81,7 +90,6 @@ jobs:
               echo "Unsupported runner operating system: $RUNNER_OS" >&2
               exit 1
           fi
-
       - name: Install Python dependencies
         shell: bash
         run: |
@@ -91,61 +99,35 @@ jobs:
           if [[ "$RUNNER_OS" == "macOS" ]]; then
               python -m pip install -r packaging/macos-build-requirements.txt
           fi
-
-      - name: Verify tag and application version
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="$(tr -d '[:space:]' < VERSION)"
-          expected_tag="v${version}"
-          echo "Release tag: $RELEASE_TAG"
-          echo "VERSION:     $version"
-          if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
-              echo "Tag/version mismatch." >&2
-              echo "Expected tag: $expected_tag" >&2
-              echo "Actual tag:   $RELEASE_TAG" >&2
-              exit 1
-          fi
-
       - name: Build self-contained macOS runtime
         if: runner.os == 'macOS'
         shell: bash
         run: bash ./macos/build-runtime.sh
-
       - name: Run bundled macOS runtime smoke tests
         if: runner.os == 'macOS'
         shell: bash
         env:
           JL_MIXING_EXPECTED_ARCH: ${{ matrix.architecture }}
         run: bash ./tests/macos/test-runtime-bundle.sh
-
       - name: Run release verification
         shell: bash
-        run: |
-          set -euo pipefail
-          make release-check
-
+        run: make release-check
       - name: Build release package
         shell: bash
         run: |
           set -euo pipefail
           rm -rf dist
           tools/build-release --platform "${{ matrix.platform }}"
-
       - name: Verify generated assets
         shell: bash
         run: |
           set -euo pipefail
-          version="$(tr -d '[:space:]' < VERSION)"
+          version="${{ needs.validate.outputs.version }}"
           archive="dist/jl-mixing-${version}-${{ matrix.platform }}.tar.gz"
           checksum="${archive}.sha256"
           inventory="${archive}.inventory.txt"
           for file in "$archive" "$checksum" "$inventory"; do
-              if [[ ! -f "$file" ]]; then
-                  echo "Missing release asset: $file" >&2
-                  exit 1
-              fi
-              echo "Created: $file"
+              test -f "$file" || { echo "Missing release asset: $file" >&2; exit 1; }
           done
           if [[ "$RUNNER_OS" == "macOS" ]]; then
               tar -tzf "$archive" | grep -q "jl-mixing-${version}/runtime/python$" || {
@@ -153,9 +135,6 @@ jobs:
                   exit 1
               }
           fi
-          echo
-          ls -lh dist
-
       - name: Upload platform release assets
         uses: actions/upload-artifact@v4
         with:
@@ -169,15 +148,14 @@ jobs:
 
   build-windows:
     name: Build windows package
+    needs: validate
     runs-on: windows-latest
-
     steps:
       - name: Check out release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -186,61 +164,41 @@ jobs:
           cache-dependency-path: |
             packaging/requirements.txt
             packaging/windows-build-requirements.txt
-
       - name: Install Python dependencies
         shell: pwsh
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r packaging/requirements.txt
           python -m pip install -r packaging/windows-build-requirements.txt
-
-      - name: Verify tag and application version
-        shell: pwsh
-        run: |
-          $version = (Get-Content -LiteralPath VERSION -Raw).Trim()
-          $expectedTag = "v$version"
-          Write-Output "Release tag: $env:RELEASE_TAG"
-          Write-Output "VERSION:     $version"
-          if ($env:RELEASE_TAG -ne $expectedTag) {
-              throw "Tag/version mismatch. Expected $expectedTag; actual $env:RELEASE_TAG"
-          }
-
       - name: Run Python runtime tests
         shell: pwsh
         env:
           PYTHONPATH: ${{ github.workspace }}\src
         run: python -m unittest discover -s tests/python -p "test_*.py"
-
       - name: Run native Windows command tests
         shell: pwsh
         run: ./tests/windows/test-command-surface.ps1
-
       - name: Build self-contained Windows runtime
         shell: pwsh
         run: ./windows/build-runtime.ps1
-
       - name: Run bundled runtime smoke tests
         shell: pwsh
         run: ./tests/windows/test-runtime-bundle.ps1
-
       - name: Run Windows installation lifecycle tests
         shell: pwsh
         run: ./tests/windows/test-installation.ps1
-
       - name: Build and verify Windows release package
         shell: pwsh
         run: ./tests/windows/test-release-package.ps1
-
       - name: Build official Windows release assets
         shell: pwsh
         run: |
           Remove-Item -LiteralPath dist -Recurse -Force -ErrorAction SilentlyContinue
           ./windows/build-release.ps1 -OutputDir dist
-
       - name: Verify generated assets
         shell: pwsh
         run: |
-          $version = (Get-Content -LiteralPath VERSION -Raw).Trim()
+          $version = "${{ needs.validate.outputs.version }}"
           $archive = "dist\jl-mixing-$version-windows.zip"
           $checksum = "$archive.sha256"
           $inventory = "$archive.inventory.txt"
@@ -248,10 +206,7 @@ jobs:
               if (-not (Test-Path -LiteralPath $file -PathType Leaf)) {
                   throw "Missing release asset: $file"
               }
-              Write-Output "Created: $file"
           }
-          Get-ChildItem -LiteralPath dist
-
       - name: Upload Windows release assets
         uses: actions/upload-artifact@v4
         with:
@@ -266,65 +221,68 @@ jobs:
   publish:
     name: Publish GitHub release
     runs-on: ubuntu-latest
-    needs: [build, build-windows]
-
+    needs: [validate, build, build-windows]
+    permissions:
+      contents: write
+    env:
+      RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
     steps:
-      - name: Check out release notes
+      - name: Check out release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
-          sparse-checkout: docs/RELEASE_NOTES_V2.1.md
-          sparse-checkout-cone-mode: false
-
+          ref: ${{ github.sha }}
+          fetch-depth: 0
       - name: Download release assets
         uses: actions/download-artifact@v4
         with:
           pattern: release-*
           path: release-assets
           merge-multiple: true
-
       - name: Verify downloaded assets
         shell: bash
         run: |
           set -euo pipefail
-          echo "Assets prepared for $RELEASE_TAG:"
-          find release-assets -maxdepth 1 -type f -print | sort
           asset_count="$(find release-assets -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
-          # Intel macOS, Apple Silicon macOS, Linux, and Windows each publish
-          # an archive, checksum, and inventory.
-          if [[ "$asset_count" -ne 12 ]]; then
-              echo "Expected 12 release assets; found $asset_count." >&2
+          test "$asset_count" -eq 12 || {
+            echo "Expected 12 release assets; found $asset_count." >&2
+            exit 1
+          }
+      - name: Create release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            target="$(git rev-list -n 1 "$RELEASE_TAG")"
+            test "$target" = "$GITHUB_SHA" || {
+              echo "Tag $RELEASE_TAG already points to $target, not $GITHUB_SHA" >&2
               exit 1
+            }
+          else
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git tag -a "$RELEASE_TAG" "$GITHUB_SHA" -m "JL Mixing Automation $RELEASE_TAG"
+            git push origin "$RELEASE_TAG"
           fi
-
       - name: Create or update GitHub release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="$RELEASE_TAG"
           shopt -s nullglob
           assets=(release-assets/*)
-          if [[ "${#assets[@]}" -eq 0 ]]; then
-              echo "No release assets were downloaded." >&2
-              exit 1
+          prerelease_args=()
+          if [[ "$RELEASE_VERSION" == *-* ]]; then
+              prerelease_args+=(--prerelease)
           fi
-          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              echo "Release $tag already exists."
-              echo "Uploading and replacing its custom assets."
-              gh release upload "$tag" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
           else
-              echo "Creating release $tag."
-              prerelease_args=()
-              if [[ "$tag" == *-* ]]; then
-                  prerelease_args+=(--prerelease)
-              fi
-              gh release create "$tag" "${assets[@]}" \
-                  --repo "$GITHUB_REPOSITORY" \
+              gh release create "$RELEASE_TAG" "${assets[@]}" \
                   --verify-tag \
-                  --title "JL Mixing Automation ${tag#v}" \
+                  --title "JL Mixing Automation $RELEASE_VERSION" \
                   --notes-file docs/RELEASE_NOTES_V2.1.md \
                   "${prerelease_args[@]}"
           fi

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ The default workspace is `~/Music/Mixes/`. Projects live directly beneath `Clien
 
 ## Installation
 
+Use the version shown on the GitHub release in place of `<version>` below.
+
 ### Windows
 
-For the release candidate, download and extract `jl-mixing-2.1.0-rc.2-windows.zip`, then run:
+Download and extract `jl-mixing-<version>-windows.zip`, then run:
 
 ```powershell
 .\windows\install.ps1
@@ -50,8 +52,8 @@ The package includes its private Python runtime. The default installation is ben
 Choose the release archive for your architecture (`macos-x86_64` for Intel or `macos-arm64` for Apple Silicon) and extract it. The packages are unsigned and not notarized, so after verifying the release checksum remove quarantine recursively from the extracted folder before installing:
 
 ```bash
-xattr -dr com.apple.quarantine /path/to/jl-mixing-2.1.0-rc.2
-cd /path/to/jl-mixing-2.1.0-rc.2
+xattr -dr com.apple.quarantine /path/to/jl-mixing-<version>
+cd /path/to/jl-mixing-<version>
 ./macos/install.sh
 ```
 
@@ -93,6 +95,6 @@ New records identify the current application release in `created_with` without c
 
 ## Documentation
 
-Start with [`docs/README.md`](docs/README.md), the [`v2.1 User Guide`](docs/USER_GUIDE.md), the [`Installation Guide`](docs/INSTALLATION_GUIDE.md), and the [`2.1 release notes`](docs/RELEASE_NOTES_V2.1.md).
+Start with [`docs/README.md`](docs/README.md), the [`v2.1 User Guide`](docs/USER_GUIDE.md), the [`Installation Guide`](docs/INSTALLATION_GUIDE.md), the [`Release Checklist`](docs/RELEASE_CHECKLIST.md), and the [`2.1 release notes`](docs/RELEASE_NOTES_V2.1.md).
 
 JL Mixing Automation is licensed under Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,33 @@
+# JL Mixing Automation Release Checklist
+
+`VERSION` is the single release-version source of truth. Tests and release scripts must validate `VERSION` dynamically; they must not encode the current RC or stable release number.
+
+## Prepare the release
+
+- [ ] Confirm all intended release changes are merged to `main` and no release-blocking PR remains open.
+- [ ] Update `VERSION` to the intended SemVer value (for example `2.1.0-rc.3` or `2.1.0`).
+- [ ] Do not change tests or application code solely to advance the release number.
+- [ ] Update release notes only when release content or installation guidance actually changed; do not edit them solely to change an RC number.
+- [ ] Run `make release-check`.
+- [ ] Open the release-preparation PR.
+- [ ] Confirm ShellCheck and the complete Tests workflow are green before merge.
+- [ ] Merge the release-preparation PR to `main`.
+
+## Build and publish
+
+- [ ] From GitHub Actions, run the **Release** workflow on `main`. Do not create the release tag manually.
+- [ ] The workflow must read `VERSION`, build the exact dispatched `main` commit, and create `v${VERSION}` only after all platform builds succeed.
+- [ ] Monitor the workflow through completion. If a job fails, inspect all failed jobs before changing code and rerun only after the complete failure set is understood.
+- [ ] Confirm Windows package succeeds.
+- [ ] Confirm macOS Intel package succeeds.
+- [ ] Confirm macOS Apple Silicon package succeeds.
+- [ ] Confirm Linux package succeeds.
+- [ ] Confirm all archive checksums and inventories are present.
+- [ ] Confirm the GitHub release is published and is marked prerelease when `VERSION` contains a prerelease suffix.
+
+## Coordinated acceptance
+
+- [ ] Install the published Automation package on Windows and verify the command/runtime surface.
+- [ ] Install the appropriate Automation package on macOS and verify the command/runtime surface.
+- [ ] Perform coordinated acceptance with the intended JL Mixing Studio candidate.
+- [ ] Record release-blocking findings as issues/PRs and do not advance to the next RC or stable release until resolved or explicitly deferred.

--- a/docs/RELEASE_NOTES_V2.1.md
+++ b/docs/RELEASE_NOTES_V2.1.md
@@ -4,7 +4,7 @@ JL Mixing Automation 2.1 supplies the authoritative workflow capabilities used b
 
 ## Installation
 
-Download the release archive for your platform from the Assets section and verify its accompanying SHA-256 checksum before installing.
+Download the release archive for your platform from the Assets section and verify its accompanying SHA-256 checksum before installing. Replace `<version>` below with the version shown on the release, for example `2.1.0-rc.3`.
 
 ### macOS
 
@@ -16,8 +16,8 @@ Choose the archive that matches your Mac:
 The packages remain unsigned and not notarized. After verifying the checksum, remove quarantine recursively from the extracted release directory before running the installer:
 
 ```bash
-xattr -dr com.apple.quarantine /path/to/jl-mixing-2.1.0-rc.2
-cd /path/to/jl-mixing-2.1.0-rc.2
+xattr -dr com.apple.quarantine /path/to/jl-mixing-<version>
+cd /path/to/jl-mixing-<version>
 ./macos/install.sh
 ```
 
@@ -29,7 +29,7 @@ jl-mixing --version
 
 ### Windows
 
-Download and extract `jl-mixing-2.1.0-rc.2-windows.zip`, then run:
+Download and extract `jl-mixing-<version>-windows.zip`, then run:
 
 ```powershell
 .\windows\install.ps1
@@ -99,4 +99,4 @@ Closing a revision is non-destructive; it does not delete the revision directory
 
 ## Release-candidate validation
 
-`2.1.0-rc.2` is intended for coordinated packaged validation with JL Mixing Studio `2.1.0-rc.2` on Windows and macOS before promotion to the stable 2.1 release.
+Prerelease versions of 2.1 are intended for coordinated packaged validation with the corresponding JL Mixing Studio 2.1 candidate on Windows and macOS before promotion to the stable 2.1 release.

--- a/tests/unit/test-release-prep.sh
+++ b/tests/unit/test-release-prep.sh
@@ -32,6 +32,8 @@ for file in "$ROOT/README.md" "$ROOT/packaging/RELEASE_README.md" \
         grep -q 'Music/JL Mixing' "$file"
 done
 
+assert_file_exists "$ROOT/VERSION"
+assert_success "VERSION is supported SemVer" grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' "$ROOT/VERSION"
 assert_file_exists "$ROOT/API_VERSION"
 assert_file_exists "$ROOT/api/schemas/v1.0/system-info.schema.json"
 assert_file_exists "$ROOT/api/schemas/v1.0/operations/client-create.schema.json"
@@ -71,8 +73,6 @@ assert_file_exists "$ROOT/docs/RELEASE_NOTES_V1.5.md"
 assert_file_exists "$ROOT/docs/RELEASE_NOTES_V2.0.md"
 assert_file_exists "$ROOT/docs/RELEASE_NOTES_V2.1.md"
 assert_file_exists "$ROOT/docs/SCOPE_FREEZE_V1.2.md"
-assert_eq "2.1.0-rc.2" "$(sed -n '1p' "$ROOT/VERSION")" \
-    "v2.1.0-rc.2 application release version"
 assert_eq "1.0" "$(sed -n '1p' "$ROOT/API_VERSION")" \
     "Automation API version is independent"
 assert_contains "$(cat "$ROOT/.github/workflows/release.yml")" \
@@ -84,7 +84,7 @@ assert_contains "$(cat "$ROOT/.github/workflows/release.yml")" \
 assert_contains "$(cat "$ROOT/docs/INSTALLATION_GUIDE.md")" \
     'xattr -dr com.apple.quarantine .' "installation guide documents unsigned macOS quarantine handling"
 assert_contains "$(cat "$ROOT/docs/RELEASE_NOTES_V2.1.md")" \
-    'xattr -dr com.apple.quarantine /path/to/jl-mixing-2.1.0-rc.2' "v2.1 release notes document bundled-runtime quarantine workaround"
+    '/path/to/jl-mixing-<version>' "v2.1 release notes use version-independent quarantine example"
 assert_contains "$(cat "$ROOT/docs/RELEASE_NOTES_V2.1.md")" \
     'Unblock-File .\windows\install.ps1' "v2.1 release notes document Windows downloaded-script unblock"
 assert_contains "$(cat "$ROOT/docs/USER_GUIDE.md")" \


### PR DESCRIPTION
## Summary
- keeps `VERSION` as the single release-version source of truth
- removes hard-coded current-RC assertions from release-preparation tests
- makes active 2.1 install/release documentation version-independent
- changes the normal Release workflow to read `VERSION`, build the exact dispatched `main` commit, and create `v${VERSION}` only after all platform builds pass
- adds `docs/RELEASE_CHECKLIST.md` for repeatable release preparation, publishing, and coordinated acceptance

## Intended RC3 process
For RC3, release preparation should require updating `VERSION` only unless release-note content actually changed. Tests and workflow code should not require an RC-number edit.