### PR TITLE
Use stdin for unbounded managed request payloads

### DIFF
--- a/src/jl_mixing/cli.py
+++ b/src/jl_mixing/cli.py
@@ -59,10 +59,68 @@ from .system_info import document as system_info_document
 
 EXIT_ARGUMENTS = 2
 EXIT_CONFIG = 3
+_STDIN_REQUEST_FLAG = "--request-stdin"
 
 
 def _emit_json(payload: dict[str, object]) -> None:
     print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
+def _string_list(payload: dict[str, object], key: str) -> list[str]:
+    value = payload.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ArgumentError(f"stdin request field {key} must be an array of strings.")
+    return value
+
+
+def _string_map(payload: dict[str, object], key: str) -> dict[str, str] | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in value.items()):
+        raise ArgumentError(f"stdin request field {key} must be an object mapping strings to strings.")
+    return value
+
+
+def _expand_managed_stdin(args: list[str]) -> list[str]:
+    if _STDIN_REQUEST_FLAG not in args:
+        return args
+    if args.count(_STDIN_REQUEST_FLAG) != 1:
+        raise ArgumentError("managed operation accepts at most one --request-stdin option.")
+    if len(args) < 2:
+        raise ArgumentError("--request-stdin requires a managed operation.")
+    command = tuple(args[:2])
+    supported = {
+        ("client-files", "import-plan"),
+        ("client-files", "import-execute"),
+        ("audio-prep", "reset-plan"),
+        ("audio-prep", "reset-execute"),
+    }
+    if command not in supported:
+        raise ArgumentError("--request-stdin is only supported for managed import and Audio Prep reset operations.")
+    try:
+        payload = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as exc:
+        raise ArgumentError("--request-stdin requires valid JSON on stdin.") from exc
+    if not isinstance(payload, dict):
+        raise ArgumentError("--request-stdin requires a JSON object on stdin.")
+
+    expanded = [arg for arg in args if arg != _STDIN_REQUEST_FLAG]
+    if command[0] == "client-files":
+        for source in _string_list(payload, "sources"):
+            expanded.extend(["--source", source])
+        for relative_path in _string_list(payload, "selected_relative_paths"):
+            expanded.extend(["--include-relative-path", relative_path])
+    else:
+        for relative_path in _string_list(payload, "relative_paths"):
+            expanded.extend(["--relative-path", relative_path])
+
+    decisions = _string_map(payload, "decisions")
+    if decisions is not None:
+        expanded.extend(["--decisions-json", json.dumps(decisions, separators=(",", ":"), sort_keys=True)])
+    return expanded
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -103,28 +161,36 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if len(args) >= 2 and args[0:2] == ["client-files", "import-plan"]:
         operation = "client.files.import.plan"
-        try: request = parse_managed_import_args(args[2:], execute=False)
+        try:
+            expanded = _expand_managed_stdin(args)
+            request = parse_managed_import_args(expanded[2:], execute=False)
         except ArgumentError as exc:
             _emit_json(managed_files_error(operation, "INVALID_REQUEST", str(exc), exc.exit_code)); return exc.exit_code
         payload, status = managed_import_plan_execute(request); _emit_json(payload); return status
 
     if len(args) >= 2 and args[0:2] == ["client-files", "import-execute"]:
         operation = "client.files.import.execute"
-        try: request = parse_managed_import_args(args[2:], execute=True)
+        try:
+            expanded = _expand_managed_stdin(args)
+            request = parse_managed_import_args(expanded[2:], execute=True)
         except ArgumentError as exc:
             _emit_json(managed_files_error(operation, "INVALID_REQUEST", str(exc), exc.exit_code)); return exc.exit_code
         payload, status = managed_import_execute(request); _emit_json(payload); return status
 
     if len(args) >= 2 and args[0:2] == ["audio-prep", "reset-plan"]:
         operation = "audio.prep.reset.plan"
