### PR TITLE
Move staged originals into Original Delivery

### DIFF
--- a/src/jl_mixing/managed_client_files.py
+++ b/src/jl_mixing/managed_client_files.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import os
@@ -369,6 +370,10 @@ def execute_plan(
     cleanup_ms = 0.0
     staged_bytes = 0
     written_bytes = 0
+    copied_bytes = 0
+    moved_bytes = 0
+    copied_items = 0
+    moved_items = 0
 
     setup_started = time.perf_counter()
     decisions = _decisions(plan, decisions)
@@ -466,21 +471,51 @@ def execute_plan(
                 os.replace(destination, backup)
             backup_ms = _elapsed_ms(backup_started)
             applied.append((destination, backup))
-            if item["area"] == "audio_prep" and dependency:
-                original_item = item_by_id[dependency]
-                authoritative_source = _managed_destination(project_root, original_item["destination_relative_path"])
-                copy_source = authoritative_source if authoritative_source.exists() else staged[item["source_relative_path"]]
+            copy_ms = 0.0
+            replace_ms = 0.0
+            transfer_method = "copy"
+            size_bytes = int(item.get("size_bytes", 0))
+            if item["area"] == "original_delivery":
+                staged_source = staged[item["source_relative_path"]]
+                replace_started = time.perf_counter()
+                try:
+                    os.replace(staged_source, destination)
+                    replace_ms = _elapsed_ms(replace_started)
+                    transfer_method = "move"
+                    moved_bytes += size_bytes
+                    moved_items += 1
+                except OSError as exc:
+                    if exc.errno != errno.EXDEV:
+                        raise
+                    replace_ms = _elapsed_ms(replace_started)
+                    writes.mkdir(parents=True, exist_ok=True)
+                    temp_dest = writes / f"write-{position}.tmp"
+                    copy_started = time.perf_counter()
+                    shutil.copyfile(staged_source, temp_dest)
+                    copy_ms = _elapsed_ms(copy_started)
+                    replace_started = time.perf_counter()
+                    os.replace(temp_dest, destination)
+                    replace_ms += _elapsed_ms(replace_started)
+                    copied_bytes += size_bytes
+                    copied_items += 1
             else:
-                copy_source = staged[item["source_relative_path"]]
-            writes.mkdir(parents=True, exist_ok=True)
-            temp_dest = writes / f"write-{position}.tmp"
-            copy_started = time.perf_counter()
-            shutil.copyfile(copy_source, temp_dest)
-            copy_ms = _elapsed_ms(copy_started)
-            replace_started = time.perf_counter()
-            os.replace(temp_dest, destination)
-            replace_ms = _elapsed_ms(replace_started)
-            written_bytes += int(item.get("size_bytes", 0))
+                if item["area"] == "audio_prep" and dependency:
+                    original_item = item_by_id[dependency]
+                    authoritative_source = _managed_destination(project_root, original_item["destination_relative_path"])
+                    copy_source = authoritative_source if authoritative_source.exists() else staged[item["source_relative_path"]]
+                else:
+                    copy_source = staged[item["source_relative_path"]]
+                writes.mkdir(parents=True, exist_ok=True)
+                temp_dest = writes / f"write-{position}.tmp"
+                copy_started = time.perf_counter()
+                shutil.copyfile(copy_source, temp_dest)
+                copy_ms = _elapsed_ms(copy_started)
+                replace_started = time.perf_counter()
+                os.replace(temp_dest, destination)
+                replace_ms = _elapsed_ms(replace_started)
+                copied_bytes += size_bytes
+                copied_items += 1
+            written_bytes += size_bytes
             changed_original = changed_original or item["area"] == "original_delivery"
             changed_audio = changed_audio or item["area"] == "audio_prep"
             result_name = "replaced" if backup else "created"
@@ -489,8 +524,9 @@ def execute_plan(
                 "managed_import_write_item_profile",
                 relative_path=relative,
                 area=item["area"],
-                size_bytes=int(item.get("size_bytes", 0)),
+                size_bytes=size_bytes,
                 result=result_name,
+                transfer_method=transfer_method,
                 backup_ms=backup_ms,
                 copy_ms=copy_ms,
                 replace_ms=replace_ms,
@@ -539,6 +575,10 @@ def execute_plan(
             item_count=len(plan["items"]),
             staged_bytes=staged_bytes,
             written_bytes=written_bytes,
+            copied_bytes=copied_bytes,
+            moved_bytes=moved_bytes,
+            copied_items=copied_items,
+            moved_items=moved_items,
             created_count=result_counts["created"],
             replaced_count=result_counts["replaced"],
             skipped_count=result_counts["skipped"],

--- a/tests/python/test_managed_import_staged_move.py
+++ b/tests/python/test_managed_import_staged_move.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import errno
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jl_mixing import managed_client_files
+
+
+class ManagedImportStagedMoveTests(unittest.TestCase):
+    def _project_and_source(self, root: Path, content: bytes = b"new-audio") -> tuple[Path, Path]:
+        project = root / "project"
+        (project / "00_Admin").mkdir(parents=True)
+        source = root / "mix.wav"
+        source.write_bytes(content)
+        return project, source
+
+    def test_create_moves_original_and_copies_working_audio(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project, source = self._project_and_source(Path(tmp))
+            plan = managed_client_files.plan_import(project, "files", (source,))
+
+            with (
+                patch.object(managed_client_files.diagnostic_log, "info") as info_log,
+                patch.object(managed_client_files.diagnostic_log, "debug") as debug_log,
+            ):
+                result = managed_client_files.execute_plan(project, plan, {})
+
+            self.assertEqual([item["result"] for item in result["items"]], ["created", "created"])
+            self.assertEqual((project / managed_client_files.ORIGINAL_ROOT / "mix.wav").read_bytes(), b"new-audio")
+            self.assertEqual((project / managed_client_files.AUDIO_ROOT / "mix.wav").read_bytes(), b"new-audio")
+
+            profile = next(
+                call.kwargs for call in info_log.call_args_list
+                if call.args == ("managed_import_execute_profile",)
+            )
+            self.assertEqual(profile["moved_items"], 1)
+            self.assertEqual(profile["copied_items"], 1)
+            self.assertEqual(profile["moved_bytes"], len(b"new-audio"))
+            self.assertEqual(profile["copied_bytes"], len(b"new-audio"))
+            write_profiles = [
+                call.kwargs for call in debug_log.call_args_list
+                if call.args == ("managed_import_write_item_profile",)
+            ]
+            self.assertEqual([entry["transfer_method"] for entry in write_profiles], ["move", "copy"])
+
+    def test_replace_moves_original_and_preserves_authoritative_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project, source = self._project_and_source(Path(tmp))
+            original = project / managed_client_files.ORIGINAL_ROOT / "mix.wav"
+            working = project / managed_client_files.AUDIO_ROOT / "mix.wav"
+            original.parent.mkdir(parents=True)
+            working.parent.mkdir(parents=True)
+            original.write_bytes(b"old-original")
+            working.write_bytes(b"old-working")
+            plan = managed_client_files.plan_import(project, "files", (source,))
+
+            result = managed_client_files.execute_plan(
+                project,
+                plan,
+                {"original:0": "replace", "audio:0": "replace"},
+            )
+
+            self.assertEqual([item["result"] for item in result["items"]], ["replaced", "replaced"])
+            self.assertEqual(original.read_bytes(), b"new-audio")
+            self.assertEqual(working.read_bytes(), b"new-audio")
+
+    def test_skipped_original_skips_dependent_audio(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project, source = self._project_and_source(Path(tmp))
+            original = project / managed_client_files.ORIGINAL_ROOT / "mix.wav"
+            original.parent.mkdir(parents=True)
+            original.write_bytes(b"existing")
+            plan = managed_client_files.plan_import(project, "files", (source,))
+
+            result = managed_client_files.execute_plan(project, plan, {"original:0": "skip"})
+
+            self.assertEqual([item["result"] for item in result["items"]], ["skipped", "skipped"])
+            self.assertEqual(original.read_bytes(), b"existing")
+            self.assertFalse((project / managed_client_files.AUDIO_ROOT / "mix.wav").exists())
+
+    def test_failure_after_original_move_rolls_back_original_and_working(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project, source = self._project_and_source(Path(tmp))
+            original = project / managed_client_files.ORIGINAL_ROOT / "mix.wav"
+            working = project / managed_client_files.AUDIO_ROOT / "mix.wav"
+            original.parent.mkdir(parents=True)
+            working.parent.mkdir(parents=True)
+            original.write_bytes(b"old-original")
+            working.write_bytes(b"old-working")
+            plan = managed_client_files.plan_import(project, "files", (source,))
+
+            with patch.object(managed_client_files.shutil, "copyfile", side_effect=OSError("injected copy failure")):
+                with self.assertRaises(OSError):
+                    managed_client_files.execute_plan(
+                        project,
+                        plan,
+                        {"original:0": "replace", "audio:0": "replace"},
+                    )
+
+            self.assertEqual(original.read_bytes(), b"old-original")
+            self.assertEqual(working.read_bytes(), b"old-working")
+
+    def test_cross_device_original_move_falls_back_to_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project, source = self._project_and_source(Path(tmp))
+            plan = managed_client_files.plan_import(project, "files", (source,))
+            real_replace = os.replace
+            injected = False
+
+            def replace_with_exdev(source_path: str | os.PathLike[str], destination_path: str | os.PathLike[str]) -> None:
+                nonlocal injected
+                source_candidate = Path(source_path)
+                destination_candidate = Path(destination_path)
+                if (
+                    not injected
+                    and ".jl-managed-import-" in source_candidate.as_posix()
+                    and "/stage/" in source_candidate.as_posix()
+                    and managed_client_files.ORIGINAL_ROOT.as_posix() in destination_candidate.as_posix()
+                ):
+                    injected = True
+                    raise OSError(errno.EXDEV, "cross-device link")
+                real_replace(source_path, destination_path)
+
+            with (
+                patch.object(managed_client_files.os, "replace", side_effect=replace_with_exdev),
+                patch.object(managed_client_files.diagnostic_log, "info") as info_log,
+                patch.object(managed_client_files.diagnostic_log, "debug") as debug_log,
+            ):
+                result = managed_client_files.execute_plan(project, plan, {})
+
+            self.assertTrue(injected)
+            self.assertEqual([item["result"] for item in result["items"]], ["created", "created"])
+            self.assertEqual((project / managed_client_files.ORIGINAL_ROOT / "mix.wav").read_bytes(), b"new-audio")
+            self.assertEqual((project / managed_client_files.AUDIO_ROOT / "mix.wav").read_bytes(), b"new-audio")
+            profile = next(
+                call.kwargs for call in info_log.call_args_list
+                if call.args == ("managed_import_execute_profile",)
+            )
+            self.assertEqual(profile["moved_items"], 0)
+            self.assertEqual(profile["copied_items"], 2)
+            write_profiles = [
+                call.kwargs for call in debug_log.call_args_list
+                if call.args == ("managed_import_write_item_profile",)
+            ]
+            self.assertEqual([entry["transfer_method"] for entry in write_profiles], ["copy", "copy"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #176.

Consumes successfully staged `original_delivery` files with `os.replace` instead of copying them into another transaction temp file first. The existing replacement backup and rollback sequence is preserved, Working Audio continues to copy from the authoritative Original Delivery file, and cross-device moves fall back to the prior copy-to-temp + replace behavior.

Profiling now distinguishes logical `written_bytes` from physical `moved_bytes` / `copied_bytes` and item counts, and per-item debug records identify `transfer_method`.

Adds focused tests for create, replace, dependent skip, rollback after a moved original, and `EXDEV` fallback behavior. Public API and progress contracts are unchanged.