### PR TITLE
Docs: finalize 2.1 stable release documentation

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -8,6 +8,7 @@
 - [ ] Update `VERSION` to the intended SemVer value (for example `2.1.0-rc.3` or `2.1.0`).
 - [ ] Do not change tests or application code solely to advance the release number.
 - [ ] Update release notes only when release content or installation guidance actually changed; do not edit them solely to change an RC number.
+- [ ] Before a stable release, perform a final documentation-only pass: remove RC/prerelease wording from the release notes, describe completed qualification in past tense, and verify installation/version examples match the stable release.
 - [ ] Run `make release-check`.
 - [ ] Open the release-preparation PR.
 - [ ] Confirm ShellCheck and the complete Tests workflow are green before merge.

--- a/docs/RELEASE_NOTES_V2.1.md
+++ b/docs/RELEASE_NOTES_V2.1.md
@@ -4,7 +4,7 @@ JL Mixing Automation 2.1 supplies the authoritative workflow capabilities used b
 
 ## Installation
 
-Download the release archive for your platform from the Assets section and verify its accompanying SHA-256 checksum before installing. Replace `<version>` below with the version shown on the release, for example `2.1.0-rc.3`.
+Download the release archive for your platform from the Assets section and verify its accompanying SHA-256 checksum before installing. Replace `<version>` below with the version shown on the release (for this stable release, `2.1.0`).
 
 ### macOS
 
@@ -97,6 +97,6 @@ Closing a revision is non-destructive; it does not delete the revision directory
 - Unrestricted managed-deliverable rename/delete operations.
 - Real-time multi-user conflict resolution.
 
-## Release-candidate validation
+## Release qualification
 
-Prerelease versions of 2.1 are intended for coordinated packaged validation with the corresponding JL Mixing Studio 2.1 candidate on Windows and macOS before promotion to the stable 2.1 release.
+Automation 2.1.0 was qualified through coordinated packaged acceptance with JL Mixing Studio 2.1 release candidates on Windows and macOS. The accepted candidate set exercised installation/runtime behavior and the Automation-owned workflows required by Studio 2.1 before promotion to the stable release.


### PR DESCRIPTION
Documentation-only final cleanup for Automation 2.1 stable release.

- Convert 2.1 release notes from prerelease/RC wording to stable-release wording.
- Record coordinated RC qualification as completed.
- Add the stable documentation finalization pass to the release checklist.

No application code, tests, schemas, or release version files are changed.