### PR TITLE
Add explicit Studio context to client.create

### DIFF
--- a/src/jl_mixing/api/client_create.py
+++ b/src/jl_mixing/api/client_create.py
@@ -15,6 +15,7 @@ from ..versions import api_version
 @dataclass(frozen=True)
 class ClientApiRequest:
     client_id: str
+    studio: str | None = None
     client_name: str | None = None
     artist: str = ""
     sample_rate: int | None = None
@@ -43,7 +44,8 @@ def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "e
 
 def execute(request: ClientApiRequest) -> tuple[dict[str, Any], int]:
     try:
-        workspace = studio_root(Path.cwd())
+        context = Path(request.studio) if request.studio is not None else Path.cwd()
+        workspace = studio_root(context)
         result = create_client(ClientCreateRequest(
             studio_root=workspace,
             client_id=request.client_id,
@@ -99,6 +101,7 @@ def parse_args(args: list[str]) -> ClientApiRequest:
     if not args or args[0].startswith("-"):
         raise ArgumentError("client create requires CLIENT_ID and --json.")
     client_id = args[0]
+    studio: str | None = None
     client_name: str | None = None
     artist = ""
     sample_rate: int | None = None
@@ -115,12 +118,16 @@ def parse_args(args: list[str]) -> ClientApiRequest:
             json_seen += 1
         elif arg in {"--cd", "--no-cd"}:
             raise ArgumentError("client create JSON mode does not accept --cd or --no-cd.")
-        elif arg in {"--name", "--artist", "--sample-rate", "--bit-depth", "--file-format", "--delivery-method", "--deliverables"}:
+        elif arg in {"--studio", "--name", "--artist", "--sample-rate", "--bit-depth", "--file-format", "--delivery-method", "--deliverables"}:
             index += 1
             if index >= len(args):
                 raise ArgumentError(f"{arg} requires a value.")
             value = args[index]
-            if arg == "--name":
+            if arg == "--studio":
+                if not value.strip():
+                    raise ArgumentError("--studio requires a non-empty path.")
+                studio = value
+            elif arg == "--name":
                 client_name = value
             elif arg == "--artist":
                 artist = value
@@ -151,6 +158,7 @@ def parse_args(args: list[str]) -> ClientApiRequest:
         raise ArgumentError("client create requires exactly one --json option.")
     return ClientApiRequest(
         client_id=client_id,
+        studio=studio,
         client_name=client_name,
         artist=artist,
         sample_rate=sample_rate,

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -10,6 +10,7 @@ _CAPABILITIES = [
     "audio.prep.reset.plan",
     "audio.prep.validation.structured",
     "client.create",
+    "client.create.explicit-context",
     "client.update",
     "client.files.import.execute",
     "client.files.import.plan",

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -10,7 +10,7 @@ _CAPABILITIES = [
     "audio.prep.reset.plan",
     "audio.prep.validation.structured",
     "client.create",
-    "client.create.explicit-context",
+    "client.create.context",
     "client.update",
     "client.files.import.execute",
     "client.files.import.plan",

--- a/tests/python/test_client_api.py
+++ b/tests/python/test_client_api.py
@@ -72,6 +72,33 @@ class ClientApiTests(unittest.TestCase):
                 ["client.json", "Projects"],
             )
 
+    def test_explicit_studio_context_does_not_depend_on_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as unrelated:
+            studio = write_studio(Path(tmp))
+            proc = run_cli(
+                Path(unrelated),
+                "client",
+                "create",
+                "explicit-client",
+                "--json",
+                "--studio",
+                str(studio),
+                "--dry-run",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stderr, "")
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(Path(payload["data"]["workspace_path"]), studio)
+            self.assertEqual(payload["data"]["client"]["id"], "explicit-client")
+
+    def test_system_info_advertises_explicit_client_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = run_cli(Path(tmp), "system-info", "--json")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertIn("client.create.explicit-context", payload["capabilities"])
+
     def test_success_commits_authoritative_client_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             studio = write_studio(Path(tmp))

--- a/tests/python/test_client_api.py
+++ b/tests/python/test_client_api.py
@@ -97,7 +97,7 @@ class ClientApiTests(unittest.TestCase):
             proc = run_cli(Path(tmp), "system-info", "--json")
             self.assertEqual(proc.returncode, 0, proc.stderr)
             payload = json.loads(proc.stdout)
-            self.assertIn("client.create.explicit-context", payload["capabilities"])
+            self.assertIn("client.create.context", payload["capabilities"])
 
     def test_success_commits_authoritative_client_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/python/test_client_api.py
+++ b/tests/python/test_client_api.py
@@ -89,7 +89,7 @@ class ClientApiTests(unittest.TestCase):
             self.assertEqual(proc.stderr, "")
             payload = json.loads(proc.stdout)
             self.assertEqual(payload["status"], "planned")
-            self.assertEqual(Path(payload["data"]["workspace_path"]), studio)
+            self.assertTrue(Path(payload["data"]["workspace_path"]).samefile(studio))
             self.assertEqual(payload["data"]["client"]["id"], "explicit-client")
 
     def test_system_info_advertises_explicit_client_context(self) -> None:

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -23,7 +23,7 @@ class SystemInfoTests(unittest.TestCase):
         self.assertEqual(info["metadata"], {"readable_schema_versions": ["1.1.0"], "writable_schema_version": "1.1.0"})
         self.assertEqual(info["capabilities"], [
             "audio.prep.provenance.sha256", "audio.prep.reset.execute", "audio.prep.reset.plan",
-            "audio.prep.validation.structured", "client.create", "client.update",
+            "audio.prep.validation.structured", "client.create", "client.create.context", "client.update",
             "client.files.import.execute", "client.files.import.plan", "delivery.create",
             "delivery.package.delete", "delivery.package.rebuild", "delivery.status", "intake.validate",
             "intake.validate.incremental", "intake.validate.report", "intake.validate.structured",

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -21,7 +21,7 @@ assert d['application']=={'name':'jl-mixing','version':app}
 assert d['metadata']=={'readable_schema_versions':['1.1.0'],'writable_schema_version':'1.1.0'}
 assert d['capabilities']==[
 'audio.prep.provenance.sha256','audio.prep.reset.execute','audio.prep.reset.plan','audio.prep.validation.structured',
-'client.create','client.update','client.files.import.execute','client.files.import.plan',
+'client.create','client.create.explicit-context','client.update','client.files.import.execute','client.files.import.plan',
 'delivery.create','delivery.package.delete','delivery.package.rebuild','delivery.status','intake.validate',
 'intake.validate.incremental','intake.validate.report','intake.validate.structured','project.create','project.create.artist',
 'project.update','revision.approve','revision.close','revision.create','revision.create.description','revision.reopen',

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -21,7 +21,7 @@ assert d['application']=={'name':'jl-mixing','version':app}
 assert d['metadata']=={'readable_schema_versions':['1.1.0'],'writable_schema_version':'1.1.0'}
 assert d['capabilities']==[
 'audio.prep.provenance.sha256','audio.prep.reset.execute','audio.prep.reset.plan','audio.prep.validation.structured',
-'client.create','client.create.explicit-context','client.update','client.files.import.execute','client.files.import.plan',
+'client.create','client.create.context','client.update','client.files.import.execute','client.files.import.plan',
 'delivery.create','delivery.package.delete','delivery.package.rebuild','delivery.status','intake.validate',
 'intake.validate.incremental','intake.validate.report','intake.validate.structured','project.create','project.create.artist',
 'project.update','revision.approve','revision.close','revision.create','revision.create.description','revision.reopen',


### PR DESCRIPTION
## Summary
- adds additive `client.create --studio <path>` support so API callers do not need process cwd for Studio identity
- retains cwd fallback for backward-compatible CLI behavior
- advertises schema-compliant `client.create.context`
- adds regression coverage proving an unrelated cwd still succeeds with explicit Studio context

## Context
Windows cannot reliably set a UNC share as a subprocess working directory. Studio New Client therefore fell back to `C:\Windows` and Automation could not find `Studio/studio.json`. This makes context explicit at the API boundary.