### PR TITLE
Profile managed Client Files import timing

### DIFF
--- a/docs/DIAGNOSTIC_LOGGING.md
+++ b/docs/DIAGNOSTIC_LOGGING.md
@@ -14,13 +14,20 @@ Set `JL_MIXING_LOG_DIR` to override the directory. Set `JL_MIXING_LOG_LEVEL=debu
 
 Managed Client Files imports record concise timing summaries at the default `info` level:
 
-- `managed_import_plan_profile` measures source collection, destination/conflict checks, plan finalization, file/byte counts, and total planning time.
-- `managed_import_execute_profile` measures setup, transaction creation, staging, destination writes, cache invalidation, rollback/cleanup, file/byte counts, result counts, and total execution time.
+- `managed_import_plan_profile` measures source collection, destination/conflict checks, plan finalization, file/byte counts, and total lower-level planning time.
+- `managed_import_provenance_plan_profile` measures provenance-wrapper planning, including base planning, provenance loading, destination resolution/fallback matching, and total wrapper time.
+- `managed_import_working_hash_index_profile` measures Working_Audio content-index hashing when fallback/recovery matching requires it.
+- `managed_import_execute_profile` measures setup, transaction creation, staging, destination writes, cache invalidation, rollback/cleanup, file/byte counts, result counts, and total lower-level execution time.
+- `managed_import_provenance_finalize_profile` measures post-copy lineage recording, including source/working SHA-256 work and provenance-file writing.
+- `managed_import_provenance_execute_profile` measures lower-level execute time versus lineage finalization and total wrapper execution time.
 
 For per-file detail, run Studio or Automation with `JL_MIXING_LOG_LEVEL=debug`. Debug logging adds:
 
 - `managed_import_stage_file_profile` for each staged source file.
 - `managed_import_write_item_profile` for each Original Delivery or Audio Prep write, including copy and replace timing.
+- `managed_import_fallback_hash_profile` for each fallback source hash used during provenance resolution.
+- `managed_import_working_hash_file_profile` for each Working_Audio file hashed into the recovery index.
+- `managed_import_provenance_hash_file_profile` for the Original Delivery and Working_Audio hashes recorded after a successful import.
 
 These events are diagnostic only. They do not change the Automation API response or stderr progress stream.
 

--- a/docs/DIAGNOSTIC_LOGGING.md
+++ b/docs/DIAGNOSTIC_LOGGING.md
@@ -10,6 +10,20 @@ JL Mixing Automation writes structured JSON Lines diagnostics to a per-user log 
 
 Set `JL_MIXING_LOG_DIR` to override the directory. Set `JL_MIXING_LOG_LEVEL=debug` for detailed progress events; the default level is `info`.
 
+## Managed Client Files import profiling
+
+Managed Client Files imports record concise timing summaries at the default `info` level:
+
+- `managed_import_plan_profile` measures source collection, destination/conflict checks, plan finalization, file/byte counts, and total planning time.
+- `managed_import_execute_profile` measures setup, transaction creation, staging, destination writes, cache invalidation, rollback/cleanup, file/byte counts, result counts, and total execution time.
+
+For per-file detail, run Studio or Automation with `JL_MIXING_LOG_LEVEL=debug`. Debug logging adds:
+
+- `managed_import_stage_file_profile` for each staged source file.
+- `managed_import_write_item_profile` for each Original Delivery or Audio Prep write, including copy and replace timing.
+
+These events are diagnostic only. They do not change the Automation API response or stderr progress stream.
+
 ## Retention
 
 The active file rotates at 5 MB. One rotated backup is retained as `automation.jsonl.1`, bounding normal disk use to roughly 10 MB.

--- a/src/jl_mixing/managed_client_file_provenance.py
+++ b/src/jl_mixing/managed_client_file_provenance.py
@@ -11,14 +11,20 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any
 
+from . import diagnostic_log
 from .errors import UnsafeOperationError, ValidationError
 from . import managed_client_files as base
 
 PROVENANCE_PATH = Path("00_Admin") / "audio-prep-provenance.json"
 SCHEMA_VERSION = 1
+
+
+def _elapsed_ms(started: float) -> float:
+    return round((time.perf_counter() - started) * 1000.0, 3)
 
 
 def _empty_document() -> dict[str, Any]:
@@ -91,12 +97,21 @@ class _WorkingHashIndex:
         self._by_hash: dict[str, list[str]] | None = None
 
     def _build(self) -> dict[str, list[str]]:
+        started = time.perf_counter()
         audio_root = self.project_root / base.AUDIO_ROOT
         if not audio_root.exists():
+            diagnostic_log.info(
+                "managed_import_working_hash_index_profile",
+                file_count=0,
+                total_bytes=0,
+                elapsed_ms=_elapsed_ms(started),
+            )
             return {}
         if audio_root.is_symlink() or not audio_root.is_dir():
             raise UnsafeOperationError(f"Audio Prep root is unavailable or unsafe: {audio_root}")
         by_hash: dict[str, list[str]] = {}
+        file_count = 0
+        total_bytes = 0
         for current, dirs, names in os.walk(audio_root, followlinks=False):
             current_path = Path(current)
             for directory in dirs:
@@ -106,9 +121,24 @@ class _WorkingHashIndex:
                 candidate = current_path / name
                 if candidate.is_symlink() or not candidate.is_file():
                     continue
+                size = candidate.stat().st_size
+                hash_started = time.perf_counter()
                 digest = base._sha256_file(candidate)
+                diagnostic_log.debug(
+                    "managed_import_working_hash_file_profile",
+                    size_bytes=size,
+                    elapsed_ms=_elapsed_ms(hash_started),
+                )
                 relative = (base.AUDIO_ROOT / candidate.relative_to(audio_root)).as_posix()
                 by_hash.setdefault(digest, []).append(relative)
+                file_count += 1
+                total_bytes += size
+        diagnostic_log.info(
+            "managed_import_working_hash_index_profile",
+            file_count=file_count,
+            total_bytes=total_bytes,
+            elapsed_ms=_elapsed_ms(started),
+        )
         return by_hash
 
     def match(self, digest: str, *, ambiguity_message: str) -> str | None:
@@ -141,7 +171,15 @@ def _lineage_destination(project_root: Path, source_relative: str, provenance: d
 def _fallback_match(source_relative: str, candidate: Path | None, working_index: _WorkingHashIndex) -> str | None:
     if candidate is None or not candidate.is_file():
         return None
+    size = candidate.stat().st_size
+    started = time.perf_counter()
     source_hash = base._sha256_file(candidate)
+    diagnostic_log.debug(
+        "managed_import_fallback_hash_profile",
+        source_relative_path=source_relative,
+        size_bytes=size,
+        elapsed_ms=_elapsed_ms(started),
+    )
     return working_index.match(source_hash, ambiguity_message=f"Multiple Audio Prep files match Original Delivery content for {source_relative}; repair is required before reset.")
 
 
@@ -150,9 +188,17 @@ def _resolved_destination(project_root: Path, source_relative: str, fallback_sou
 
 
 def plan_import(project_root: Path, source_kind: str, sources: tuple[Path, ...]) -> dict[str, Any]:
+    total_started = time.perf_counter()
+    base_started = time.perf_counter()
     plan = base.plan_import(project_root, source_kind, sources)
+    base_plan_ms = _elapsed_ms(base_started)
+
+    provenance_started = time.perf_counter()
     source_objects = {source.relative_path: source for source in _source_objects(plan)}
     provenance = _provenance_by_source(_load(project_root))
+    provenance_load_ms = _elapsed_ms(provenance_started)
+
+    resolution_started = time.perf_counter()
     working_index = _WorkingHashIndex(project_root)
     items: list[dict[str, Any]] = []
     for item in plan["items"]:
@@ -167,8 +213,23 @@ def plan_import(project_root: Path, source_kind: str, sources: tuple[Path, ...])
             items.append(base._item(project_root, item["id"], "audio_prep", destination, source_objects[source_relative], depends_on=item.get("depends_on")))
         else:
             items.append(item)
+    resolution_ms = _elapsed_ms(resolution_started)
+
+    finalize_started = time.perf_counter()
     plan["items"] = items
     plan["plan_id"] = base._plan_id("client.files.import", source_kind, sources, source_objects.values(), items)
+    finalize_ms = _elapsed_ms(finalize_started)
+    diagnostic_log.info(
+        "managed_import_provenance_plan_profile",
+        source_kind=source_kind,
+        file_count=len(source_objects),
+        provenance_entry_count=len(provenance),
+        base_plan_ms=base_plan_ms,
+        provenance_load_ms=provenance_load_ms,
+        resolution_ms=resolution_ms,
+        finalize_ms=finalize_ms,
+        total_ms=_elapsed_ms(total_started),
+    )
     return plan
 
 
@@ -204,10 +265,17 @@ def plan_reset(project_root: Path, relative_paths: tuple[str, ...]) -> dict[str,
 
 
 def _record_successful_lineage(project_root: Path, plan: dict[str, Any], result: dict[str, Any]) -> None:
+    total_started = time.perf_counter()
     statuses = {item["id"]: item["result"] for item in result.get("items", [])}
+    load_started = time.perf_counter()
     document = _load(project_root)
+    load_ms = _elapsed_ms(load_started)
     entries = list(document["entries"])
     changed = False
+    source_hash_ms = 0.0
+    working_hash_ms = 0.0
+    hashed_bytes = 0
+    recorded_count = 0
     for item in plan["items"]:
         if item["area"] != "audio_prep" or statuses.get(item["id"]) not in {"created", "replaced"}:
             continue
@@ -217,21 +285,54 @@ def _record_successful_lineage(project_root: Path, plan: dict[str, Any], result:
         working_path = base._managed_destination(project_root, working_relative)
         if not source_path.is_file() or not working_path.is_file():
             continue
+        source_size = source_path.stat().st_size
+        working_size = working_path.stat().st_size
+        source_started = time.perf_counter()
+        source_hash = base._sha256_file(source_path)
+        source_elapsed = _elapsed_ms(source_started)
+        source_hash_ms += source_elapsed
+        working_started = time.perf_counter()
+        working_hash = base._sha256_file(working_path)
+        working_elapsed = _elapsed_ms(working_started)
+        working_hash_ms += working_elapsed
+        hashed_bytes += source_size + working_size
+        diagnostic_log.debug(
+            "managed_import_provenance_hash_file_profile",
+            source_relative_path=source_relative,
+            source_size_bytes=source_size,
+            working_size_bytes=working_size,
+            source_hash_ms=source_elapsed,
+            working_hash_ms=working_elapsed,
+        )
         source_key = source_relative.casefold()
         working_key = working_relative.casefold()
         entries = [entry for entry in entries if str(entry.get("source_relative_path", "")).casefold() != source_key and str(entry.get("working_relative_path", "")).casefold() != working_key]
         entries.append({
             "source_relative_path": source_relative,
             "working_relative_path": working_relative,
-            "source_sha256": base._sha256_file(source_path),
-            "working_sha256": base._sha256_file(working_path),
+            "source_sha256": source_hash,
+            "working_sha256": working_hash,
             "transformations": ["copied"],
         })
+        recorded_count += 1
         changed = True
+    write_ms = 0.0
     if changed:
         entries.sort(key=lambda entry: str(entry["source_relative_path"]).casefold())
         document["entries"] = entries
+        write_started = time.perf_counter()
         _write(project_root, document)
+        write_ms = _elapsed_ms(write_started)
+    diagnostic_log.info(
+        "managed_import_provenance_finalize_profile",
+        recorded_count=recorded_count,
+        hashed_bytes=hashed_bytes,
+        load_ms=load_ms,
+        source_hash_ms=round(source_hash_ms, 3),
+        working_hash_ms=round(working_hash_ms, 3),
+        write_ms=write_ms,
+        total_ms=_elapsed_ms(total_started),
+    )
 
 
 def execute_plan(
@@ -241,6 +342,17 @@ def execute_plan(
     *,
     progress: base.ProgressCallback | None = None,
 ) -> dict[str, Any]:
+    total_started = time.perf_counter()
+    base_started = time.perf_counter()
     result = base.execute_plan(project_root, plan, decisions, progress=progress)
+    base_execute_ms = _elapsed_ms(base_started)
+    lineage_started = time.perf_counter()
     _record_successful_lineage(project_root, plan, result)
+    lineage_ms = _elapsed_ms(lineage_started)
+    diagnostic_log.info(
+        "managed_import_provenance_execute_profile",
+        base_execute_ms=base_execute_ms,
+        lineage_ms=lineage_ms,
+        total_ms=_elapsed_ms(total_started),
+    )
     return result

--- a/src/jl_mixing/managed_client_files.py
+++ b/src/jl_mixing/managed_client_files.py
@@ -7,11 +7,13 @@ import json
 import os
 import shutil
 import stat
+import time
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Iterable
 
+from . import diagnostic_log
 from .errors import UnsafeOperationError, ValidationError
 from .transactions import create_staging_directory
 
@@ -29,6 +31,10 @@ class SourceFile:
     zip_member: str | None
     size: int
     fingerprint: str
+
+
+def _elapsed_ms(started: float) -> float:
+    return round((time.perf_counter() - started) * 1000.0, 3)
 
 
 def _safe_relative(value: str) -> str:
@@ -222,7 +228,12 @@ def _serialized_source(source: SourceFile) -> dict[str, Any]:
 
 
 def plan_import(project_root: Path, source_kind: str, sources: tuple[Path, ...]) -> dict[str, Any]:
+    total_started = time.perf_counter()
+    collect_started = time.perf_counter()
     files = _collect_files(source_kind, sources)
+    collect_ms = _elapsed_ms(collect_started)
+
+    items_started = time.perf_counter()
     items: list[dict[str, Any]] = []
     for index, source in enumerate(files):
         original_rel = (ORIGINAL_ROOT / Path(source.relative_path)).as_posix()
@@ -230,7 +241,10 @@ def plan_import(project_root: Path, source_kind: str, sources: tuple[Path, ...])
         original_id = f"original:{index}"
         items.append(_item(project_root, original_id, "original_delivery", original_rel, source))
         items.append(_item(project_root, f"audio:{index}", "audio_prep", audio_rel, source, depends_on=original_id))
-    return {
+    items_ms = _elapsed_ms(items_started)
+
+    finalize_started = time.perf_counter()
+    result = {
         "operation": "client.files.import",
         "source_kind": source_kind,
         "sources": [str(path.expanduser().absolute()) for path in sources],
@@ -238,6 +252,21 @@ def plan_import(project_root: Path, source_kind: str, sources: tuple[Path, ...])
         "files": [_serialized_source(source) for source in files],
         "items": items,
     }
+    finalize_ms = _elapsed_ms(finalize_started)
+    diagnostic_log.info(
+        "managed_import_plan_profile",
+        source_kind=source_kind,
+        source_count=len(sources),
+        file_count=len(files),
+        total_bytes=sum(source.size for source in files),
+        item_count=len(items),
+        conflict_count=sum(1 for item in items if item["conflict"]),
+        collect_ms=collect_ms,
+        destination_check_ms=items_ms,
+        finalize_ms=finalize_ms,
+        total_ms=_elapsed_ms(total_started),
+    )
+    return result
 
 
 def plan_reset(project_root: Path, relative_paths: tuple[str, ...]) -> dict[str, Any]:
@@ -318,6 +347,18 @@ def execute_plan(
     *,
     progress: ProgressCallback | None = None,
 ) -> dict[str, Any]:
+    total_started = time.perf_counter()
+    phase = "setup"
+    success = False
+    staging_ms = 0.0
+    importing_ms = 0.0
+    invalidation_ms = 0.0
+    rollback_ms = 0.0
+    cleanup_ms = 0.0
+    staged_bytes = 0
+    written_bytes = 0
+
+    setup_started = time.perf_counter()
     decisions = _decisions(plan, decisions)
     source_objects = {
         data["relative_path"]: SourceFile(
@@ -327,13 +368,15 @@ def execute_plan(
         for data in plan["files"]
     }
     total_files = len(source_objects)
+    total_bytes = sum(source.size for source in source_objects.values())
     completed_files = 0
     remaining_by_source = {relative: sum(1 for item in plan["items"] if item["source_relative_path"] == relative) for relative in source_objects}
+    setup_ms = _elapsed_ms(setup_started)
 
-    def emit_progress(phase: str, active: list[str], *, completed: int | None = None) -> None:
+    def emit_progress(phase_name: str, active: list[str], *, completed: int | None = None) -> None:
         if progress is not None:
             progress({
-                "phase": phase,
+                "phase": phase_name,
                 "completed": completed_files if completed is None else completed,
                 "total": total_files,
                 "active": active,
@@ -347,7 +390,9 @@ def execute_plan(
             completed_files += 1
         emit_progress("importing", [relative] if remaining_by_source[relative] else [])
 
+    transaction_started = time.perf_counter()
     transaction = create_staging_directory(project_root / "00_Admin", ".jl-managed-import-")
+    transaction_setup_ms = _elapsed_ms(transaction_started)
     stage = transaction / "stage"
     backups = transaction / "backups"
     writes = transaction / "writes"
@@ -356,13 +401,29 @@ def execute_plan(
     changed_original = False
     changed_audio = False
     try:
+        phase = "staging"
+        phase_started = time.perf_counter()
         staged: dict[str, Path] = {}
         staged_files = 0
         for relative, source in source_objects.items():
             emit_progress("staging", [relative], completed=staged_files)
+            file_started = time.perf_counter()
             staged[relative] = _stage_source(source, stage)
+            file_ms = _elapsed_ms(file_started)
+            staged_bytes += source.size
+            diagnostic_log.debug(
+                "managed_import_stage_file_profile",
+                relative_path=relative,
+                size_bytes=source.size,
+                zip_member=source.zip_member is not None,
+                elapsed_ms=file_ms,
+            )
             staged_files += 1
             emit_progress("staging", [relative], completed=staged_files)
+        staging_ms = _elapsed_ms(phase_started)
+
+        phase = "importing"
+        phase_started = time.perf_counter()
         emit_progress("importing", [])
         item_by_id = {item["id"]: item for item in plan["items"]}
         for position, item in enumerate(plan["items"]):
@@ -377,15 +438,18 @@ def execute_plan(
                 results.append({"id": item["id"], "result": "skipped"})
                 complete_item(item)
                 continue
+            item_started = time.perf_counter()
             destination = _managed_destination(project_root, item["destination_relative_path"])
             if _file_state(destination) != item["destination_state"]:
                 raise ValidationError(f"Managed destination changed after planning: {item['destination_relative_path']}")
             destination.parent.mkdir(parents=True, exist_ok=True)
             backup: Path | None = None
+            backup_started = time.perf_counter()
             if destination.exists():
                 backup = backups / Path(item["destination_relative_path"])
                 backup.parent.mkdir(parents=True, exist_ok=True)
                 os.replace(destination, backup)
+            backup_ms = _elapsed_ms(backup_started)
             applied.append((destination, backup))
             if item["area"] == "audio_prep" and dependency:
                 original_item = item_by_id[dependency]
@@ -395,16 +459,42 @@ def execute_plan(
                 copy_source = staged[item["source_relative_path"]]
             writes.mkdir(parents=True, exist_ok=True)
             temp_dest = writes / f"write-{position}.tmp"
+            copy_started = time.perf_counter()
             shutil.copyfile(copy_source, temp_dest)
+            copy_ms = _elapsed_ms(copy_started)
+            replace_started = time.perf_counter()
             os.replace(temp_dest, destination)
+            replace_ms = _elapsed_ms(replace_started)
+            written_bytes += int(item.get("size_bytes", 0))
             changed_original = changed_original or item["area"] == "original_delivery"
             changed_audio = changed_audio or item["area"] == "audio_prep"
-            results.append({"id": item["id"], "result": "replaced" if backup else "created"})
+            result_name = "replaced" if backup else "created"
+            results.append({"id": item["id"], "result": result_name})
+            diagnostic_log.debug(
+                "managed_import_write_item_profile",
+                relative_path=relative,
+                area=item["area"],
+                size_bytes=int(item.get("size_bytes", 0)),
+                result=result_name,
+                backup_ms=backup_ms,
+                copy_ms=copy_ms,
+                replace_ms=replace_ms,
+                total_ms=_elapsed_ms(item_started),
+            )
             complete_item(item)
+        importing_ms = _elapsed_ms(phase_started)
+
+        phase = "invalidation"
+        phase_started = time.perf_counter()
         invalidated = _invalidate(project_root, changed_original, changed_audio)
+        invalidation_ms = _elapsed_ms(phase_started)
         emit_progress("complete", [])
+        success = True
+        phase = "complete"
         return {"items": results, "invalidations": invalidated}
     except Exception:
+        phase = "rollback"
+        rollback_started = time.perf_counter()
         for destination, backup in reversed(applied):
             try:
                 if destination.exists() and not destination.is_symlink():
@@ -414,6 +504,35 @@ def execute_plan(
                     os.replace(backup, destination)
             except OSError:
                 pass
+        rollback_ms = _elapsed_ms(rollback_started)
         raise
     finally:
+        cleanup_started = time.perf_counter()
         shutil.rmtree(transaction, ignore_errors=True)
+        cleanup_ms = _elapsed_ms(cleanup_started)
+        result_counts = {
+            "created": sum(1 for item in results if item["result"] == "created"),
+            "replaced": sum(1 for item in results if item["result"] == "replaced"),
+            "skipped": sum(1 for item in results if item["result"] == "skipped"),
+        }
+        diagnostic_log.info(
+            "managed_import_execute_profile",
+            success=success,
+            final_phase=phase,
+            file_count=total_files,
+            total_bytes=total_bytes,
+            item_count=len(plan["items"]),
+            staged_bytes=staged_bytes,
+            written_bytes=written_bytes,
+            created_count=result_counts["created"],
+            replaced_count=result_counts["replaced"],
+            skipped_count=result_counts["skipped"],
+            setup_ms=setup_ms,
+            transaction_setup_ms=transaction_setup_ms,
+            staging_ms=staging_ms,
+            importing_ms=importing_ms,
+            invalidation_ms=invalidation_ms,
+            rollback_ms=rollback_ms,
+            cleanup_ms=cleanup_ms,
+            total_ms=_elapsed_ms(total_started),
+        )

--- a/tests/python/test_managed_import_profiling.py
+++ b/tests/python/test_managed_import_profiling.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing import managed_client_files
+
+
+class ManagedImportProfilingTests(unittest.TestCase):
+    def test_plan_and_execute_emit_timing_profiles_without_changing_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            (project / "00_Admin").mkdir(parents=True)
+            source = root / "mix.wav"
+            source.write_bytes(b"audio-data")
+
+            with patch.object(managed_client_files.diagnostic_log, "info") as info_log:
+                plan = managed_client_files.plan_import(project, "files", (source,))
+
+            plan_profile = next(
+                call for call in info_log.call_args_list
+                if call.args == ("managed_import_plan_profile",)
+            )
+            plan_fields = plan_profile.kwargs
+            self.assertEqual(plan_fields["source_kind"], "files")
+            self.assertEqual(plan_fields["file_count"], 1)
+            self.assertEqual(plan_fields["total_bytes"], len(b"audio-data"))
+            self.assertEqual(plan_fields["item_count"], 2)
+            self.assertGreaterEqual(plan_fields["collect_ms"], 0)
+            self.assertGreaterEqual(plan_fields["destination_check_ms"], 0)
+            self.assertGreaterEqual(plan_fields["total_ms"], 0)
+
+            with (
+                patch.object(managed_client_files.diagnostic_log, "info") as info_log,
+                patch.object(managed_client_files.diagnostic_log, "debug") as debug_log,
+            ):
+                result = managed_client_files.execute_plan(project, plan, {})
+
+            self.assertEqual(
+                [item["result"] for item in result["items"]],
+                ["created", "created"],
+            )
+            self.assertEqual(
+                (project / "01_Client_Files" / "Original_Delivery" / "mix.wav").read_bytes(),
+                b"audio-data",
+            )
+            self.assertEqual(
+                (project / "02_Audio_Preparation" / "Working_Audio" / "mix.wav").read_bytes(),
+                b"audio-data",
+            )
+
+            execute_profile = next(
+                call for call in info_log.call_args_list
+                if call.args == ("managed_import_execute_profile",)
+            )
+            execute_fields = execute_profile.kwargs
+            self.assertTrue(execute_fields["success"])
+            self.assertEqual(execute_fields["file_count"], 1)
+            self.assertEqual(execute_fields["staged_bytes"], len(b"audio-data"))
+            self.assertEqual(execute_fields["written_bytes"], len(b"audio-data") * 2)
+            self.assertEqual(execute_fields["created_count"], 2)
+            self.assertEqual(execute_fields["replaced_count"], 0)
+            self.assertEqual(execute_fields["skipped_count"], 0)
+            for field in (
+                "setup_ms",
+                "transaction_setup_ms",
+                "staging_ms",
+                "importing_ms",
+                "invalidation_ms",
+                "cleanup_ms",
+                "total_ms",
+            ):
+                self.assertGreaterEqual(execute_fields[field], 0)
+
+            debug_events = [call.args[0] for call in debug_log.call_args_list]
+            self.assertIn("managed_import_stage_file_profile", debug_events)
+            self.assertEqual(debug_events.count("managed_import_write_item_profile"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_managed_provenance_profiling.py
+++ b/tests/python/test_managed_provenance_profiling.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing import managed_client_file_provenance as provenance
+
+
+class ManagedProvenanceProfilingTests(unittest.TestCase):
+    def test_plan_and_execute_emit_provenance_profiles(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            (project / "00_Admin").mkdir(parents=True)
+            source = root / "mix.wav"
+            source.write_bytes(b"audio-data")
+
+            with (
+                patch.object(provenance.diagnostic_log, "info") as info_log,
+                patch.object(provenance.diagnostic_log, "debug") as debug_log,
+            ):
+                plan = provenance.plan_import(project, "files", (source,))
+
+            events = [call.args[0] for call in info_log.call_args_list]
+            self.assertIn("managed_import_provenance_plan_profile", events)
+            self.assertIn("managed_import_working_hash_index_profile", events)
+            plan_profile = next(
+                call for call in info_log.call_args_list
+                if call.args == ("managed_import_provenance_plan_profile",)
+            ).kwargs
+            self.assertEqual(plan_profile["source_kind"], "files")
+            self.assertEqual(plan_profile["file_count"], 1)
+            self.assertGreaterEqual(plan_profile["resolution_ms"], 0)
+            self.assertGreaterEqual(plan_profile["total_ms"], 0)
+            self.assertIn(
+                "managed_import_fallback_hash_profile",
+                [call.args[0] for call in debug_log.call_args_list],
+            )
+
+            with (
+                patch.object(provenance.diagnostic_log, "info") as info_log,
+                patch.object(provenance.diagnostic_log, "debug") as debug_log,
+            ):
+                result = provenance.execute_plan(project, plan, {})
+
+            self.assertEqual(
+                [item["result"] for item in result["items"]],
+                ["created", "created"],
+            )
+            events = [call.args[0] for call in info_log.call_args_list]
+            self.assertIn("managed_import_provenance_finalize_profile", events)
+            self.assertIn("managed_import_provenance_execute_profile", events)
+            finalize_profile = next(
+                call for call in info_log.call_args_list
+                if call.args == ("managed_import_provenance_finalize_profile",)
+            ).kwargs
+            self.assertEqual(finalize_profile["recorded_count"], 1)
+            self.assertEqual(finalize_profile["hashed_bytes"], len(b"audio-data") * 2)
+            self.assertGreaterEqual(finalize_profile["source_hash_ms"], 0)
+            self.assertGreaterEqual(finalize_profile["working_hash_ms"], 0)
+            self.assertIn(
+                "managed_import_provenance_hash_file_profile",
+                [call.args[0] for call in debug_log.call_args_list],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #170.

Adds behavior-neutral structured timing instrumentation for managed Client Files import planning and execution using the existing Automation JSONL diagnostic logger.

At the default `info` level, logs concise plan/execute summaries with phase durations, file/byte counts, result counts, and total elapsed time. At `debug`, adds per-file staging and destination-write timings.

No stdout/stderr, API response, or progress-contract changes. Includes focused profiling-event tests and diagnostic logging documentation.