### PR TITLE
Add permanent structured diagnostic logging

### DIFF
--- a/docs/DIAGNOSTIC_LOGGING.md
+++ b/docs/DIAGNOSTIC_LOGGING.md
@@ -1,0 +1,21 @@
+# Diagnostic Logging
+
+JL Mixing Automation writes structured JSON Lines diagnostics to a per-user log file. Logging is best-effort and never changes stdout/stderr API or progress contracts.
+
+## Default locations
+
+- macOS: `~/Library/Logs/JL Mixing/automation.jsonl`
+- Windows: `%LOCALAPPDATA%\JL Mixing\logs\automation.jsonl`
+- Linux: `$XDG_STATE_HOME/jl-mixing/logs/automation.jsonl` or `~/.local/state/jl-mixing/logs/automation.jsonl`
+
+Set `JL_MIXING_LOG_DIR` to override the directory. Set `JL_MIXING_LOG_LEVEL=debug` for detailed progress events; the default level is `info`.
+
+## Retention
+
+The active file rotates at 5 MB. One rotated backup is retained as `automation.jsonl.1`, bounding normal disk use to roughly 10 MB.
+
+## Privacy and support
+
+Logs contain operation names, timing/count information, status/error diagnostics, and at debug level progress event metadata such as active file names. They do not intentionally log file contents, metadata-document contents, credentials, secrets, or secret command-line values. Known sensitive field names are redacted by the logger.
+
+When troubleshooting, reproduce the issue once with `JL_MIXING_LOG_LEVEL=debug`, then collect `automation.jsonl` and, when present, `automation.jsonl.1`.

--- a/src/jl_mixing/api/managed_client_files.py
+++ b/src/jl_mixing/api/managed_client_files.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from ..context import resolve_project, studio_root
+from ..diagnostic_log import debug as log_debug
+from ..diagnostic_log import error as log_error
+from ..diagnostic_log import info as log_info
 from ..errors import ArgumentError, ContextError, JLMixingError, UnsafeOperationError, ValidationError
 from ..managed_client_file_provenance import execute_plan, plan_import, plan_reset
 from ..versions import api_version
