### PR TITLE
Make managed import progress monotonic through completion

### DIFF
--- a/src/jl_mixing/api/managed_client_files.py
+++ b/src/jl_mixing/api/managed_client_files.py
@@ -56,6 +56,67 @@ def _emit_progress(operation: str, event: dict[str, Any]) -> None:
     )
 
 
+class _ImportProgressAdapter:
+    """Translate phase-local engine progress into an additive monotonic import contract."""
+
+    def __init__(self, operation: str, total_files: int):
+        self.operation = operation
+        self.total_files = total_files
+        self.overall_total = total_files * 2 + 1
+        self.staging_seen = 0
+        self.staging_complete_emitted = False
+        self.finalizing_emitted = False
+
+    def _emit(self, phase: str, completed: int, active: list[str], overall_completed: int) -> None:
+        _emit_progress(
+            self.operation,
+            {
+                "phase": phase,
+                "completed": completed,
+                "total": self.total_files,
+                "overall_completed": overall_completed,
+                "overall_total": self.overall_total,
+                "active": active,
+            },
+        )
+
+    def _finish_staging(self) -> None:
+        if not self.staging_complete_emitted:
+            self._emit("staging", self.total_files, [], self.total_files)
+            self.staging_complete_emitted = True
+
+    def __call__(self, event: dict[str, Any]) -> None:
+        phase = str(event.get("phase", ""))
+        active = [str(value) for value in event.get("active", [])]
+        completed = max(0, min(int(event.get("completed", 0)), self.total_files))
+
+        if phase == "staging":
+            stage_completed = min(self.staging_seen, self.total_files)
+            self._emit("staging", stage_completed, active, stage_completed)
+            self.staging_seen += 1
+            return
+
+        if phase == "importing":
+            self._finish_staging()
+            self._emit("importing", completed, active, self.total_files + completed)
+            return
+
+        if phase == "complete":
+            self._finish_staging()
+            self._emit("finalizing", self.total_files, [], self.total_files * 2)
+            self.finalizing_emitted = True
+            return
+
+        _emit_progress(self.operation, event)
+
+    def finish(self) -> None:
+        self._finish_staging()
+        if not self.finalizing_emitted:
+            self._emit("finalizing", self.total_files, [], self.total_files * 2)
+            self.finalizing_emitted = True
+        self._emit("complete", self.total_files, [], self.overall_total)
+
+
 def _selected_import_plan(plan: dict[str, Any], selected_relative_paths: tuple[str, ...] | None) -> dict[str, Any]:
     if selected_relative_paths is None:
         return plan
@@ -94,12 +155,27 @@ def execute_import(request: ImportRequest) -> tuple[dict[str, Any], int]:
         if not request.plan_id:
             raise ValidationError("Import execute requires --plan-id.")
         root = resolve_project(request.project, Path.cwd())
+        progress_enabled = request.progress == _PROGRESS_MODE
+        if progress_enabled:
+            _emit_progress(
+                operation,
+                {
+                    "phase": "planning",
+                    "completed": 0,
+                    "total": None,
+                    "overall_completed": 0,
+                    "overall_total": None,
+                    "active": [],
+                },
+            )
         full_plan = plan_import(root, request.source_kind, request.sources)
         if full_plan["plan_id"] != request.plan_id:
             raise ValidationError("Import plan is stale; run import-plan again.")
         plan = _selected_import_plan(full_plan, request.selected_relative_paths)
-        progress_callback = (lambda event: _emit_progress(operation, event)) if request.progress == _PROGRESS_MODE else None
-        result = execute_plan(root, plan, request.decisions or {}, progress=progress_callback)
+        progress_adapter = _ImportProgressAdapter(operation, len(plan["files"])) if progress_enabled else None
+        result = execute_plan(root, plan, request.decisions or {}, progress=progress_adapter)
+        if progress_adapter is not None:
+            progress_adapter.finish()
         return _envelope(operation, "success", {"project": _project_data(root), "plan_id": full_plan["plan_id"], "result": result}), 0
     except ContextError as exc: return _error(operation, "PROJECT_NOT_FOUND", str(exc), exc.exit_code), exc.exit_code
     except UnsafeOperationError as exc: return _error(operation, "UNSAFE_OPERATION", str(exc), exc.exit_code, status="blocked"), exc.exit_code

