### PR TITLE
Optimize intake validation and add progress events

### DIFF
--- a/src/jl_mixing/api/intake_validate.py
+++ b/src/jl_mixing/api/intake_validate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,8 @@ from ..versions import api_version
 _BEGIN = "<!-- BEGIN AUTOMATED SECTION -->"
 _END = "<!-- END AUTOMATED SECTION -->"
 _CACHE_NAME = "intake-validation-cache.json"
+_PROGRESS_PREFIX = "JL_PROGRESS "
+_PROGRESS_MODE = "stderr-json"
 
 
 @dataclass(frozen=True)
@@ -28,6 +31,7 @@ class IntakeRequest:
     expected_bit_depth: int | None = None
     duplicate_check: bool = True
     dry_run: bool = False
+    progress: str | None = None
 
 
 def _manifest(project: Path) -> dict[str, Any]:
@@ -61,6 +65,15 @@ def _error_envelope(code: str, message: str, exit_code: int, *, status: str = "e
     }
 
 
+def _emit_progress(event: dict[str, Any]) -> None:
+    payload = {"operation": "intake.validate", **event}
+    print(
+        _PROGRESS_PREFIX + json.dumps(payload, separators=(",", ":"), sort_keys=True),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def execute(request: IntakeRequest) -> tuple[dict[str, Any], int]:
     try:
         project = resolve_project(request.project, Path.cwd())
@@ -78,6 +91,7 @@ def execute(request: IntakeRequest) -> tuple[dict[str, Any], int]:
         source = (request.source or (project / "01_Client_Files" / "Original_Delivery")).resolve()
         report_path = project / "00_Admin" / "Intake_Report.md"
         cache_path = project / "00_Admin" / _CACHE_NAME
+        progress_callback = _emit_progress if request.progress == _PROGRESS_MODE else None
         result = validate_intake_incremental(
             source,
             expected_sample_rate=sample_rate,
@@ -86,7 +100,15 @@ def execute(request: IntakeRequest) -> tuple[dict[str, Any], int]:
             duplicate_check=request.duplicate_check,
             cache_path=cache_path,
             update_cache=not request.dry_run,
+            progress=progress_callback,
         )
+        if progress_callback is not None:
+            progress_callback({
+                "phase": "finalizing",
+                "completed": result.files_discovered,
+                "total": result.files_discovered,
+                "active": [],
+            })
         audio_prep = build_audio_prep_status(
             project,
             original_files=result.files,
@@ -160,6 +182,7 @@ def parse_args(args: list[str]) -> IntakeRequest:
     bit_depth: int | None = None
     duplicate_check = True
     dry_run = False
+    progress: str | None = None
     json_seen = 0
     index = 0
     while index < len(args):
@@ -192,7 +215,14 @@ def parse_args(args: list[str]) -> IntakeRequest:
         elif arg == "--dry-run":
             dry_run = True
         elif arg.startswith("--progress="):
-            raise ArgumentError("intake validate does not yet support JSON progress events.")
+            value = arg.split("=", 1)[1]
+            if value != _PROGRESS_MODE:
+                raise ArgumentError(
+                    f"Unsupported intake progress mode: {value}. Expected {_PROGRESS_MODE}."
+                )
+            if progress is not None:
+                raise ArgumentError("intake validate accepts at most one --progress option.")
+            progress = value
         else:
             raise ArgumentError(f"Unknown option: {arg}")
         index += 1
@@ -207,4 +237,5 @@ def parse_args(args: list[str]) -> IntakeRequest:
         expected_bit_depth=bit_depth,
         duplicate_check=duplicate_check,
         dry_run=dry_run,
+        progress=progress,
     )

--- a/src/jl_mixing/intake.py
+++ b/src/jl_mixing/intake.py
@@ -75,6 +75,7 @@ def ffmpeg_decode_check(path: Path, executable: str = "ffmpeg") -> str | None:
 
 
 def _channel_hash(path: Path, channel: int, executable: str) -> str | None:
+    """Legacy single-channel helper retained for direct callers/tests."""
     result = subprocess.run(
         [
             executable, "-v", "error", "-i", str(path), "-map", "0:a:0",
@@ -91,6 +92,7 @@ def _channel_hash(path: Path, channel: int, executable: str) -> str | None:
 
 
 def exact_dual_mono(path: Path, metadata: dict[str, Any] | None, executable: str) -> bool | None:
+    """Legacy exact comparison helper retained for direct callers/tests."""
     if not metadata or metadata.get("channels") != 2:
         return False
     left = _channel_hash(path, 0, executable)
@@ -98,6 +100,58 @@ def exact_dual_mono(path: Path, metadata: dict[str, Any] | None, executable: str
     if left is None or right is None:
         return None
     return left == right
+
+
+def _parse_stereo_framehash(output: str) -> bool | None:
+    streams: dict[int, list[str]] = {0: [], 1: []}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = [field.strip() for field in line.split(",")]
+        if len(fields) < 6:
+            continue
+        try:
+            stream_index = int(fields[0])
+        except ValueError:
+            continue
+        if stream_index in streams:
+            streams[stream_index].append(fields[-1])
+    left = streams[0]
+    right = streams[1]
+    if not left or not right or len(left) != len(right):
+        return None
+    return left == right
+
+
+def ffmpeg_decode_and_dual_mono(path: Path, executable: str = "ffmpeg") -> tuple[str | None, bool | None]:
+    """Decode stereo audio once while hashing both decoded channels frame-by-frame."""
+    result = subprocess.run(
+        [
+            executable,
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-filter_complex",
+            "[0:a:0]channelsplit=channel_layout=stereo[left][right]",
+            "-map",
+            "[left]",
+            "-map",
+            "[right]",
+            "-f",
+            "framehash",
+            "-hash",
+            "sha256",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return result.stderr.strip() or "ffmpeg could not decode the complete audio file", None
+    return None, _parse_stereo_framehash(result.stdout)
 
 
 def _format_technical(metadata: dict[str, Any] | None, inspection: str) -> str:
@@ -269,8 +323,10 @@ def validate_intake(
             findings: list[dict[str, Any]] = []
             decode_ok: bool | None = None
             dual_mono: bool | None = None
+            digest: str | None = None
 
             if is_audio:
+                digest = sha256_file(path)
                 if ffprobe_available:
                     metadata, probe_error = ffprobe_metadata(path, str(detected_ffprobe))
                     if probe_error:
@@ -288,20 +344,23 @@ def validate_intake(
                     ))
 
                 if ffmpeg_available:
-                    decode_error = ffmpeg_decode_check(path, str(detected_ffmpeg))
+                    if metadata and metadata.get("channels") == 2:
+                        decode_error, dual_mono = ffmpeg_decode_and_dual_mono(
+                            path, str(detected_ffmpeg)
+                        )
+                    else:
+                        decode_error = ffmpeg_decode_check(path, str(detected_ffmpeg))
                     decode_ok = decode_error is None
                     if decode_error:
                         findings.append(_finding(
                             "DECODE_INTEGRITY_FAILED", "critical",
                             f"Full-file decode integrity check failed: {decode_error}",
                         ))
-                    elif metadata and metadata.get("channels") == 2:
-                        dual_mono = exact_dual_mono(path, metadata, str(detected_ffmpeg))
-                        if dual_mono:
-                            findings.append(_finding(
-                                "EXACT_DUAL_MONO", "info",
-                                "Stereo left and right channels are exactly identical.",
-                            ))
+                    elif dual_mono:
+                        findings.append(_finding(
+                            "EXACT_DUAL_MONO", "info",
+                            "Stereo left and right channels are exactly identical.",
+                        ))
                 else:
                     findings.append(_finding(
                         "FFMPEG_UNAVAILABLE", "warning",
@@ -335,7 +394,7 @@ def validate_intake(
                 **cache_identity(path),
                 "relative_path": relative,
                 "is_audio": is_audio,
-                "sha256": None,
+                "sha256": digest,
                 "metadata": metadata,
                 "inspection": inspection,
                 "decode_ok": decode_ok,
@@ -365,31 +424,11 @@ def validate_intake(
         file_results.append(record)
 
     if duplicate_check:
-        candidate_groups: dict[tuple[int, str], list[dict[str, Any]]] = {}
-        for record in file_results:
-            if not record.get("is_audio"):
-                continue
-            size = record.get("size_bytes")
-            fingerprint = record.get("fingerprint")
-            if isinstance(size, int) and isinstance(fingerprint, str) and fingerprint:
-                candidate_groups.setdefault((size, fingerprint), []).append(record)
-        duplicate_candidates = [group for group in candidate_groups.values() if len(group) > 1]
-        hash_records = [record for group in duplicate_candidates for record in group if not record.get("sha256")]
-
-        def calculate_hash(record: dict[str, Any]) -> tuple[dict[str, Any], str]:
-            return record, sha256_file(source / Path(str(record["relative_path"])))
-
-        if hash_records:
-            with ThreadPoolExecutor(max_workers=_VALIDATION_WORKERS, thread_name_prefix="intake-hash") as executor:
-                for record, digest in executor.map(calculate_hash, hash_records):
-                    record["sha256"] = digest
-
         by_hash: dict[str, list[dict[str, Any]]] = {}
-        for group in duplicate_candidates:
-            for record in group:
-                digest = record.get("sha256")
-                if isinstance(digest, str) and digest:
-                    by_hash.setdefault(digest, []).append(record)
+        for record in file_results:
+            digest = record.get("sha256")
+            if record.get("is_audio") and isinstance(digest, str) and digest:
+                by_hash.setdefault(digest, []).append(record)
         for group in by_hash.values():
             if len(group) < 2:
                 continue

--- a/src/jl_mixing/intake.py
+++ b/src/jl_mixing/intake.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .errors import ValidationError
 from .intake_cache import cache_identity, load_cache, reusable_cache_record, sha256_file, write_cache
 
 AUDIO_EXTENSIONS = {".wav", ".wave", ".aif", ".aiff", ".flac", ".mp3", ".m4a"}
+_VALIDATION_WORKERS = 2
+ProgressCallback = Callable[[dict[str, Any]], None]
 
 
 @dataclass(frozen=True)
@@ -166,6 +170,18 @@ def _status_for(record: dict[str, Any]) -> str:
     return "valid"
 
 
+def _without_duplicate_findings(record: dict[str, Any]) -> dict[str, Any]:
+    cleaned = dict(record)
+    findings = cleaned.get("findings")
+    if isinstance(findings, list):
+        cleaned["findings"] = [
+            finding
+            for finding in findings
+            if not isinstance(finding, dict) or finding.get("code") != "EXACT_DUPLICATE"
+        ]
+    return cleaned
+
+
 def validate_intake(
     source: Path,
     *,
@@ -177,11 +193,14 @@ def validate_intake(
     ffmpeg_path: str | None = None,
     cache_path: Path | None = None,
     update_cache: bool = True,
+    progress: ProgressCallback | None = None,
 ) -> IntakeResult:
     source = source.resolve()
     if not source.is_dir() or source.is_symlink():
         raise ValidationError(f"Source directory not found or unsafe: {source}")
 
+    if progress is not None:
+        progress({"phase": "scanning", "completed": 0, "total": None, "active": []})
     files = sorted(
         (p for p in source.rglob("*") if p.is_file() and not p.is_symlink()),
         key=lambda p: str(p.relative_to(source)).lower(),
@@ -201,32 +220,57 @@ def validate_intake(
     unsupported_findings: list[str] = []
     unavailable_findings: list[str] = []
     inventory: list[tuple[Path, dict[str, Any] | None, str]] = []
-    file_results: list[dict[str, Any]] = []
+    results_by_path: dict[str, dict[str, Any]] = {}
     cache_reused = 0
     files_validated = 0
+    total_files = len(files)
+    completed_files = 0
+    active_files: set[str] = set()
+    progress_lock = threading.Lock()
+
+    def emit_progress(phase: str = "validating") -> None:
+        if progress is None:
+            return
+        progress({
+            "phase": phase,
+            "completed": completed_files,
+            "total": total_files,
+            "active": sorted(active_files, key=str.lower),
+        })
 
     if not files:
         critical_errors.append("No files were found in the intake source.")
+    emit_progress()
 
+    uncached: list[tuple[Path, str, bool]] = []
     for path in files:
         relative = str(path.relative_to(source)).replace("\\", "/")
         is_audio = path.suffix.lower() in AUDIO_EXTENSIONS
         reusable = reusable_cache_record(path, relative, prior_cache)
         if reusable is not None and reusable.get("is_audio") == is_audio:
-            record = dict(reusable)
+            record = _without_duplicate_findings(reusable)
             record["cache_state"] = "reused"
+            results_by_path[relative] = record
             cache_reused += 1
+            completed_files += 1
+            emit_progress()
         else:
-            files_validated += 1
+            uncached.append((path, relative, is_audio))
+
+    def validate_file(item: tuple[Path, str, bool]) -> tuple[str, dict[str, Any]]:
+        path, relative, is_audio = item
+        nonlocal completed_files
+        with progress_lock:
+            active_files.add(relative)
+            emit_progress()
+        try:
             metadata: dict[str, Any] | None = None
             inspection = "not-inspected"
             findings: list[dict[str, Any]] = []
             decode_ok: bool | None = None
             dual_mono: bool | None = None
-            digest: str | None = None
 
             if is_audio:
-                digest = sha256_file(path)
                 if ffprobe_available:
                     metadata, probe_error = ffprobe_metadata(path, str(detected_ffprobe))
                     if probe_error:
@@ -286,14 +330,12 @@ def validate_intake(
                         f"File format is {actual_format.upper()}; expected {expected_file_format.upper()}.",
                         expected=expected_file_format.upper(), actual=actual_format.upper(),
                     ))
-            else:
-                unsupported_findings.append(f"`{relative}`")
 
             record = {
                 **cache_identity(path),
                 "relative_path": relative,
                 "is_audio": is_audio,
-                "sha256": digest,
+                "sha256": None,
                 "metadata": metadata,
                 "inspection": inspection,
                 "decode_ok": decode_ok,
@@ -301,18 +343,53 @@ def validate_intake(
                 "findings": findings,
                 "cache_state": "validated",
             }
+            return relative, record
+        finally:
+            with progress_lock:
+                active_files.discard(relative)
+                completed_files += 1
+                emit_progress()
 
+    if uncached:
+        with ThreadPoolExecutor(max_workers=_VALIDATION_WORKERS, thread_name_prefix="intake") as executor:
+            for relative, record in executor.map(validate_file, uncached):
+                results_by_path[relative] = record
+        files_validated = len(uncached)
+
+    file_results: list[dict[str, Any]] = []
+    for path in files:
+        relative = str(path.relative_to(source)).replace("\\", "/")
+        record = results_by_path[relative]
         record["relative_path"] = relative
         record["status"] = _status_for(record)
-        next_cache[relative] = {key: value for key, value in record.items() if key not in {"cache_state", "status"}}
         file_results.append(record)
 
     if duplicate_check:
-        by_hash: dict[str, list[dict[str, Any]]] = {}
+        candidate_groups: dict[tuple[int, str], list[dict[str, Any]]] = {}
         for record in file_results:
-            digest = record.get("sha256")
-            if record.get("is_audio") and isinstance(digest, str) and digest:
-                by_hash.setdefault(digest, []).append(record)
+            if not record.get("is_audio"):
+                continue
+            size = record.get("size_bytes")
+            fingerprint = record.get("fingerprint")
+            if isinstance(size, int) and isinstance(fingerprint, str) and fingerprint:
+                candidate_groups.setdefault((size, fingerprint), []).append(record)
+        duplicate_candidates = [group for group in candidate_groups.values() if len(group) > 1]
+        hash_records = [record for group in duplicate_candidates for record in group if not record.get("sha256")]
+
+        def calculate_hash(record: dict[str, Any]) -> tuple[dict[str, Any], str]:
+            return record, sha256_file(source / Path(str(record["relative_path"])))
+
+        if hash_records:
+            with ThreadPoolExecutor(max_workers=_VALIDATION_WORKERS, thread_name_prefix="intake-hash") as executor:
+                for record, digest in executor.map(calculate_hash, hash_records):
+                    record["sha256"] = digest
+
+        by_hash: dict[str, list[dict[str, Any]]] = {}
+        for group in duplicate_candidates:
+            for record in group:
+                digest = record.get("sha256")
+                if isinstance(digest, str) and digest:
+                    by_hash.setdefault(digest, []).append(record)
         for group in by_hash.values():
             if len(group) < 2:
                 continue
@@ -330,10 +407,15 @@ def validate_intake(
 
     for record in file_results:
         relative = str(record["relative_path"])
+        next_cache[relative] = {
+            key: value for key, value in record.items() if key not in {"cache_state", "status"}
+        }
         metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else None
         inspection = str(record.get("inspection") or "not-inspected")
         path = source / Path(relative)
         inventory.append((path, metadata, inspection))
+        if not record.get("is_audio"):
+            unsupported_findings.append(f"`{relative}`")
         for finding in record.get("findings", []):
             severity = finding.get("severity")
             code = finding.get("code")
@@ -377,7 +459,6 @@ def validate_intake(
     ):
         lines.extend(["", f"## {title}", ""])
         lines.extend(_items(items))
-
     lines.extend(["", "## Source Inventory", "", "| File | Size (bytes) | Technical details | Status |", "|---|---:|---|---|"])
     status_by_path = {str(record["relative_path"]): str(record["status"]) for record in file_results}
     for path, metadata, inspection in inventory:
@@ -413,6 +494,7 @@ def validate_intake(
         except OSError as exc:
             raise ValidationError(f"Unable to update intake validation cache: {cache_path}") from exc
 
+    emit_progress("complete")
     return IntakeResult(
         report_markdown="\n".join(lines).rstrip() + "\n",
         files_discovered=len(files),

--- a/src/jl_mixing/intake_incremental.py
+++ b/src/jl_mixing/intake_incremental.py
@@ -15,7 +15,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from .intake import IntakeResult, validate_intake
+from .intake import IntakeResult, ProgressCallback, validate_intake
 
 
 def _normalized_format(value: str | None) -> str | None:
@@ -178,6 +178,7 @@ def validate_intake_incremental(
     ffmpeg_path: str | None = None,
     cache_path: Path | None = None,
     update_cache: bool = True,
+    progress: ProgressCallback | None = None,
 ) -> IntakeResult:
     resolved_ffprobe = _tool_value(ffprobe_path, "ffprobe")
     resolved_ffmpeg = _tool_value(ffmpeg_path, "ffmpeg")
@@ -212,6 +213,7 @@ def validate_intake_incremental(
         ffmpeg_path=resolved_ffmpeg or "",
         cache_path=active_cache,
         update_cache=update_cache,
+        progress=progress,
     )
     result = _preserve_human_report_compatibility(result, duplicate_check=duplicate_check)
 

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -20,6 +20,7 @@ _CAPABILITIES = [
     "delivery.status",
     "intake.validate",
     "intake.validate.incremental",
+    "intake.validate.progress",
     "intake.validate.report",
     "intake.validate.structured",
     "project.create",

--- a/tests/python/test_intake_performance.py
+++ b/tests/python/test_intake_performance.py
@@ -14,7 +14,7 @@ from jl_mixing.intake_incremental import validate_intake_incremental
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
 
-_METADATA = {
+_MONO_METADATA = {
     "sample_rate": 48000,
     "bit_depth": 24,
     "channels": 1,
@@ -22,6 +22,7 @@ _METADATA = {
     "codec_name": "pcm_s24le",
     "format_name": "wav",
 }
+_STEREO_METADATA = {**_MONO_METADATA, "channels": 2}
 
 
 def _write_project(root: Path) -> Path:
@@ -52,34 +53,14 @@ def _write_project(root: Path) -> Path:
 
 
 class IntakePerformanceTests(unittest.TestCase):
-    def test_unique_audio_avoids_full_content_hash(self) -> None:
+    def test_content_hash_is_retained_for_exact_provenance(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             source = Path(tmp) / "source"
             source.mkdir()
             (source / "One.wav").write_bytes(b"first unique audio payload")
             (source / "Two.wav").write_bytes(b"second different audio payload")
             with (
-                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_METADATA, None)),
-                patch("jl_mixing.intake.ffmpeg_decode_check", return_value=None),
-                patch("jl_mixing.intake.sha256_file", side_effect=AssertionError("unique file was fully hashed")),
-            ):
-                result = validate_intake_incremental(
-                    source,
-                    ffprobe_path="ffprobe",
-                    ffmpeg_path="ffmpeg",
-                )
-            self.assertEqual(result.files_validated, 2)
-            self.assertTrue(all(record["sha256"] is None for record in result.files))
-
-    def test_duplicate_candidates_still_receive_exact_hashes(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            source = Path(tmp) / "source"
-            source.mkdir()
-            payload = b"identical audio payload"
-            (source / "One.wav").write_bytes(payload)
-            (source / "Two.wav").write_bytes(payload)
-            with (
-                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_METADATA, None)),
+                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_MONO_METADATA, None)),
                 patch("jl_mixing.intake.ffmpeg_decode_check", return_value=None),
                 patch("jl_mixing.intake.sha256_file", side_effect=lambda path: path.read_bytes().hex()) as digest,
             ):
@@ -88,10 +69,30 @@ class IntakePerformanceTests(unittest.TestCase):
                     ffprobe_path="ffprobe",
                     ffmpeg_path="ffmpeg",
                 )
+            self.assertEqual(result.files_validated, 2)
             self.assertEqual(digest.call_count, 2)
-            for record in result.files:
-                self.assertIsInstance(record["sha256"], str)
-                self.assertTrue(any(finding["code"] == "EXACT_DUPLICATE" for finding in record["findings"]))
+            self.assertTrue(all(isinstance(record["sha256"], str) for record in result.files))
+
+    def test_stereo_file_uses_one_combined_ffmpeg_validation_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            source.mkdir()
+            (source / "Stereo.wav").write_bytes(b"stereo audio")
+            with (
+                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_STEREO_METADATA, None)),
+                patch("jl_mixing.intake.sha256_file", return_value="digest"),
+                patch("jl_mixing.intake.ffmpeg_decode_and_dual_mono", return_value=(None, False)) as combined,
+                patch("jl_mixing.intake.ffmpeg_decode_check", side_effect=AssertionError("separate decode ran")),
+                patch("jl_mixing.intake.exact_dual_mono", side_effect=AssertionError("legacy channel hashes ran")),
+            ):
+                result = validate_intake_incremental(
+                    source,
+                    ffprobe_path="ffprobe",
+                    ffmpeg_path="ffmpeg",
+                )
+            self.assertEqual(combined.call_count, 1)
+            self.assertTrue(result.files[0]["decode_ok"])
+            self.assertFalse(result.files[0]["dual_mono"])
 
     def test_progress_reports_inventory_completed_count_and_active_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -101,7 +102,7 @@ class IntakePerformanceTests(unittest.TestCase):
             (source / "Two.wav").write_bytes(b"two")
             events: list[dict[str, object]] = []
             with (
-                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_METADATA, None)),
+                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_MONO_METADATA, None)),
                 patch("jl_mixing.intake.ffmpeg_decode_check", return_value=None),
             ):
                 validate_intake_incremental(

--- a/tests/python/test_intake_performance.py
+++ b/tests/python/test_intake_performance.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing.intake_incremental import validate_intake_incremental
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+
+_METADATA = {
+    "sample_rate": 48000,
+    "bit_depth": 24,
+    "channels": 1,
+    "duration": 1.0,
+    "codec_name": "pcm_s24le",
+    "format_name": "wav",
+}
+
+
+def _write_project(root: Path) -> Path:
+    project = root / "Clients" / "Progress Client" / "Projects" / "Progress Project"
+    admin = project / "00_Admin"
+    source = project / "01_Client_Files" / "Original_Delivery"
+    admin.mkdir(parents=True)
+    source.mkdir(parents=True)
+    manifest = {
+        "metadata": {
+            "schema": "mixing-project",
+            "schema_version": "1.1.0",
+            "document_id": "11111111-1111-1111-1111-111111111111",
+            "created_with": "jl-mixing test",
+            "created_at": "2030-01-01T12:00:00Z",
+            "last_modified_at": "2030-01-01T12:00:00Z",
+        },
+        "project_id": "progress-project",
+        "project_name": "Progress Project",
+        "audio": {"sample_rate": 48000, "bit_depth": 24, "file_format": "WAV"},
+    }
+    (admin / "project-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (admin / "Intake_Report.md").write_text(
+        "# Intake Report\n\n<!-- BEGIN AUTOMATED SECTION -->\nold\n<!-- END AUTOMATED SECTION -->\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+class IntakePerformanceTests(unittest.TestCase):
+    def test_unique_audio_avoids_full_content_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            source.mkdir()
+            (source / "One.wav").write_bytes(b"first unique audio payload")
+            (source / "Two.wav").write_bytes(b"second different audio payload")
+            with (
+                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_METADATA, None)),
+                patch("jl_mixing.intake.ffmpeg_decode_check", return_value=None),
+                patch("jl_mixing.intake.sha256_file", side_effect=AssertionError("unique file was fully hashed")),
+            ):
+                result = validate_intake_incremental(
+                    source,
+                    ffprobe_path="ffprobe",
+                    ffmpeg_path="ffmpeg",
+                )
+            self.assertEqual(result.files_validated, 2)
+            self.assertTrue(all(record["sha256"] is None for record in result.files))
+
+    def test_duplicate_candidates_still_receive_exact_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            source.mkdir()
+            payload = b"identical audio payload"
+            (source / "One.wav").write_bytes(payload)
+            (source / "Two.wav").write_bytes(payload)
+            with (
+                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_METADATA, None)),
+                patch("jl_mixing.intake.ffmpeg_decode_check", return_value=None),
+                patch("jl_mixing.intake.sha256_file", side_effect=lambda path: path.read_bytes().hex()) as digest,
+            ):
+                result = validate_intake_incremental(
+                    source,
+                    ffprobe_path="ffprobe",
+                    ffmpeg_path="ffmpeg",
+                )
+            self.assertEqual(digest.call_count, 2)
+            for record in result.files:
+                self.assertIsInstance(record["sha256"], str)
+                self.assertTrue(any(finding["code"] == "EXACT_DUPLICATE" for finding in record["findings"]))
+
+    def test_progress_reports_inventory_completed_count_and_active_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            source.mkdir()
+            (source / "One.wav").write_bytes(b"one")
+            (source / "Two.wav").write_bytes(b"two")
+            events: list[dict[str, object]] = []
+            with (
+                patch("jl_mixing.intake.ffprobe_metadata", return_value=(_METADATA, None)),
+                patch("jl_mixing.intake.ffmpeg_decode_check", return_value=None),
+            ):
+                validate_intake_incremental(
+                    source,
+                    ffprobe_path="ffprobe",
+                    ffmpeg_path="ffmpeg",
+                    progress=events.append,
+                )
+            self.assertEqual(events[0]["phase"], "scanning")
+            determinate = [event for event in events if event.get("total") == 2]
+            self.assertTrue(determinate)
+            self.assertEqual(determinate[-1]["completed"], 2)
+            self.assertLessEqual(max(len(event["active"]) for event in determinate), 2)
+            active_names = {name for event in determinate for name in event["active"]}
+            self.assertEqual(active_names, {"One.wav", "Two.wav"})
+
+    def test_cli_progress_is_opt_in_on_stderr_and_stdout_stays_single_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = _write_project(Path(tmp))
+            source = project / "01_Client_Files" / "Original_Delivery"
+            (source / "Notes.txt").write_text("notes\n", encoding="utf-8")
+            env = os.environ.copy()
+            env["PYTHONPATH"] = str(SRC)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "jl_mixing.cli",
+                    "intake",
+                    "validate",
+                    "--json",
+                    "--project",
+                    str(project),
+                    "--progress=stderr-json",
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["operation"], "intake.validate")
+            progress_lines = [line for line in proc.stderr.splitlines() if line.startswith("JL_PROGRESS ")]
+            self.assertGreaterEqual(len(progress_lines), 3)
+            events = [json.loads(line.removeprefix("JL_PROGRESS ")) for line in progress_lines]
+            self.assertTrue(all(event["operation"] == "intake.validate" for event in events))
+            self.assertEqual(events[0]["phase"], "scanning")
+            self.assertEqual(events[-1]["phase"], "finalizing")
+            self.assertEqual(events[-1]["completed"], 1)
+            self.assertEqual(events[-1]["total"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -26,10 +26,10 @@ class SystemInfoTests(unittest.TestCase):
             "audio.prep.validation.structured", "client.create", "client.create.context", "client.update",
             "client.files.import.execute", "client.files.import.plan", "delivery.create",
             "delivery.package.delete", "delivery.package.rebuild", "delivery.status", "intake.validate",
-            "intake.validate.incremental", "intake.validate.report", "intake.validate.structured",
-            "project.create", "project.create.artist", "project.update", "revision.approve", "revision.close",
-            "revision.create", "revision.create.description", "revision.reopen", "revision.unapprove",
-            "revision.update.description", "studio.update", "system.info",
+            "intake.validate.incremental", "intake.validate.progress", "intake.validate.report",
+            "intake.validate.structured", "project.create", "project.create.artist", "project.update",
+            "revision.approve", "revision.close", "revision.create", "revision.create.description",
+            "revision.reopen", "revision.unapprove", "revision.update.description", "studio.update", "system.info",
         ])
         self.assertEqual(Path(info["schemas"]["installed_path"]), (ROOT / "api" / "schemas" / "v1.0").resolve())
 

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -23,9 +23,9 @@ assert d['capabilities']==[
 'audio.prep.provenance.sha256','audio.prep.reset.execute','audio.prep.reset.plan','audio.prep.validation.structured',
 'client.create','client.create.context','client.update','client.files.import.execute','client.files.import.plan',
 'delivery.create','delivery.package.delete','delivery.package.rebuild','delivery.status','intake.validate',
-'intake.validate.incremental','intake.validate.report','intake.validate.structured','project.create','project.create.artist',
-'project.update','revision.approve','revision.close','revision.create','revision.create.description','revision.reopen',
-'revision.unapprove','revision.update.description','studio.update','system.info']
+'intake.validate.incremental','intake.validate.progress','intake.validate.report','intake.validate.structured',
+'project.create','project.create.artist','project.update','revision.approve','revision.close','revision.create',
+'revision.create.description','revision.reopen','revision.unapprove','revision.update.description','studio.update','system.info']
 assert Path(d['schemas']['installed_path']).resolve()==(root/'api'/'schemas'/f'v{av}').resolve()
 assert d['schemas']['public_base_url']==f'https://jlaudio.github.io/jl-mixing/api/v{av}/schemas/'
 PY_ASSERT


### PR DESCRIPTION
## Summary
- validate up to two intake files concurrently while preserving deterministic report order
- collapse stereo decode integrity + exact dual-mono detection from three ffmpeg passes to one framehash decode pass
- retain raw SHA-256 for exact-content Audio Prep provenance and exact duplicate semantics
- add opt-in `--progress=stderr-json` structured progress events without changing the final stdout API JSON
- advertise additive `intake.validate.progress` capability
- clear cached exact-duplicate findings before recomputing current duplicate state

## Progress contract
When requested, stderr emits newline-delimited records prefixed with `JL_PROGRESS ` containing `operation`, `phase`, `completed`, `total`, and `active`. The final API response remains a single JSON document on stdout.

## NAS rationale
The previous stereo path performed a full SHA-256 read, ffprobe, a full ffmpeg decode, then two additional full ffmpeg channel-hash decodes serially. The new path keeps exact provenance/hash semantics but reduces stereo ffmpeg work to one decode and processes two files at a time to avoid overwhelming network storage.