### PR TITLE
Reuse import content hashes for provenance finalization

### DIFF
--- a/src/jl_mixing/managed_client_file_provenance.py
+++ b/src/jl_mixing/managed_client_file_provenance.py
@@ -265,7 +265,12 @@ def plan_reset(project_root: Path, relative_paths: tuple[str, ...]) -> dict[str,
     }
 
 
-def _record_successful_lineage(project_root: Path, plan: dict[str, Any], result: dict[str, Any]) -> None:
+def _record_successful_lineage(
+    project_root: Path,
+    plan: dict[str, Any],
+    result: dict[str, Any],
+    content_hashes: dict[str, str] | None = None,
+) -> None:
     total_started = time.perf_counter()
     statuses = {item["id"]: item["result"] for item in result.get("items", [])}
     load_started = time.perf_counter()
@@ -276,6 +281,8 @@ def _record_successful_lineage(project_root: Path, plan: dict[str, Any], result:
     source_hash_ms = 0.0
     working_hash_ms = 0.0
     hashed_bytes = 0
+    reused_hash_count = 0
+    reused_hash_bytes = 0
     recorded_count = 0
     for item in plan["items"]:
         if item["area"] != "audio_prep" or statuses.get(item["id"]) not in {"created", "replaced"}:
@@ -288,15 +295,24 @@ def _record_successful_lineage(project_root: Path, plan: dict[str, Any], result:
             continue
         source_size = source_path.stat().st_size
         working_size = working_path.stat().st_size
-        source_started = time.perf_counter()
-        source_hash = base._sha256_file(source_path)
-        source_elapsed = _elapsed_ms(source_started)
-        source_hash_ms += source_elapsed
-        working_started = time.perf_counter()
-        working_hash = base._sha256_file(working_path)
-        working_elapsed = _elapsed_ms(working_started)
-        working_hash_ms += working_elapsed
-        hashed_bytes += source_size + working_size
+        reusable_hash = content_hashes.get(source_relative) if content_hashes is not None else None
+        if reusable_hash:
+            source_hash = reusable_hash
+            working_hash = reusable_hash
+            source_elapsed = 0.0
+            working_elapsed = 0.0
+            reused_hash_count += 1
+            reused_hash_bytes += source_size + working_size
+        else:
+            source_started = time.perf_counter()
+            source_hash = base._sha256_file(source_path)
+            source_elapsed = _elapsed_ms(source_started)
+            source_hash_ms += source_elapsed
+            working_started = time.perf_counter()
+            working_hash = base._sha256_file(working_path)
+            working_elapsed = _elapsed_ms(working_started)
+            working_hash_ms += working_elapsed
+            hashed_bytes += source_size + working_size
         diagnostic_log.debug(
             "managed_import_provenance_hash_file_profile",
             source_relative_path=source_relative,
@@ -304,6 +320,7 @@ def _record_successful_lineage(project_root: Path, plan: dict[str, Any], result:
             working_size_bytes=working_size,
             source_hash_ms=source_elapsed,
             working_hash_ms=working_elapsed,
+            reused_staged_hash=bool(reusable_hash),
         )
         source_key = source_relative.casefold()
         working_key = working_relative.casefold()
@@ -328,6 +345,8 @@ def _record_successful_lineage(project_root: Path, plan: dict[str, Any], result:
         "managed_import_provenance_finalize_profile",
         recorded_count=recorded_count,
         hashed_bytes=hashed_bytes,
+        reused_hash_count=reused_hash_count,
+        reused_hash_bytes=reused_hash_bytes,
         load_ms=load_ms,
         source_hash_ms=round(source_hash_ms, 3),
         working_hash_ms=round(working_hash_ms, 3),
@@ -345,10 +364,11 @@ def execute_plan(
 ) -> dict[str, Any]:
     total_started = time.perf_counter()
     base_started = time.perf_counter()
-    result = base.execute_plan(project_root, plan, decisions, progress=progress)
+    content_hashes: dict[str, str] = {}
+    result = base.execute_plan(project_root, plan, decisions, progress=progress, content_hashes=content_hashes)
     base_execute_ms = _elapsed_ms(base_started)
     lineage_started = time.perf_counter()
-    _record_successful_lineage(project_root, plan, result)
+    _record_successful_lineage(project_root, plan, result, content_hashes)
     lineage_ms = _elapsed_ms(lineage_started)
     diagnostic_log.info(
         "managed_import_provenance_execute_profile",

--- a/src/jl_mixing/managed_client_files.py
+++ b/src/jl_mixing/managed_client_files.py
@@ -11,7 +11,7 @@ import time
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, Iterable
+from typing import Any, BinaryIO, Callable, Iterable
 
 from . import diagnostic_log
 from .errors import UnsafeOperationError, ValidationError
@@ -313,17 +313,28 @@ def _decisions(plan: dict[str, Any], decisions: dict[str, str]) -> dict[str, str
     return decisions
 
 
-def _stage_source(source: SourceFile, stage: Path) -> Path:
+def _copy_stream_with_sha256(input_stream: BinaryIO, output_stream: BinaryIO) -> str:
+    digest = hashlib.sha256()
+    while True:
+        chunk = input_stream.read(1024 * 1024)
+        if not chunk:
+            break
+        output_stream.write(chunk)
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _stage_source(source: SourceFile, stage: Path) -> tuple[Path, str]:
     target = stage / Path(source.relative_path)
     target.parent.mkdir(parents=True, exist_ok=True)
+    assert source.source_path is not None
     if source.zip_member is None:
-        assert source.source_path is not None
-        shutil.copyfile(source.source_path, target)
+        with source.source_path.open("rb") as input_stream, target.open("wb") as output_stream:
+            digest = _copy_stream_with_sha256(input_stream, output_stream)
     else:
-        assert source.source_path is not None
         with zipfile.ZipFile(source.source_path) as archive, archive.open(source.zip_member) as input_stream, target.open("wb") as output_stream:
-            shutil.copyfileobj(input_stream, output_stream)
-    return target
+            digest = _copy_stream_with_sha256(input_stream, output_stream)
+    return target, digest
 
 
 def _invalidate(project_root: Path, changed_original: bool, changed_audio: bool) -> list[str]:
@@ -346,6 +357,7 @@ def execute_plan(
     decisions: dict[str, str],
     *,
     progress: ProgressCallback | None = None,
+    content_hashes: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     total_started = time.perf_counter()
     phase = "setup"
@@ -408,7 +420,10 @@ def execute_plan(
         for relative, source in source_objects.items():
             emit_progress("staging", [relative], completed=staged_files)
             file_started = time.perf_counter()
-            staged[relative] = _stage_source(source, stage)
+            staged_path, staged_hash = _stage_source(source, stage)
+            staged[relative] = staged_path
+            if content_hashes is not None:
+                content_hashes[relative] = staged_hash
             file_ms = _elapsed_ms(file_started)
             staged_bytes += source.size
             diagnostic_log.debug(

--- a/tests/python/test_import_provenance_hash_reuse.py
+++ b/tests/python/test_import_provenance_hash_reuse.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing import managed_client_file_provenance as provenance
+
+
+class ImportProvenanceHashReuseTests(unittest.TestCase):
+    def test_zip_import_reuses_staged_hash_for_both_provenance_copies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            (project / "00_Admin").mkdir(parents=True)
+            archive = root / "delivery.zip"
+            payload = b"representative-audio-content" * 4096
+            info = zipfile.ZipInfo("mix.wav")
+            info.external_attr = (stat.S_IFREG | 0o644) << 16
+            with zipfile.ZipFile(archive, "w") as handle:
+                handle.writestr(info, payload)
+
+            plan = provenance.plan_import(project, "zip", (archive,))
+            info_events: list[tuple[str, dict[str, object]]] = []
+
+            def capture_info(event: str, **fields: object) -> None:
+                info_events.append((event, fields))
+
+            with (
+                patch.object(provenance.base, "_sha256_file", side_effect=AssertionError("destination content was reread for hashing")),
+                patch.object(provenance.diagnostic_log, "info", side_effect=capture_info),
+            ):
+                result = provenance.execute_plan(project, plan, {})
+
+            self.assertTrue(all(item["result"] == "created" for item in result["items"]))
+            expected_hash = hashlib.sha256(payload).hexdigest()
+            document = json.loads((project / provenance.PROVENANCE_PATH).read_text(encoding="utf-8"))
+            self.assertEqual(len(document["entries"]), 1)
+            entry = document["entries"][0]
+            self.assertEqual(entry["source_sha256"], expected_hash)
+            self.assertEqual(entry["working_sha256"], expected_hash)
+
+            original = project / "01_Client_Files" / "Original_Delivery" / "mix.wav"
+            working = project / "02_Audio_Preparation" / "Working_Audio" / "mix.wav"
+            self.assertEqual(original.read_bytes(), payload)
+            self.assertEqual(working.read_bytes(), payload)
+
+            finalize = next(fields for event, fields in info_events if event == "managed_import_provenance_finalize_profile")
+            self.assertEqual(finalize["hashed_bytes"], 0)
+            self.assertEqual(finalize["reused_hash_count"], 1)
+            self.assertEqual(finalize["reused_hash_bytes"], len(payload) * 2)
+            self.assertEqual(finalize["source_hash_ms"], 0.0)
+            self.assertEqual(finalize["working_hash_ms"], 0.0)
+
+    def test_lineage_finalization_falls_back_to_destination_hashing_without_staged_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            source = root / "mix.wav"
+            source.write_bytes(b"fallback-content")
+            (project / "00_Admin").mkdir(parents=True)
+
+            plan = provenance.plan_import(project, "files", (source,))
+            result = provenance.base.execute_plan(project, plan, {})
+
+            with patch.object(provenance.base, "_sha256_file", wraps=provenance.base._sha256_file) as sha256_file:
+                provenance._record_successful_lineage(project, plan, result)
+
+            self.assertEqual(sha256_file.call_count, 2)
+            document = json.loads((project / provenance.PROVENANCE_PATH).read_text(encoding="utf-8"))
+            entry = document["entries"][0]
+            expected_hash = hashlib.sha256(b"fallback-content").hexdigest()
+            self.assertEqual(entry["source_sha256"], expected_hash)
+            self.assertEqual(entry["working_sha256"], expected_hash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_managed_provenance_profiling.py
+++ b/tests/python/test_managed_provenance_profiling.py
@@ -57,13 +57,16 @@ class ManagedProvenanceProfilingTests(unittest.TestCase):
                 if call.args == ("managed_import_provenance_finalize_profile",)
             ).kwargs
             self.assertEqual(finalize_profile["recorded_count"], 1)
-            self.assertEqual(finalize_profile["hashed_bytes"], len(b"audio-data") * 2)
-            self.assertGreaterEqual(finalize_profile["source_hash_ms"], 0)
-            self.assertGreaterEqual(finalize_profile["working_hash_ms"], 0)
-            self.assertIn(
-                "managed_import_provenance_hash_file_profile",
-                [call.args[0] for call in debug_log.call_args_list],
-            )
+            self.assertEqual(finalize_profile["hashed_bytes"], 0)
+            self.assertEqual(finalize_profile["reused_hash_count"], 1)
+            self.assertEqual(finalize_profile["reused_hash_bytes"], len(b"audio-data") * 2)
+            self.assertEqual(finalize_profile["source_hash_ms"], 0.0)
+            self.assertEqual(finalize_profile["working_hash_ms"], 0.0)
+            hash_profile = next(
+                call for call in debug_log.call_args_list
+                if call.args == ("managed_import_provenance_hash_file_profile",)
+            ).kwargs
+            self.assertTrue(hash_profile["reused_staged_hash"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #174.

Captures SHA-256 while managed import bytes are already being staged and passes those digests through a private executor output dictionary to the provenance wrapper. Successful import provenance then reuses the same digest for Original Delivery and Working Audio, avoiding immediate rereads of both freshly written copies.

The public Automation API response and progress contracts are unchanged; existing destination hashing remains as a fallback when no staged digest is available.

Adds regression coverage proving persisted provenance hashes match actual imported content, proving optimized finalization performs no destination hash reads, and proving the legacy fallback hashing path still works.