### PR TITLE
Reconcile managed import staging progress

### DIFF
--- a/docs/MANAGED_IMPORT_PROGRESS.md
+++ b/docs/MANAGED_IMPORT_PROGRESS.md
@@ -1,0 +1,9 @@
+# Managed import progress implementation note
+
+The v2.1 managed-import progress contract is split intentionally between the import engine and API adapter:
+
+- the engine reports phase-local completed source-file counts while staging and importing;
+- the API adapter translates those counts into the additive monotonic whole-operation progress contract (`planning`, `staging`, `importing`, `finalizing`, `complete`);
+- the final stdout API response remains unchanged.
+
+This reconciles the original staging-count work from draft PR #163 with the monotonic contract merged in PR #167. The API adapter must not synthesize file completion counts when the engine already supplies them.

--- a/src/jl_mixing/api/managed_client_files.py
+++ b/src/jl_mixing/api/managed_client_files.py
@@ -69,7 +69,6 @@ class _ImportProgressAdapter:
         self.operation = operation
         self.total_files = total_files
         self.overall_total = total_files * 2 + 1
-        self.staging_seen = 0
         self.staging_complete_emitted = False
         self.finalizing_emitted = False
 
@@ -97,9 +96,9 @@ class _ImportProgressAdapter:
         completed = max(0, min(int(event.get("completed", 0)), self.total_files))
 
         if phase == "staging":
-            stage_completed = min(self.staging_seen, self.total_files)
-            self._emit("staging", stage_completed, active, stage_completed)
-            self.staging_seen += 1
+            self._emit("staging", completed, active, completed)
+            if completed >= self.total_files:
+                self.staging_complete_emitted = True
             return
 
         if phase == "importing":

--- a/src/jl_mixing/managed_client_files.py
+++ b/src/jl_mixing/managed_client_files.py
@@ -330,9 +330,14 @@ def execute_plan(
     completed_files = 0
     remaining_by_source = {relative: sum(1 for item in plan["items"] if item["source_relative_path"] == relative) for relative in source_objects}
 
-    def emit_progress(phase: str, active: list[str]) -> None:
+    def emit_progress(phase: str, active: list[str], *, completed: int | None = None) -> None:
         if progress is not None:
-            progress({"phase": phase, "completed": completed_files, "total": total_files, "active": active})
+            progress({
+                "phase": phase,
+                "completed": completed_files if completed is None else completed,
+                "total": total_files,
+                "active": active,
+            })
 
     def complete_item(item: dict[str, Any]) -> None:
         nonlocal completed_files
@@ -352,9 +357,12 @@ def execute_plan(
     changed_audio = False
     try:
         staged: dict[str, Path] = {}
+        staged_files = 0
         for relative, source in source_objects.items():
-            emit_progress("staging", [relative])
+            emit_progress("staging", [relative], completed=staged_files)
             staged[relative] = _stage_source(source, stage)
+            staged_files += 1
+            emit_progress("staging", [relative], completed=staged_files)
         emit_progress("importing", [])
         item_by_id = {item["id"]: item for item in plan["items"]}
         for position, item in enumerate(plan["items"]):

--- a/tests/python/test_managed_import_progress_contract.py
+++ b/tests/python/test_managed_import_progress_contract.py
@@ -24,13 +24,15 @@ def progress_events(stderr: str) -> list[dict[str, object]]:
 
 
 class ManagedImportProgressContractTests(unittest.TestCase):
-    def test_adapter_emits_monotonic_overall_progress_until_complete(self) -> None:
+    def test_adapter_uses_engine_staging_counts_and_stays_monotonic(self) -> None:
         output = io.StringIO()
         adapter = api._ImportProgressAdapter("client.files.import.execute", 2)
 
         with redirect_stderr(output):
             adapter({"phase": "staging", "completed": 0, "total": 2, "active": ["one.wav"]})
-            adapter({"phase": "staging", "completed": 0, "total": 2, "active": ["two.wav"]})
+            adapter({"phase": "staging", "completed": 1, "total": 2, "active": ["one.wav"]})
+            adapter({"phase": "staging", "completed": 1, "total": 2, "active": ["two.wav"]})
+            adapter({"phase": "staging", "completed": 2, "total": 2, "active": ["two.wav"]})
             adapter({"phase": "importing", "completed": 0, "total": 2, "active": []})
             adapter({"phase": "importing", "completed": 1, "total": 2, "active": ["one.wav"]})
             adapter({"phase": "importing", "completed": 2, "total": 2, "active": []})
@@ -40,8 +42,8 @@ class ManagedImportProgressContractTests(unittest.TestCase):
         events = progress_events(output.getvalue())
         phases = [event["phase"] for event in events]
         self.assertEqual(phases[-2:], ["finalizing", "complete"])
-        self.assertIn("staging", phases)
-        self.assertIn("importing", phases)
+        staging = [int(event["completed"]) for event in events if event["phase"] == "staging"]
+        self.assertEqual(staging, [0, 1, 1, 2])
         overall = [int(event["overall_completed"]) for event in events]
         self.assertEqual(overall, sorted(overall))
         self.assertTrue(all(event["overall_total"] == 5 for event in events))
@@ -75,6 +77,7 @@ class ManagedImportProgressContractTests(unittest.TestCase):
         def fake_execute_plan(_root, _plan, _decisions, *, progress=None):
             assert progress is not None
             progress({"phase": "staging", "completed": 0, "total": 1, "active": ["one.wav"]})
+            progress({"phase": "staging", "completed": 1, "total": 1, "active": ["one.wav"]})
             progress({"phase": "importing", "completed": 1, "total": 1, "active": []})
             progress({"phase": "complete", "completed": 1, "total": 1, "active": []})
             return {"items": []}


### PR DESCRIPTION
Supersedes draft PR #163 while preserving the monotonic progress contract merged in #167.

## Summary
- keeps engine-level staging progress tied to real completed source files
- updates the #167 adapter to consume engine `completed` counts instead of synthesizing them
- preserves monotonic `overall_completed` / `overall_total`
- preserves `planning`, `staging`, `importing`, `finalizing`, `complete`
- preserves final stdout JSON unchanged
- adds focused regression coverage for true staging counts and monotonic overall progress

The old draft branch must not be merged directly because its richer staging events combined with the original #167 adapter would double-count staging progress.