### PR TITLE
Ignore filesystem noise inside delivery ZIP packages

### DIFF
--- a/src/jl_mixing/delivery.py
+++ b/src/jl_mixing/delivery.py
@@ -19,6 +19,7 @@ from typing import Any, Literal
 from .approval import derive_project_stage
 from .context import resolve_project, revision_root_for_number, studio_root as resolve_studio_root
 from .errors import ContextError, UnsafeOperationError, ValidationError
+from .filesystem_noise import path_contains_filesystem_noise
 from .metadata import create_v11, now_iso8601
 from .filesystem_noise import is_filesystem_noise_name
 from .revision import _load_manifest, _validate_project_state, _validate_schema
@@ -209,6 +210,8 @@ def _zip_stage(stage: Path, zip_name: str, project_id: str) -> None:
         for path in sorted(stage.rglob("*"), key=lambda value: (value.relative_to(stage).as_posix().casefold(), value.relative_to(stage).as_posix())):
             relative = path.relative_to(stage).as_posix()
             if path == archive or generated.fullmatch(path.name):
+                continue
+            if path_contains_filesystem_noise(relative):
                 continue
             if path.is_symlink():
                 raise ValidationError(f"Symbolic links cannot be archived in a delivery ZIP: {path}")

--- a/src/jl_mixing/delivery_management.py
+++ b/src/jl_mixing/delivery_management.py
@@ -128,7 +128,11 @@ def _package_record(path: Path, delivery_root: Path, snapshot: dict[str, Path]) 
         return record
     try:
         with zipfile.ZipFile(path, "r") as handle:
-            members = {info.filename for info in handle.infolist() if not info.is_dir()}
+            members = {
+                info.filename
+                for info in handle.infolist()
+                if not info.is_dir() and not path_contains_filesystem_noise(info.filename)
+            }
             expected = set(snapshot)
             missing = sorted(expected - members)
             extra = sorted(members - expected)

--- a/tests/python/test_filesystem_noise.py
+++ b/tests/python/test_filesystem_noise.py
@@ -61,6 +61,29 @@ class FilesystemNoiseTests(unittest.TestCase):
             self.assertEqual(status["untracked"], ["unexpected.txt"])
             self.assertIn("UNTRACKED_DELIVERY_FILE", {item["code"] for item in status["issues"]})
 
+    def test_delivery_package_omits_and_ignores_archived_filesystem_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = write_project(Path(tmp))
+            created = create_delivery(DeliveryCreateRequest(project, make_zip=True))
+            self.assertIsNotNone(created.zip_name)
+            delivery = project / "05_Final_Delivery"
+            (delivery / ".DS_Store").write_bytes(b"finder")
+
+            rebuilt = create_delivery(
+                DeliveryCreateRequest(project, overwrite=True, make_zip=True)
+            )
+            self.assertIsNotNone(rebuilt.zip_name)
+            rebuilt_package = delivery / str(rebuilt.zip_name)
+            with zipfile.ZipFile(rebuilt_package) as handle:
+                self.assertNotIn(".DS_Store", handle.namelist())
+
+            with zipfile.ZipFile(rebuilt_package, "a") as handle:
+                write_regular_zip_entry(handle, ".DS_Store", b"finder")
+
+            status = inspect_delivery(DeliveryStatusRequest(project))
+            self.assertEqual(status["package_state"], "current")
+            self.assertEqual(status["current_package"]["issues"], [])
+
     def test_folder_import_excludes_nested_filesystem_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

Completes the platform-neutral filesystem-noise policy for generated Delivery ZIPs.

- omits `.DS_Store`, AppleDouble `._*`, `Thumbs.db`, and `desktop.ini` from newly generated packages
- ignores those members when reconciling existing ZIPs
- preserves normal comparison for legitimate dotfiles and other package members

## Regression

Covers the reproduced sequence where Finder creates `.DS_Store` in `05_Final_Delivery` before a package rebuild. The rebuilt ZIP omits the file, and an existing ZIP containing the file still reconciles as current.

## Verification

- focused filesystem-noise tests: 4 passed
- full Python suite: 226 passed
- ShellCheck and cross-platform Automation CI #1523 passed
- manual Studio/Automation reproduction verified the package no longer reports a rebuild for `.DS_Store`

Follow-up to #191 and #193.