### PR TITLE
Add revision Variants folder convention

### DIFF
--- a/src/jl_mixing/delivery.py
+++ b/src/jl_mixing/delivery.py
@@ -267,6 +267,9 @@ def plan_delivery(
             continue
         if item.is_symlink():
             raise ValidationError(f"Symbolic links are not allowed in a delivery source: {item}")
+        if item.name == "Variants" and item.is_dir():
+            excluded.append(DeliveryExclusion(item.name, "revision variants"))
+            continue
         if item.is_dir():
             raise ValidationError(f"Subdirectories are not allowed in a delivery source: {item}")
         if not _regular_no_symlink(item):

--- a/src/jl_mixing/delivery.py
+++ b/src/jl_mixing/delivery.py
@@ -261,6 +261,24 @@ def plan_delivery(
     selected: list[DeliverySelection] = []
     excluded: list[DeliveryExclusion] = []
 
+    def consider_file(item: Path) -> None:
+        if item.is_symlink():
+            raise ValidationError(f"Symbolic links are not allowed in a delivery source: {item}")
+        if not _regular_no_symlink(item):
+            raise ValidationError(f"Unsupported source item: {item}")
+        if working_prefix and item.name.startswith(working_prefix):
+            excluded.append(DeliveryExclusion(item.name, "working prefix"))
+            return
+        if include_patterns and not any(fnmatch.fnmatchcase(item.name, pattern) for pattern in include_patterns):
+            excluded.append(DeliveryExclusion(item.name, "include pattern"))
+            return
+        if exclude_patterns and any(fnmatch.fnmatchcase(item.name, pattern) for pattern in exclude_patterns):
+            excluded.append(DeliveryExclusion(item.name, "exclude pattern"))
+            return
+        kind = classify_deliverable(item.name)
+        relative = f"Stems/{item.name}" if kind == "stems" else item.name
+        selected.append(DeliverySelection(item, item.name, kind, relative))
+
     for item in sorted(revision_root.iterdir(), key=lambda path: (path.name.casefold(), path.name)):
         if item.name == "Revision_Notes.md":
             excluded.append(DeliveryExclusion(item.name, "revision notes"))
@@ -268,24 +286,14 @@ def plan_delivery(
         if item.is_symlink():
             raise ValidationError(f"Symbolic links are not allowed in a delivery source: {item}")
         if item.name == "Variants" and item.is_dir():
-            excluded.append(DeliveryExclusion(item.name, "revision variants"))
+            for variant in sorted(item.iterdir(), key=lambda path: (path.name.casefold(), path.name)):
+                if variant.is_dir() and not variant.is_symlink():
+                    raise ValidationError(f"Subdirectories are not allowed in revision Variants: {variant}")
+                consider_file(variant)
             continue
         if item.is_dir():
             raise ValidationError(f"Subdirectories are not allowed in a delivery source: {item}")
-        if not _regular_no_symlink(item):
-            raise ValidationError(f"Unsupported source item: {item}")
-        if working_prefix and item.name.startswith(working_prefix):
-            excluded.append(DeliveryExclusion(item.name, "working prefix"))
-            continue
-        if include_patterns and not any(fnmatch.fnmatchcase(item.name, pattern) for pattern in include_patterns):
-            excluded.append(DeliveryExclusion(item.name, "include pattern"))
-            continue
-        if exclude_patterns and any(fnmatch.fnmatchcase(item.name, pattern) for pattern in exclude_patterns):
-            excluded.append(DeliveryExclusion(item.name, "exclude pattern"))
-            continue
-        kind = classify_deliverable(item.name)
-        relative = f"Stems/{item.name}" if kind == "stems" else item.name
-        selected.append(DeliverySelection(item, item.name, kind, relative))
+        consider_file(item)
 
     if not selected:
         raise ValidationError("No deliverable files were found after applying filters")

--- a/src/jl_mixing/project.py
+++ b/src/jl_mixing/project.py
@@ -290,6 +290,7 @@ def create_project(request: ProjectCreateRequest) -> ProjectCreateResult:
             "02_Audio_Preparation/Rejected_Files",
             "03_DAW_Project",
             "04_Revisions/Revision_01",
+            "04_Revisions/Revision_01/Variants",
             "05_Final_Delivery/Stems",
             "06_Recall/External_Files",
             "06_Recall/Screenshots",

--- a/src/jl_mixing/revision.py
+++ b/src/jl_mixing/revision.py
@@ -220,6 +220,7 @@ def create_revision(request: RevisionCreateRequest) -> RevisionCreateResult:
         os.close(manifest_fd)
         if source_plan is not None:
             copy_from_plan(source_plan, stage)
+        (stage / "Variants").mkdir()
         (stage / "Revision_Notes.md").write_text(
             _render_notes(number, description), encoding="utf-8", newline="\n"
         )

--- a/tests/python/test_delivery_service.py
+++ b/tests/python/test_delivery_service.py
@@ -76,23 +76,35 @@ class DeliveryServiceTests(unittest.TestCase):
             ])
             reasons = {item.name: item.reason for item in result.plan.excluded}
             self.assertEqual(reasons["Revision_Notes.md"], "revision notes")
-            self.assertEqual(reasons["Variants"], "revision variants")
             self.assertEqual(reasons["WORK rough.wav"], "working prefix")
             self.assertEqual(before_manifest, manifest_path.read_bytes())
             self.assertEqual(before_listing, sorted(path.relative_to(delivery).as_posix() for path in delivery.rglob("*")))
 
-    def test_variants_are_excluded_but_other_subdirectories_remain_invalid(self) -> None:
+    def test_variants_are_included_but_other_subdirectories_remain_invalid(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project = write_project(Path(tmp))
             revision = project / "04_Revisions" / "Revision_01"
-            (revision / "Variants" / "Delivery Song Instrumental Alt.wav").write_bytes(b"variant")
+            variant = revision / "Variants" / "Delivery Song TV Mix.wav"
+            variant.write_bytes(b"variant")
             result = create_delivery(DeliveryCreateRequest(project, dry_run=True))
-            self.assertNotIn(
-                "Delivery Song Instrumental Alt.wav",
+            self.assertIn(
+                "Delivery Song TV Mix.wav",
                 [record.name for record in result.plan.selected],
             )
+            selected = next(record for record in result.plan.selected if record.name == "Delivery Song TV Mix.wav")
+            self.assertEqual(selected.source, variant)
+            self.assertEqual(selected.path, "Delivery Song TV Mix.wav")
+            self.assertEqual(selected.deliverable_type, "tv_mix")
             (revision / "Unexpected").mkdir()
             with self.assertRaisesRegex(ValidationError, "Subdirectories are not allowed"):
+                create_delivery(DeliveryCreateRequest(project, dry_run=True))
+
+    def test_nested_variants_subdirectories_remain_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            revision = project / "04_Revisions" / "Revision_01"
+            (revision / "Variants" / "Nested").mkdir()
+            with self.assertRaisesRegex(ValidationError, "Subdirectories are not allowed in revision Variants"):
                 create_delivery(DeliveryCreateRequest(project, dry_run=True))
 
     def test_create_copies_verifies_and_records_delivery(self) -> None:

--- a/tests/python/test_delivery_service.py
+++ b/tests/python/test_delivery_service.py
@@ -76,9 +76,24 @@ class DeliveryServiceTests(unittest.TestCase):
             ])
             reasons = {item.name: item.reason for item in result.plan.excluded}
             self.assertEqual(reasons["Revision_Notes.md"], "revision notes")
+            self.assertEqual(reasons["Variants"], "revision variants")
             self.assertEqual(reasons["WORK rough.wav"], "working prefix")
             self.assertEqual(before_manifest, manifest_path.read_bytes())
             self.assertEqual(before_listing, sorted(path.relative_to(delivery).as_posix() for path in delivery.rglob("*")))
+
+    def test_variants_are_excluded_but_other_subdirectories_remain_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            revision = project / "04_Revisions" / "Revision_01"
+            (revision / "Variants" / "Delivery Song Instrumental Alt.wav").write_bytes(b"variant")
+            result = create_delivery(DeliveryCreateRequest(project, dry_run=True))
+            self.assertNotIn(
+                "Delivery Song Instrumental Alt.wav",
+                [record.name for record in result.plan.selected],
+            )
+            (revision / "Unexpected").mkdir()
+            with self.assertRaisesRegex(ValidationError, "Subdirectories are not allowed"):
+                create_delivery(DeliveryCreateRequest(project, dry_run=True))
 
     def test_create_copies_verifies_and_records_delivery(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/python/test_revision_service.py
+++ b/tests/python/test_revision_service.py
@@ -60,6 +60,11 @@ def make_project(root: Path) -> Path:
 
 
 class RevisionServiceTests(unittest.TestCase):
+    def test_project_creation_provisions_variants_for_initial_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = make_project(Path(tmp))
+            self.assertTrue((project / "04_Revisions" / "Revision_01" / "Variants").is_dir())
+
     def test_dry_run_plans_revision_two_without_mutation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project = make_project(Path(tmp))
@@ -74,12 +79,13 @@ class RevisionServiceTests(unittest.TestCase):
             self.assertFalse(result.revision_root.exists())
             self.assertEqual(manifest_path.read_text(encoding="utf-8"), before)
 
-    def test_create_revision_updates_manifest_and_notes(self) -> None:
+    def test_create_revision_updates_manifest_notes_and_variants_folder(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project = make_project(Path(tmp))
             result = create_revision(RevisionCreateRequest(project, description="Vocal up 1 dB", change_directory=False))
             self.assertTrue(result.created)
             self.assertTrue((result.revision_root / "Revision_Notes.md").is_file())
+            self.assertTrue((result.revision_root / "Variants").is_dir())
             self.assertIn("Vocal up 1 dB", (result.revision_root / "Revision_Notes.md").read_text(encoding="utf-8"))
             persisted = json.loads((project / "00_Admin" / "project-manifest.json").read_text(encoding="utf-8"))
             self.assertEqual(persisted["state"]["current_revision"], 2)
@@ -113,6 +119,7 @@ class RevisionServiceTests(unittest.TestCase):
             result = create_revision(RevisionCreateRequest(project, source=source))
             self.assertEqual((result.revision_root / "Mix.wav").read_bytes(), b"mix")
             self.assertEqual((result.revision_root / "Instrumental.wav").read_bytes(), b"inst")
+            self.assertTrue((result.revision_root / "Variants").is_dir())
 
             nested = root / "nested"
             (nested / "folder").mkdir(parents=True)


### PR DESCRIPTION
Implements the Automation portion of Studio issue jl-mixing-studio#340.

- creates `Variants/` in Revision_01 for every new project
- creates `Variants/` in every subsequently created revision
- treats `Variants/` as canonical revision content for actual package delivery
- includes regular files directly inside `Variants/` in normal delivery planning/package creation while preserving existing delivery classification/output layout
- keeps arbitrary unexpected revision subdirectories invalid
- leaves existing projects/revisions without `Variants/` valid and untouched
- keeps imported primary revision source files at the revision root; Studio listening source selection ignores `Variants/` by default
- adds regression coverage for creation and delivery behavior

Important distinction: `Variants/` is excluded only from automatic Listening primary-source selection. It is not excluded from actual client delivery.

Coordinated with Studio PR #350 for #340.