-        try: request = parse_managed_reset_args(args[2:], execute=False)
+        try:
+            expanded = _expand_managed_stdin(args)
+            request = parse_managed_reset_args(expanded[2:], execute=False)
         except ArgumentError as exc:
             _emit_json(managed_files_error(operation, "INVALID_REQUEST", str(exc), exc.exit_code)); return exc.exit_code
         payload, status = managed_reset_plan_execute(request); _emit_json(payload); return status
 
     if len(args) >= 2 and args[0:2] == ["audio-prep", "reset-execute"]:
         operation = "audio.prep.reset.execute"
-        try: request = parse_managed_reset_args(args[2:], execute=True)
+        try:
+            expanded = _expand_managed_stdin(args)
+            request = parse_managed_reset_args(expanded[2:], execute=True)
         except ArgumentError as exc:
             _emit_json(managed_files_error(operation, "INVALID_REQUEST", str(exc), exc.exit_code)); return exc.exit_code
         payload, status = managed_reset_execute(request); _emit_json(payload); return status

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -24,6 +24,7 @@ _CAPABILITIES = [
     "intake.validate.progress",
     "intake.validate.report",
     "intake.validate.structured",
+    "managed.requests.stdin-json",
     "project.create",
     "project.create.artist",
     "project.update",

--- a/src/jl_mixing/system_info.py
+++ b/src/jl_mixing/system_info.py
@@ -24,7 +24,7 @@ _CAPABILITIES = [
     "intake.validate.progress",
     "intake.validate.report",
     "intake.validate.structured",
-    "managed.requests.stdin-json",
+    "managed.requests.stdinjson",
     "project.create",
     "project.create.artist",
     "project.update",

--- a/tests/python/test_managed_stdin_request.py
+++ b/tests/python/test_managed_stdin_request.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from unittest.mock import patch
+
+from jl_mixing.cli import _expand_managed_stdin
+from jl_mixing.errors import ArgumentError
+
+
+class ManagedStdinRequestTests(unittest.TestCase):
+    def test_large_import_request_moves_variable_paths_off_process_argv(self) -> None:
+        sources = [f"C:/delivery/{index:04}-{'long-name-' * 12}.wav" for index in range(500)]
+        selected = [f"{index:04}-{'long-name-' * 12}.wav" for index in range(500)]
+        payload = json.dumps(
+            {
+                "sources": sources,
+                "selected_relative_paths": selected,
+                "decisions": {"conflict-1": "replace"},
+            }
+        )
+        process_args = [
+            "client-files",
+            "import-execute",
+            "--json",
+            "--request-stdin",
+            "--source-kind",
+            "files",
+            "--plan-id",
+            "plan-1",
+            "--progress=stderr-json",
+        ]
+        self.assertLess(len(process_args), 12)
+        self.assertGreater(len(payload), 100_000)
+
+        with patch("sys.stdin", io.StringIO(payload)):
+            expanded = _expand_managed_stdin(process_args)
+
+        self.assertNotIn("--request-stdin", expanded)
+        self.assertEqual(expanded.count("--source"), 500)
+        self.assertEqual(expanded.count("--include-relative-path"), 500)
+        self.assertIn("--decisions-json", expanded)
+        self.assertEqual(expanded[0:2], ["client-files", "import-execute"])
+
+    def test_large_reset_request_uses_same_stdin_contract(self) -> None:
+        relative_paths = [f"folder/track-{index:04}-{'long-' * 10}.wav" for index in range(500)]
+        payload = json.dumps({"relative_paths": relative_paths, "decisions": {}})
+        process_args = [
+            "audio-prep",
+            "reset-execute",
+            "--json",
+            "--request-stdin",
+            "--plan-id",
+            "plan-2",
+        ]
+
+        with patch("sys.stdin", io.StringIO(payload)):
+            expanded = _expand_managed_stdin(process_args)
+
+        self.assertEqual(expanded.count("--relative-path"), 500)
+        self.assertNotIn("--request-stdin", expanded)
+
+    def test_stdin_request_rejects_non_string_path_arrays(self) -> None:
+        payload = json.dumps({"sources": ["one.wav", 2]})
+        with patch("sys.stdin", io.StringIO(payload)):
+            with self.assertRaises(ArgumentError):
+                _expand_managed_stdin(
+                    [
+                        "client-files",
+                        "import-plan",
+                        "--json",
+                        "--request-stdin",
+                        "--source-kind",
+                        "files",
+                    ]
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -27,8 +27,8 @@ class SystemInfoTests(unittest.TestCase):
             "client.files.import.execute", "client.files.import.plan", "client.files.import.progress", "delivery.create",
             "delivery.package.delete", "delivery.package.rebuild", "delivery.status", "intake.validate",
             "intake.validate.incremental", "intake.validate.progress", "intake.validate.report",
-            "intake.validate.structured", "project.create", "project.create.artist", "project.update",
-            "revision.approve", "revision.close", "revision.create", "revision.create.description",
+            "intake.validate.structured", "managed.requests.stdin-json", "project.create", "project.create.artist",
+            "project.update", "revision.approve", "revision.close", "revision.create", "revision.create.description",
             "revision.reopen", "revision.unapprove", "revision.update.description", "studio.update", "system.info",
         ])
         self.assertEqual(Path(info["schemas"]["installed_path"]), (ROOT / "api" / "schemas" / "v1.0").resolve())

--- a/tests/python/test_system_info.py
+++ b/tests/python/test_system_info.py
@@ -27,7 +27,7 @@ class SystemInfoTests(unittest.TestCase):
             "client.files.import.execute", "client.files.import.plan", "client.files.import.progress", "delivery.create",
             "delivery.package.delete", "delivery.package.rebuild", "delivery.status", "intake.validate",
             "intake.validate.incremental", "intake.validate.progress", "intake.validate.report",
-            "intake.validate.structured", "managed.requests.stdin-json", "project.create", "project.create.artist",
+            "intake.validate.structured", "managed.requests.stdinjson", "project.create", "project.create.artist",
             "project.update", "revision.approve", "revision.close", "revision.create", "revision.create.description",
             "revision.reopen", "revision.unapprove", "revision.update.description", "studio.update", "system.info",
         ])

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -24,7 +24,7 @@ assert d['capabilities']==[
 'client.create','client.create.context','client.update','client.files.import.execute','client.files.import.plan','client.files.import.progress',
 'delivery.create','delivery.package.delete','delivery.package.rebuild','delivery.status','intake.validate',
 'intake.validate.incremental','intake.validate.progress','intake.validate.report','intake.validate.structured',
-'managed.requests.stdin-json','project.create','project.create.artist','project.update','revision.approve','revision.close','revision.create',
+'managed.requests.stdinjson','project.create','project.create.artist','project.update','revision.approve','revision.close','revision.create',
 'revision.create.description','revision.reopen','revision.unapprove','revision.update.description','studio.update','system.info']
 assert Path(d['schemas']['installed_path']).resolve()==(root/'api'/'schemas'/f'v{av}').resolve()
 assert d['schemas']['public_base_url']==f'https://jlaudio.github.io/jl-mixing/api/v{av}/schemas/'

