### PR TITLE
Fix Windows SMB staging ACLs for create operations

### DIFF
--- a/src/jl_mixing/client.py
+++ b/src/jl_mixing/client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import shutil
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -13,7 +12,7 @@ from .errors import ContextError, UnsafeOperationError, ValidationError
 from .metadata import create_v11
 from .naming import sanitize_folder_name, title_from_slug
 from .paths import assert_no_case_insensitive_child_collision, assert_no_symlink_components
-from .transactions import commit_new_directory
+from .transactions import commit_new_directory, create_staging_directory
 from .validation import (
     require_bit_depth,
     require_deliverables,
@@ -141,7 +140,7 @@ def create_client(request: ClientCreateRequest) -> ClientCreateResult:
     if request.dry_run:
         return ClientCreateResult(destination, document, effective_cd, False)
 
-    stage = Path(tempfile.mkdtemp(prefix=f".{folder_name}.jl-stage-", dir=clients_root))
+    stage = create_staging_directory(clients_root, f".{folder_name}.jl-stage-")
     try:
         (stage / "Projects").mkdir()
         (stage / "client.json").write_text(

--- a/src/jl_mixing/project.py
+++ b/src/jl_mixing/project.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import shutil
-import tempfile
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass
@@ -20,7 +19,7 @@ from .metadata import create_v11, now_iso8601, validate_v11
 from .naming import sanitize_folder_name, slugify
 from .paths import assert_no_case_insensitive_child_collision, assert_no_symlink_components
 from .source_import import SourcePlan, build_plan, copy_from_plan
-from .transactions import commit_new_directory
+from .transactions import commit_new_directory, create_staging_directory
 from .validation import require_bit_depth, require_deliverables, require_file_format, require_sample_rate, require_slug
 from .versions import application_root
 
@@ -280,7 +279,7 @@ def create_project(request: ProjectCreateRequest) -> ProjectCreateResult:
         return ProjectCreateResult(project_root, manifest, snapshot, initial_revision_root, values["client_root"], values["studio_root"], values["effective_cd"], values["source_plan"], False)
 
     projects_root = values["client_root"] / "Projects"
-    stage = Path(tempfile.mkdtemp(prefix=f".{project_root.name}.jl-stage-", dir=projects_root))
+    stage = create_staging_directory(projects_root, f".{project_root.name}.jl-stage-")
     try:
         for relative in (
             "00_Admin",

--- a/src/jl_mixing/transactions.py
+++ b/src/jl_mixing/transactions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import uuid
 from pathlib import Path
 
 from .errors import JLMixingError
@@ -18,6 +19,32 @@ def _fail_requested(point: str) -> bool:
 
 def _injected_failure(point: str) -> JLMixingError:
     return JLMixingError(f"Injected transaction failure at: {point}")
+
+
+def create_staging_directory(parent: Path, prefix: str) -> Path:
+    """Create a unique sibling staging directory using normal ACL inheritance.
+
+    ``tempfile.mkdtemp`` intentionally creates directories with private 0700
+    permissions. On SMB/NAS shares that can translate into a server ACL that
+    prevents the Windows client from creating children or deleting the stage.
+    A normal mkdir keeps the parent's ordinary inheritance behavior while the
+    randomized hidden name still provides collision-safe transaction staging.
+    """
+
+    if parent.is_symlink() or not parent.is_dir():
+        raise JLMixingError(f"Staging parent is missing or unsafe: {parent}")
+
+    for _ in range(32):
+        candidate = parent / f"{prefix}{uuid.uuid4().hex[:12]}"
+        try:
+            candidate.mkdir()
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            raise JLMixingError(f"Could not create staging directory in {parent}: {exc}") from exc
+        return candidate
+
+    raise JLMixingError(f"Could not allocate a unique staging directory in {parent}")
 
 
 def commit_new_directory(staged_directory: Path, destination: Path) -> None:

--- a/tests/python/test_transactions.py
+++ b/tests/python/test_transactions.py
@@ -4,13 +4,35 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from jl_mixing.errors import JLMixingError
-from jl_mixing.transactions import commit_new_directory
+from jl_mixing.transactions import commit_new_directory, create_staging_directory
 
 
 class TransactionDirectoryCommitTests(unittest.TestCase):
+    def test_staging_directory_uses_normal_mkdir_permissions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            token = Mock(hex="1234567890abcdef")
+
+            with patch("jl_mixing.transactions.uuid.uuid4", return_value=token), patch.object(
+                Path, "mkdir"
+            ) as mkdir:
+                stage = create_staging_directory(root, ".project.jl-stage-")
+
+            self.assertEqual(stage, root / ".project.jl-stage-1234567890ab")
+            mkdir.assert_called_once_with()
+
+    def test_staging_directory_creation_failure_is_wrapped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(Path, "mkdir", side_effect=OSError(5, "Access is denied")):
+                with self.assertRaises(JLMixingError) as context:
+                    create_staging_directory(root, ".project.jl-stage-")
+
+            self.assertIn("Could not create staging directory", str(context.exception))
+
     def test_new_directory_commit_uses_rename_not_replace(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- replaces `tempfile.mkdtemp()` for directory transactions with a shared staging helper that uses ordinary directory creation so SMB/NAS ACLs inherit from the parent
- applies the fix to both New Project and New Client
- preserves hidden unique sibling staging and atomic rename commit semantics
- adds regression coverage proving staging uses normal `Path.mkdir()` permissions and wraps staging creation errors

## Context
Automation v2.1.0-rc.3 Windows acceptance on a Synology SMB workspace still failed New Project with `[WinError 5] Access is denied` on the `.jl-stage-*` directory. Python `tempfile.mkdtemp()` creates directories with private 0700 semantics; on SMB this can translate into a restrictive server ACL that prevents the same Windows client from populating or deleting the stage.

`VERSION` remains `2.1.0-rc.3`; this is an acceptance fix and will be included in the next Automation release candidate after verification.