### PR TITLE
Avoid hashing ZIP container during import provenance planning

### DIFF
--- a/src/jl_mixing/managed_client_file_provenance.py
+++ b/src/jl_mixing/managed_client_file_provenance.py
@@ -206,11 +206,12 @@ def plan_import(project_root: Path, source_kind: str, sources: tuple[Path, ...])
             items.append(item)
             continue
         source_relative = item["source_relative_path"]
+        source = source_objects[source_relative]
         existing_original = base._managed_destination(project_root, (base.ORIGINAL_ROOT / Path(source_relative)).as_posix())
-        fallback = existing_original if existing_original.is_file() else source_objects[source_relative].source_path
+        fallback = existing_original if existing_original.is_file() else (None if source.zip_member is not None else source.source_path)
         destination = _resolved_destination(project_root, source_relative, fallback, provenance, working_index)
         if destination:
-            items.append(base._item(project_root, item["id"], "audio_prep", destination, source_objects[source_relative], depends_on=item.get("depends_on")))
+            items.append(base._item(project_root, item["id"], "audio_prep", destination, source, depends_on=item.get("depends_on")))
         else:
             items.append(item)
     resolution_ms = _elapsed_ms(resolution_started)

--- a/tests/python/test_zip_provenance_planning.py
+++ b/tests/python/test_zip_provenance_planning.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import stat
 import tempfile
 import unittest
 import zipfile
@@ -7,6 +8,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from jl_mixing import managed_client_file_provenance as provenance
+
+
+def _write_regular(handle: zipfile.ZipFile, name: str, content: bytes) -> None:
+    info = zipfile.ZipInfo(name)
+    info.create_system = 3
+    info.external_attr = (stat.S_IFREG | 0o644) << 16
+    handle.writestr(info, content)
 
 
 class ZipProvenancePlanningTests(unittest.TestCase):
@@ -17,8 +25,8 @@ class ZipProvenancePlanningTests(unittest.TestCase):
             (project / "00_Admin").mkdir(parents=True)
             archive = root / "delivery.zip"
             with zipfile.ZipFile(archive, "w") as handle:
-                handle.writestr("mix.wav", b"audio-data")
-                handle.writestr("Stems/bass.wav", b"bass-data")
+                _write_regular(handle, "mix.wav", b"audio-data")
+                _write_regular(handle, "Stems/bass.wav", b"bass-data")
 
             with patch.object(provenance.base, "_sha256_file", wraps=provenance.base._sha256_file) as sha256_file:
                 plan = provenance.plan_import(project, "zip", (archive,))
@@ -39,7 +47,7 @@ class ZipProvenancePlanningTests(unittest.TestCase):
             working.write_bytes(b"same-audio")
             archive = root / "delivery.zip"
             with zipfile.ZipFile(archive, "w") as handle:
-                handle.writestr("mix.wav", b"new-audio")
+                _write_regular(handle, "mix.wav", b"new-audio")
 
             plan = provenance.plan_import(project, "zip", (archive,))
             audio_item = next(item for item in plan["items"] if item["area"] == "audio_prep")

--- a/tests/python/test_zip_provenance_planning.py
+++ b/tests/python/test_zip_provenance_planning.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing import managed_client_file_provenance as provenance
+
+
+class ZipProvenancePlanningTests(unittest.TestCase):
+    def test_zip_container_is_not_hashed_as_member_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            (project / "00_Admin").mkdir(parents=True)
+            archive = root / "delivery.zip"
+            with zipfile.ZipFile(archive, "w") as handle:
+                handle.writestr("mix.wav", b"audio-data")
+                handle.writestr("Stems/bass.wav", b"bass-data")
+
+            with patch.object(provenance.base, "_sha256_file", wraps=provenance.base._sha256_file) as sha256_file:
+                plan = provenance.plan_import(project, "zip", (archive,))
+
+            self.assertEqual(len(plan["files"]), 2)
+            self.assertFalse(any(call.args and call.args[0] == archive for call in sha256_file.call_args_list))
+
+    def test_existing_original_delivery_remains_valid_fallback_for_zip_member(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            original = project / "01_Client_Files" / "Original_Delivery" / "mix.wav"
+            working = project / "02_Audio_Preparation" / "Working_Audio" / "renamed.wav"
+            (project / "00_Admin").mkdir(parents=True)
+            original.parent.mkdir(parents=True)
+            working.parent.mkdir(parents=True)
+            original.write_bytes(b"same-audio")
+            working.write_bytes(b"same-audio")
+            archive = root / "delivery.zip"
+            with zipfile.ZipFile(archive, "w") as handle:
+                handle.writestr("mix.wav", b"new-audio")
+
+            plan = provenance.plan_import(project, "zip", (archive,))
+            audio_item = next(item for item in plan["items"] if item["area"] == "audio_prep")
+
+            self.assertEqual(
+                audio_item["destination_relative_path"],
+                "02_Audio_Preparation/Working_Audio/renamed.wav",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #172.

Uses no fallback source for ZIP members when there is no existing Original Delivery file, instead of treating the ZIP container itself as the member's content. Existing Original Delivery fallback and folder/files fallback behavior are preserved.

Adds regression coverage proving ZIP planning never hashes the archive container and that an existing Original Delivery file can still recover a renamed Working_Audio destination by content.

This is the first optimization identified by the managed import timing baseline; API and progress contracts are unchanged.