--- a/tests/unit/test-api-system-info.sh
+++ b/tests/unit/test-api-system-info.sh
@@ -24,7 +24,7 @@ assert d['capabilities']==[
 'client.create','client.create.context','client.update','client.files.import.execute','client.files.import.plan','client.files.import.progress',
 'delivery.create','delivery.package.delete','delivery.package.rebuild','delivery.status','intake.validate',
 'intake.validate.incremental','intake.validate.progress','intake.validate.report','intake.validate.structured',
-'project.create','project.create.artist','project.update','revision.approve','revision.close','revision.create',
+'managed.requests.stdin-json','project.create','project.create.artist','project.update','revision.approve','revision.close','revision.create',
 'revision.create.description','revision.reopen','revision.unapprove','revision.update.description','studio.update','system.info']
 assert Path(d['schemas']['installed_path']).resolve()==(root/'api'/'schemas'/f'v{av}').resolve()
 assert d['schemas']['public_base_url']==f'https://jlaudio.github.io/jl-mixing/api/v{av}/schemas/'


### PR DESCRIPTION
Fixes #179.

Adds capability-gated `--request-stdin` transport for variable-size managed import/reset request fields while preserving the existing argv contract. This removes Windows `.cmd` command-line length as a practical limit for hundreds of files. Intake validation was also audited and remains safe because it passes a bounded source/project path and discovers files internally.