--- a/tests/python/test_managed_import_progress_contract.py
+++ b/tests/python/test_managed_import_progress_contract.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))
+
+from jl_mixing.api import managed_client_files as api
+
+
+def progress_events(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line.removeprefix("JL_PROGRESS "))
+        for line in stderr.splitlines()
+        if line.startswith("JL_PROGRESS ")
+    ]
+
+
+class ManagedImportProgressContractTests(unittest.TestCase):
+    def test_adapter_emits_monotonic_overall_progress_until_complete(self) -> None:
+        output = io.StringIO()
+        adapter = api._ImportProgressAdapter("client.files.import.execute", 2)
+
+        with redirect_stderr(output):
+            adapter({"phase": "staging", "completed": 0, "total": 2, "active": ["one.wav"]})
+            adapter({"phase": "staging", "completed": 0, "total": 2, "active": ["two.wav"]})
+            adapter({"phase": "importing", "completed": 0, "total": 2, "active": []})
+            adapter({"phase": "importing", "completed": 1, "total": 2, "active": ["one.wav"]})
+            adapter({"phase": "importing", "completed": 2, "total": 2, "active": []})
+            adapter({"phase": "complete", "completed": 2, "total": 2, "active": []})
+            adapter.finish()
+
+        events = progress_events(output.getvalue())
+        phases = [event["phase"] for event in events]
+        self.assertEqual(phases[-2:], ["finalizing", "complete"])
+        self.assertIn("staging", phases)
+        self.assertIn("importing", phases)
+        overall = [int(event["overall_completed"]) for event in events]
+        self.assertEqual(overall, sorted(overall))
+        self.assertTrue(all(event["overall_total"] == 5 for event in events))
+        self.assertTrue(all(value < 5 for value in overall[:-1]))
+        self.assertEqual(overall[-1], 5)
+        self.assertEqual(events[-1]["completed"], 2)
+        self.assertEqual(events[-1]["total"], 2)
+
+    def test_execute_import_emits_planning_before_replanning_and_complete_last(self) -> None:
+        request = api.ImportRequest(
+            project=Path("/project"),
+            source_kind="files",
+            sources=(Path("/source/one.wav"),),
+            plan_id="plan-id",
+            progress="stderr-json",
+        )
+        plan = {
+            "plan_id": "plan-id",
+            "files": [{"relative_path": "one.wav"}],
+            "items": [],
+        }
+        output = io.StringIO()
+
+        def fake_plan_import(*_args):
+            events = progress_events(output.getvalue())
+            self.assertEqual(events[0]["phase"], "planning")
+            self.assertIsNone(events[0]["total"])
+            self.assertIsNone(events[0]["overall_total"])
+            return plan
+
+        def fake_execute_plan(_root, _plan, _decisions, *, progress=None):
+            assert progress is not None
+            progress({"phase": "staging", "completed": 0, "total": 1, "active": ["one.wav"]})
+            progress({"phase": "importing", "completed": 1, "total": 1, "active": []})
+            progress({"phase": "complete", "completed": 1, "total": 1, "active": []})
+            return {"items": []}
+
+        with (
+            patch.object(api, "resolve_project", return_value=Path("/project")),
+            patch.object(api, "plan_import", side_effect=fake_plan_import),
+            patch.object(api, "execute_plan", side_effect=fake_execute_plan),
+            patch.object(api, "_project_data", return_value={"path": "/project", "workspace_path": "/workspace"}),
+            redirect_stderr(output),
+        ):
+            payload, status = api.execute_import(request)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(payload["status"], "success")
+        events = progress_events(output.getvalue())
+        self.assertEqual(events[0]["phase"], "planning")
+        self.assertEqual(events[-2]["phase"], "finalizing")
+        self.assertEqual(events[-1]["phase"], "complete")
+        self.assertEqual(events[-1]["overall_completed"], events[-1]["overall_total"])
+
+    def test_failed_import_never_emits_complete(self) -> None:
+        request = api.ImportRequest(
+            project=Path("/project"),
+            source_kind="files",
+            sources=(Path("/source/one.wav"),),
+            plan_id="plan-id",
+            progress="stderr-json",
+        )
+        plan = {"plan_id": "plan-id", "files": [{"relative_path": "one.wav"}], "items": []}
+        output = io.StringIO()
+
+        with (
+            patch.object(api, "resolve_project", return_value=Path("/project")),
+            patch.object(api, "plan_import", return_value=plan),
+            patch.object(api, "execute_plan", side_effect=api.ValidationError("failed")),
+            redirect_stderr(output),
+        ):
+            payload, status = api.execute_import(request)
+
+        self.assertNotEqual(status, 0)
+        self.assertEqual(payload["status"], "blocked")
+        self.assertNotIn("complete", [event["phase"] for event in progress_events(output.getvalue())])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #166.

## Summary
- emits immediate `planning` progress before the execute-time plan refresh
- translates phase-local import engine events into a monotonic overall lifecycle
- preserves existing `completed`, `total`, and `active` fields
- adds additive `overall_completed` / `overall_total` progress fields
- emits `finalizing` instead of prematurely reporting complete while provenance work is still running
- emits `complete` only after the full import operation returns successfully
- preserves final stdout JSON API unchanged
- adds focused contract tests, including no false complete on failure

Coordinates with Studio #312 / #302.