@@ -41,6 +45,7 @@ def _envelope(operation: str, status: str, data: dict[str, Any], *, errors: list
 
 
 def _error(operation: str, code: str, message: str, exit_code: int, *, status: str = "error") -> dict[str, Any]:
+    log_error("operation_error", operation=operation, code=code, exit_code=exit_code, message=message)
     return _envelope(operation, status, {}, errors=[{"code": code, "message": message, "details": {"exit_code": exit_code}, "retryable": False}])
 
 
@@ -49,6 +54,7 @@ def _project_data(root: Path) -> dict[str, str]:
 
 
 def _emit_progress(operation: str, event: dict[str, Any]) -> None:
+    log_debug("progress_emit", operation=operation, **event)
     print(
         _PROGRESS_PREFIX + json.dumps({"operation": operation, **event}, separators=(",", ":"), sort_keys=True),
         file=sys.stderr,
@@ -136,9 +142,12 @@ def _selected_import_plan(plan: dict[str, Any], selected_relative_paths: tuple[s
 
 def execute_import_plan(request: ImportRequest) -> tuple[dict[str, Any], int]:
     operation = "client.files.import.plan"
+    started = time.monotonic()
+    log_info("operation_start", operation=operation, source_kind=request.source_kind, source_count=len(request.sources))
     try:
         root = resolve_project(request.project, Path.cwd())
         plan = plan_import(root, request.source_kind, request.sources)
+        log_info("operation_complete", operation=operation, duration_ms=int((time.monotonic() - started) * 1000), file_count=len(plan.get("files", [])))
         return _envelope(operation, "planned", {"project": _project_data(root), "plan": plan}), 0
     except ContextError as exc: return _error(operation, "PROJECT_NOT_FOUND", str(exc), exc.exit_code), exc.exit_code
     except UnsafeOperationError as exc: return _error(operation, "UNSAFE_OPERATION", str(exc), exc.exit_code, status="blocked"), exc.exit_code
@@ -151,11 +160,21 @@ def execute_import_plan(request: ImportRequest) -> tuple[dict[str, Any], int]:
 
 def execute_import(request: ImportRequest) -> tuple[dict[str, Any], int]:
     operation = "client.files.import.execute"
+    started = time.monotonic()
+    log_info(
+        "operation_start",
+        operation=operation,
+        source_kind=request.source_kind,
+        source_count=len(request.sources),
+        selected_count=len(request.selected_relative_paths or ()),
+        progress_mode=request.progress,
+    )
     try:
         if not request.plan_id:
             raise ValidationError("Import execute requires --plan-id.")
         root = resolve_project(request.project, Path.cwd())
         progress_enabled = request.progress == _PROGRESS_MODE
+        log_info("progress_mode", operation=operation, streaming=progress_enabled)
         if progress_enabled:
             _emit_progress(
                 operation,
@@ -168,7 +187,14 @@ def execute_import(request: ImportRequest) -> tuple[dict[str, Any], int]:
                     "active": [],
                 },
             )
+        plan_started = time.monotonic()
         full_plan = plan_import(root, request.source_kind, request.sources)
+        log_info(
+            "import_replan_complete",
+            operation=operation,
+            duration_ms=int((time.monotonic() - plan_started) * 1000),
+            file_count=len(full_plan.get("files", [])),
+        )
         if full_plan["plan_id"] != request.plan_id:
             raise ValidationError("Import plan is stale; run import-plan again.")
         plan = _selected_import_plan(full_plan, request.selected_relative_paths)
@@ -176,6 +202,12 @@ def execute_import(request: ImportRequest) -> tuple[dict[str, Any], int]:
         result = execute_plan(root, plan, request.decisions or {}, progress=progress_adapter)
         if progress_adapter is not None:
             progress_adapter.finish()
+        log_info(
+            "operation_complete",
+            operation=operation,
+            duration_ms=int((time.monotonic() - started) * 1000),
+            selected_count=len(plan.get("files", [])),
+        )
         return _envelope(operation, "success", {"project": _project_data(root), "plan_id": full_plan["plan_id"], "result": result}), 0
     except ContextError as exc: return _error(operation, "PROJECT_NOT_FOUND", str(exc), exc.exit_code), exc.exit_code
     except UnsafeOperationError as exc: return _error(operation, "UNSAFE_OPERATION", str(exc), exc.exit_code, status="blocked"), exc.exit_code

--- a/src/jl_mixing/diagnostic_log.py
+++ b/src/jl_mixing/diagnostic_log.py
@@ -1,0 +1,93 @@
+"""Permanent file-based structured diagnostics for JL Mixing Automation.
+
+Diagnostics are best-effort and never write to stdout/stderr so Automation API and
+progress contracts remain unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_MAX_BYTES = 5 * 1024 * 1024
+_LEVELS = {"debug": 10, "info": 20, "warning": 30, "error": 40}
+_REDACTED = "<redacted>"
+_SENSITIVE_KEY_PARTS = ("password", "passwd", "token", "secret", "credential", "authorization", "api_key", "apikey")
+
+
+def _configured_level() -> int:
+    return _LEVELS.get(os.environ.get("JL_MIXING_LOG_LEVEL", "info").strip().lower(), 20)
+
+
+def log_path() -> Path:
+    override = os.environ.get("JL_MIXING_LOG_DIR")
+    if override:
+        root = Path(override).expanduser()
+    elif os.name == "nt" and os.environ.get("LOCALAPPDATA"):
+        root = Path(os.environ["LOCALAPPDATA"]) / "JL Mixing" / "logs"
+    elif sys.platform == "darwin":
+        root = Path.home() / "Library" / "Logs" / "JL Mixing"
+    else:
+        state = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+        root = state / "jl-mixing" / "logs"
+    return root / "automation.jsonl"
+
+
+def _rotate(path: Path) -> None:
+    try:
+        if path.exists() and path.stat().st_size >= _MAX_BYTES:
+            rotated = path.with_suffix(path.suffix + ".1")
+            if rotated.exists():
+                rotated.unlink()
+            path.replace(rotated)
+    except OSError:
+        pass
+
+
+def _safe_value(key: str, value: Any) -> Any:
+    normalized = key.casefold()
+    if any(part in normalized for part in _SENSITIVE_KEY_PARTS):
+        return _REDACTED
+    return value
+
+
+def log(level: str, event: str, **fields: Any) -> None:
+    normalized = level.lower()
+    if _LEVELS.get(normalized, 20) < _configured_level():
+        return
+    try:
+        path = log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _rotate(path)
+        record = {
+            "ts_unix_ms": int(time.time() * 1000),
+            "level": normalized,
+            "component": "automation",
+            "event": event,
+            **{key: _safe_value(key, value) for key, value in fields.items()},
+        }
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":"), sort_keys=True, default=str) + "\n")
+    except (OSError, TypeError, ValueError):
+        # Diagnostics must never break an Automation operation.
+        pass
+
+
+def debug(event: str, **fields: Any) -> None:
+    log("debug", event, **fields)
+
+
+def info(event: str, **fields: Any) -> None:
+    log("info", event, **fields)
+
+
+def warning(event: str, **fields: Any) -> None:
+    log("warning", event, **fields)
+
+
+def error(event: str, **fields: Any) -> None:
+    log("error", event, **fields)

--- a/tests/python/test_diagnostic_log.py
+++ b/tests/python/test_diagnostic_log.py
@@ -1,0 +1,34 @@
+import json
+
+from jl_mixing import diagnostic_log
+
+
+def test_diagnostic_log_is_file_only(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("JL_MIXING_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("JL_MIXING_LOG_LEVEL", "debug")
+    diagnostic_log.debug("test_event", operation="test.operation", completed=2)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    record = json.loads((tmp_path / "automation.jsonl").read_text(encoding="utf-8").strip())
+    assert record["component"] == "automation"
+    assert record["event"] == "test_event"
+    assert record["operation"] == "test.operation"
+    assert record["completed"] == 2
+
+
+def test_info_default_filters_debug(monkeypatch, tmp_path):
+    monkeypatch.setenv("JL_MIXING_LOG_DIR", str(tmp_path))
+    monkeypatch.delenv("JL_MIXING_LOG_LEVEL", raising=False)
+    diagnostic_log.debug("hidden")
+    diagnostic_log.info("visible")
+    lines = (tmp_path / "automation.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["event"] for line in lines] == ["visible"]
+
+
+def test_sensitive_field_names_are_redacted(monkeypatch, tmp_path):
+    monkeypatch.setenv("JL_MIXING_LOG_DIR", str(tmp_path))
+    diagnostic_log.info("safe", token="abc", operation="test")
+    record = json.loads((tmp_path / "automation.jsonl").read_text(encoding="utf-8").strip())
+    assert record["token"] == "<redacted>"
+    assert record["operation"] == "test"


### PR DESCRIPTION
Closes #164.

## Summary
- makes JSONL diagnostic logging a permanent supported Automation feature
- adds OS-native default log locations with `JL_MIXING_LOG_DIR` override
- defaults to `info`; `JL_MIXING_LOG_LEVEL=debug` enables detailed progress events
- rotates at 5 MB and retains one backup
- redacts common sensitive field names and never writes diagnostics to stdout/stderr
- instruments managed import planning/execution timing, execute-time replan duration, progress mode, progress emission, completion, and failures
- documents support/privacy/retention behavior
- adds regression tests for file-only logging, level filtering, and redaction

This branch starts from current `main`, including merged PR #167.