### PR TITLE
Fix Windows NAS project directory commit for RC3

### DIFF
--- a/src/jl_mixing/api/project_create.py
+++ b/src/jl_mixing/api/project_create.py
@@ -121,6 +121,8 @@ def execute(request: ProjectApiRequest) -> tuple[dict[str, Any], int]:
         return _error_envelope(code, message, exc.exit_code, status="blocked"), exc.exit_code
     except JLMixingError as exc:
         return _error_envelope("INTERNAL_ERROR", str(exc), exc.exit_code), exc.exit_code
+    except OSError as exc:
+        return _error_envelope("FILESYSTEM_ERROR", str(exc), 1), 1
 
 
 def _parse_deliverables(value: str) -> list[str]:

--- a/src/jl_mixing/transactions.py
+++ b/src/jl_mixing/transactions.py
@@ -26,6 +26,11 @@ def commit_new_directory(staged_directory: Path, destination: Path) -> None:
     Preserves the v1.4 ``before-directory-commit`` and
     ``after-directory-commit`` failure-injection contract. A failure after the
     rename removes only the directory created by this transaction.
+
+    The destination is required not to exist, so use ordinary rename semantics
+    rather than replacement semantics. This is equivalent on POSIX and avoids
+    Windows/SMB providers that reject directory replacement even when the
+    destination is absent.
     """
 
     if staged_directory.is_symlink() or not staged_directory.is_dir():
@@ -37,7 +42,12 @@ def commit_new_directory(staged_directory: Path, destination: Path) -> None:
 
     committed = False
     try:
-        os.replace(staged_directory, destination)
+        try:
+            os.rename(staged_directory, destination)
+        except OSError as exc:
+            raise JLMixingError(
+                f"Could not commit staged directory to {destination}: {exc}"
+            ) from exc
         committed = True
         if _fail_requested("after-directory-commit"):
             raise _injected_failure("after-directory-commit")

--- a/tests/python/test_project_api_failures.py
+++ b/tests/python/test_project_api_failures.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing.api.project_create import ProjectApiRequest, execute
+
+
+class ProjectApiFailureTests(unittest.TestCase):
+    def test_filesystem_failure_returns_structured_api_error(self) -> None:
+        request = ProjectApiRequest(project_name="Network Song")
+        with patch(
+            "jl_mixing.api.project_create.resolve_client_reference",
+            return_value=Path(r"\\server\mixes\Clients\Client"),
+        ), patch(
+            "jl_mixing.api.project_create.create_project",
+            side_effect=OSError(5, "Access is denied"),
+        ):
+            payload, exit_code = execute(request)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["operation"], "project.create")
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["errors"][0]["code"], "FILESYSTEM_ERROR")
+        self.assertIn("Access is denied", payload["errors"][0]["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_transactions.py
+++ b/tests/python/test_transactions.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing.errors import JLMixingError
+from jl_mixing.transactions import commit_new_directory
+
+
+class TransactionDirectoryCommitTests(unittest.TestCase):
+    def test_new_directory_commit_uses_rename_not_replace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stage = root / ".project.jl-stage-test"
+            destination = root / "Project"
+            stage.mkdir()
+            (stage / "marker.txt").write_text("ok", encoding="utf-8")
+
+            with patch(
+                "jl_mixing.transactions.os.replace",
+                side_effect=AssertionError("directory commit must not use replace semantics"),
+            ):
+                commit_new_directory(stage, destination)
+
+            self.assertFalse(stage.exists())
+            self.assertEqual((destination / "marker.txt").read_text(encoding="utf-8"), "ok")
+
+    def test_directory_rename_failure_is_wrapped_as_domain_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stage = root / ".project.jl-stage-test"
+            destination = root / "Project"
+            stage.mkdir()
+
+            with patch(
+                "jl_mixing.transactions.os.rename",
+                side_effect=OSError(5, "Access is denied"),
+            ):
+                with self.assertRaises(JLMixingError) as context:
+                    commit_new_directory(stage, destination)
+
+            self.assertIn("Could not commit staged directory", str(context.exception))
+            self.assertTrue(stage.is_dir())
+            self.assertFalse(destination.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- commit new staged project directories with rename semantics instead of replacement semantics, matching the invariant that the destination must not exist
- wrap directory-commit filesystem failures as JL Mixing domain errors
- ensure raw project.create filesystem failures still return a structured Automation API error envelope
- add regression coverage for staged-directory commit behavior and filesystem error responses

## Context
Windows RC2 acceptance exposed a failed project create on a network workspace. Automation left a `.jl-stage-*` directory and Studio received no valid API response. This is an RC3 release-blocking fix.

`VERSION` remains unchanged; the RC3 version bump will be performed separately using the release checklist after acceptance fixes are complete.